### PR TITLE
feat: Windows port Phase 1 — compile & run support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1324,6 +1324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2757,7 @@ checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
  "bitflags 2.11.0",
  "filetime",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,9 @@ objc = "0.2"
 whisper-rs = { version = "0.15" }
 notify = { version = "7" }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,12 +38,13 @@ clap_complete = "4"
 clap_mangen = "0.2"
 ctrlc = "3"
 indicatif = "0.17"
-notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+notify = { version = "7", default-features = false }
 tauri-plugin-dialog = "2"
 symphonia = { version = "0.5", features = ["aac", "alac", "flac", "mp3", "pcm", "vorbis", "isomp4", "mkv", "ogg"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.15", features = ["coreml", "metal"] }
+notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
 
 core-graphics = "0.24"
 core-foundation = "0.10"
@@ -52,6 +53,7 @@ objc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 whisper-rs = { version = "0.15" }
+notify = { version = "7" }
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -17,6 +17,7 @@ pub enum AppState {
     Idle,
     Recording,
     Transcribing,
+    #[allow(dead_code)]
     Error,
 }
 
@@ -25,6 +26,7 @@ impl AppState {
         matches!(self, AppState::Recording)
     }
 
+    #[allow(dead_code)]
     pub fn is_busy(&self) -> bool {
         matches!(self, AppState::Recording | AppState::Transcribing)
     }
@@ -34,6 +36,7 @@ impl AppState {
 pub struct AppController {
     state: AppState,
     audio: AudioCaptureService,
+    #[allow(dead_code)]
     paste: PasteService,
     hotkey: HotkeyService,
     logging: LoggingService,
@@ -182,6 +185,7 @@ impl AppController {
     }
 
     /// Auto-paste text if enabled
+    #[allow(dead_code)]
     pub fn auto_paste(&self, text: &str) -> Result<(), DictationError> {
         if !self.settings.auto_paste {
             return Ok(());
@@ -206,6 +210,7 @@ impl AppController {
             .unwrap_or(Duration::ZERO)
     }
 
+    #[allow(dead_code)]
     pub fn set_model_ready(&mut self, ready: bool) {
         self.model_ready = ready;
     }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -99,6 +99,7 @@ impl AudioCaptureService {
     }
 
     /// Get the last captured audio for retry
+    #[allow(dead_code)]
     pub fn last_captured_audio(&self) -> Option<&Vec<f32>> {
         self.last_captured.as_ref()
     }

--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -117,8 +117,8 @@ fn cmd_list() -> Result<(), DictationError> {
     let current = settings::store::load();
     let defaults = Settings::default();
 
-    println!("{:<20} {:<24} {}", "KEY", "CURRENT", "DEFAULT");
-    println!("{:<20} {:<24} {}", "---", "-------", "-------");
+    println!("{:<20} {:<24} DEFAULT", "KEY", "CURRENT");
+    println!("{:<20} {:<24} -------", "---", "-------");
     println!(
         "{:<20} {:<24} {}",
         "language",
@@ -200,7 +200,7 @@ fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
         _ => unreachable!(), // validate_key already checked
     }
 
-    settings::store::save(&settings).map_err(|e| DictationError::SettingsError(e))?;
+    settings::store::save(&settings).map_err(DictationError::SettingsError)?;
     eprintln!("Set {key} = {}", get_setting_value(&settings, key));
     Ok(())
 }
@@ -220,11 +220,11 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
             "hotkey" => settings.hotkey = defaults.hotkey,
             _ => unreachable!(),
         }
-        settings::store::save(&settings).map_err(|e| DictationError::SettingsError(e))?;
+        settings::store::save(&settings).map_err(DictationError::SettingsError)?;
         eprintln!("Reset {key} to {}", get_setting_value(&settings, key));
     } else {
         let defaults = Settings::default();
-        settings::store::save(&defaults).map_err(|e| DictationError::SettingsError(e))?;
+        settings::store::save(&defaults).map_err(DictationError::SettingsError)?;
         eprintln!("All settings reset to defaults");
     }
     Ok(())
@@ -262,20 +262,20 @@ fn get_setting_value(settings: &Settings, key: &str) -> String {
 }
 
 fn format_language(lang: Language) -> String {
-    serde_json::to_value(&lang)
-        .and_then(|v| serde_json::from_value::<String>(v))
+    serde_json::to_value(lang)
+        .and_then(serde_json::from_value::<String>)
         .unwrap_or_else(|_| format!("{:?}", lang))
 }
 
 fn format_model(model: WhisperModel) -> String {
-    serde_json::to_value(&model)
-        .and_then(|v| serde_json::from_value::<String>(v))
+    serde_json::to_value(model)
+        .and_then(serde_json::from_value::<String>)
         .unwrap_or_else(|_| format!("{:?}", model))
 }
 
 fn format_hotkey_mode(mode: HotkeyMode) -> String {
-    serde_json::to_value(&mode)
-        .and_then(|v| serde_json::from_value::<String>(v))
+    serde_json::to_value(mode)
+        .and_then(serde_json::from_value::<String>)
         .unwrap_or_else(|_| format!("{:?}", mode))
 }
 

--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -122,6 +122,7 @@ pub fn parse_language(s: &str) -> Result<Language, DictationError> {
     }
 }
 
+#[allow(dead_code)]
 pub fn resolve_model(
     model_str: Option<&str>,
     language: Language,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -63,8 +63,8 @@ pub async fn get_loaded_model(
     let loaded = whisper.loaded_model();
     Ok(LoadedModelInfo {
         effective_model: effective.display_name().to_string(),
-        effective_model_id: serde_json::to_value(&effective)
-            .and_then(|v| serde_json::from_value::<String>(v))
+        effective_model_id: serde_json::to_value(effective)
+            .and_then(serde_json::from_value::<String>)
             .unwrap_or_else(|_| format!("{:?}", effective)),
         loaded_model: loaded.map(|m| m.display_name().to_string()),
         is_loaded: loaded == Some(effective),
@@ -279,7 +279,7 @@ pub async fn get_model_info(
         .iter()
         .map(|m| ModelInfo {
             id: serde_json::to_value(m)
-                .and_then(|v| serde_json::from_value::<String>(v))
+                .and_then(serde_json::from_value::<String>)
                 .unwrap_or_else(|_| format!("{:?}", m)),
             display_name: m.display_name().to_string(),
             description: m.description().to_string(),

--- a/src-tauri/src/hotkey/service.rs
+++ b/src-tauri/src/hotkey/service.rs
@@ -3,11 +3,13 @@ use tracing::info;
 /// Hotkey management service
 /// Uses tauri-plugin-global-shortcut for registration
 /// Push-to-talk needs key-down + key-up events
+#[allow(dead_code)]
 pub struct HotkeyService {
     current_shortcut: Option<String>,
     suspended: bool,
 }
 
+#[allow(dead_code)]
 impl HotkeyService {
     pub fn new() -> Self {
         Self {

--- a/src-tauri/src/logging/log_events.rs
+++ b/src-tauri/src/logging/log_events.rs
@@ -1,10 +1,12 @@
 /// Log event name constants matching the Swift app's LogEvent structure
+#[allow(dead_code)]
 pub mod app {
     pub const STARTED: &str = "app_started";
     pub const READY: &str = "app_ready";
     pub const TERMINATED: &str = "app_terminated";
 }
 
+#[allow(dead_code)]
 pub mod hotkey {
     pub const REGISTERED: &str = "hotkey_registered";
     pub const UNREGISTERED: &str = "hotkey_unregistered";
@@ -12,6 +14,7 @@ pub mod hotkey {
     pub const KEY_UP: &str = "key_up";
 }
 
+#[allow(dead_code)]
 pub mod audio {
     pub const CAPTURE_STARTED: &str = "capture_started";
     pub const CAPTURE_STOPPED: &str = "capture_stopped";
@@ -19,6 +22,7 @@ pub mod audio {
     pub const PERMISSION_DENIED: &str = "permission_denied";
 }
 
+#[allow(dead_code)]
 pub mod transcription {
     pub const STARTED: &str = "transcription_started";
     pub const COMPLETED: &str = "transcription_completed";
@@ -27,12 +31,14 @@ pub mod transcription {
     pub const MODEL_LOADED: &str = "model_loaded";
 }
 
+#[allow(dead_code)]
 pub mod paste {
     pub const ATTEMPTED: &str = "paste_attempted";
     pub const SUCCEEDED: &str = "paste_succeeded";
     pub const FAILED: &str = "paste_failed";
 }
 
+#[allow(dead_code)]
 pub mod session {
     pub const DICTATION_STARTED: &str = "dictation_session_started";
     pub const DICTATION_COMPLETE: &str = "dictation_session_complete";

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -244,15 +244,14 @@ fn main() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building Sagascript")
-        .run(|_app_handle, event| match event {
+        .run(|_app_handle, event| {
             // Prevent app from exiting when all windows are closed (tray-only app),
             // but allow explicit exit requests (e.g. from tray "Quit" menu)
-            tauri::RunEvent::ExitRequested { api, code, .. } => {
+            if let tauri::RunEvent::ExitRequested { api, code, .. } = event {
                 if code.is_none() {
                     api.prevent_exit();
                 }
             }
-            _ => {}
         });
 }
 

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -56,6 +56,9 @@ fn create_overlay(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Erro
     #[cfg(target_os = "macos")]
     configure_macos_window(&window);
 
+    // Click-through: cross-platform via Tauri API
+    let _ = window.set_ignore_cursor_events(true);
+
     // Suppress close — just hide instead
     let _ = window;
 
@@ -68,7 +71,6 @@ fn create_overlay(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Erro
 fn configure_macos_window(window: &tauri::WebviewWindow) {
     use cocoa::appkit::NSWindow;
     use cocoa::base::{id, NO};
-    use objc::runtime::YES;
 
     let ns_window: id = window.ns_window().unwrap() as id;
 
@@ -84,9 +86,6 @@ fn configure_macos_window(window: &tauri::WebviewWindow) {
         ns_window.setOpaque_(NO);
         let clear_color: id = objc::msg_send![objc::class!(NSColor), clearColor];
         ns_window.setBackgroundColor_(clear_color);
-
-        // Click-through
-        ns_window.setIgnoresMouseEvents_(YES);
 
         // No shadow (CSS provides its own)
         ns_window.setHasShadow_(NO);

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -1,2 +1,12 @@
 // Windows-specific platform code
-// Currently no special initialization needed beyond what Tauri provides
+
+/// Windows doesn't have macOS-style accessibility permission gates.
+/// Input simulation via SendInput works without explicit user grants.
+pub fn is_accessibility_trusted() -> bool {
+    true
+}
+
+/// No-op on Windows — accessibility permissions aren't needed.
+pub fn request_accessibility_permission() {
+    // Nothing to do
+}

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 /// Supported transcription languages
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     #[serde(rename = "en")]
+    #[default]
     English,
     #[serde(rename = "sv")]
     Swedish,
@@ -35,15 +36,9 @@ impl Language {
     }
 }
 
-impl Default for Language {
-    fn default() -> Self {
-        Language::English
-    }
-}
-
 /// Whisper model variants
 /// All models use GGML format via whisper-rs (unified backend)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WhisperModel {
     #[serde(rename = "tiny.en")]
     TinyEn,
@@ -52,6 +47,7 @@ pub enum WhisperModel {
     #[serde(rename = "base.en")]
     BaseEn,
     #[serde(rename = "base")]
+    #[default]
     Base,
     #[serde(rename = "kb-whisper-tiny")]
     KbWhisperTiny,
@@ -134,10 +130,12 @@ impl WhisperModel {
         }
     }
 
+    #[allow(dead_code)]
     pub fn is_english_only(&self) -> bool {
         matches!(self, WhisperModel::TinyEn | WhisperModel::BaseEn | WhisperModel::SmallEn | WhisperModel::MediumEn)
     }
 
+    #[allow(dead_code)]
     pub fn is_swedish_optimized(&self) -> bool {
         matches!(
             self,
@@ -146,6 +144,7 @@ impl WhisperModel {
         )
     }
 
+    #[allow(dead_code)]
     pub fn is_norwegian_optimized(&self) -> bool {
         matches!(
             self,
@@ -273,34 +272,24 @@ impl WhisperModel {
     }
 }
 
-impl Default for WhisperModel {
-    fn default() -> Self {
-        WhisperModel::Base
-    }
-}
-
 /// Hotkey activation mode
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum HotkeyMode {
     #[serde(rename = "push")]
+    #[default]
     PushToTalk,
     #[serde(rename = "toggle")]
     Toggle,
 }
 
 impl HotkeyMode {
+    #[allow(dead_code)]
     pub fn display_name(&self) -> &'static str {
         match self {
             HotkeyMode::PushToTalk => "Push-to-talk",
             HotkeyMode::Toggle => "Toggle",
         }
-    }
-}
-
-impl Default for HotkeyMode {
-    fn default() -> Self {
-        HotkeyMode::PushToTalk
     }
 }
 

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -181,7 +181,7 @@
         <h1>Microphone Access</h1>
         <p class="description">
           Sagascript can record your voice for live dictation. All audio is
-          processed locally on your device — nothing leaves your Mac.
+          processed locally on your device — nothing leaves your device.
         </p>
 
         <div class="status-indicator" class:granted={micGranted}>


### PR DESCRIPTION
## Summary

### Windows port (Phase 1)
- Fix `notify` crate features for cross-platform compilation (base dep without platform features, `macos_kqueue` under macOS deps, default features for Windows)
- Add `platform::windows` accessibility stubs (`is_accessibility_trusted` → `true`, `request_accessibility_permission` → no-op)
- Replace macOS-only `setIgnoresMouseEvents_` with cross-platform `set_ignore_cursor_events(true)` in overlay
- Change "nothing leaves your Mac" to "nothing leaves your device" in onboarding

### Clippy cleanup
- Declare `cargo-clippy` as expected cfg feature value (fixes `objc` macro warnings)
- Replace 3 manual `Default` impls with `#[derive(Default)]` + `#[default]`
- Replace redundant closures with function refs (`serde_json::from_value`, `DictationError::SettingsError`)
- Remove needless borrows on Copy types passed to `serde_json::to_value`
- Inline print literals, convert `match` to `if let`
- Add `#[allow(dead_code)]` on intentionally designed but unwired APIs
- Result: `cargo clippy -- -D warnings` passes clean

## Test plan

- [x] `cargo check` passes (no regressions on macOS)
- [x] `cargo clippy -- -D warnings` — 0 errors
- [x] `cargo test` — 170/170 passing
- [x] `npx svelte-check` — 0 errors
- [ ] Full Windows verification requires Windows CI (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)