### PR TITLE
docs: fix multi-language overclaim and stale cloud references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Dictate anywhere. Privately. A lightweight menu bar app for macOS and Windows. P
 
 - **Push-to-talk dictation** -- hold a global hotkey, speak, release to transcribe and paste into any app
 - **100% local transcription** -- runs Whisper models on-device (Metal/Core ML on macOS) with no data leaving your machine
-- **Privacy by default** -- audio is processed in memory and immediately discarded; zero network traffic unless you explicitly opt in to a remote provider
+- **Privacy by default** -- audio is processed in memory and immediately discarded; zero network traffic
 - **No telemetry or tracking** -- no analytics, no usage sharing, no data collection of any kind
-- **Cloud when you choose** -- optionally use OpenAI's API with your own key for maximum accuracy; remote transcription is never the default
-- **Multi-language** -- English, Swedish, Norwegian, and 90+ other languages
+- **Multi-language** -- English, Swedish, and Norwegian with dedicated models; additional languages supported via generic Whisper models
 - **CLI + GUI** -- full CLI for scripting and automation, menu bar app for everyday use
 - **File transcription** -- transcribe audio and video files (MP3, WAV, M4A, FLAC, MP4, MKV, OGG, and more)
 - **Configurable** -- choose your model, language, hotkey, and output behavior


### PR DESCRIPTION
## Summary
- Change "90+ other languages" to clarify only en/sv/no have dedicated models; others available via generic Whisper models
- Remove stale "Cloud when you choose" OpenAI API opt-in feature bullet
- Remove "unless you explicitly opt in to a remote provider" from privacy bullet

## Test plan
- [x] Text-only change, no code affected
- [x] Claims now match actual codebase capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)