### PR TITLE
ci: build universal macOS binary (ARM64 + Intel)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -31,9 +33,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             src-tauri/target
-          key: macos-release-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: macos-universal-release-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
-            macos-release-cargo-
+            macos-universal-release-cargo-
 
       - name: Install npm dependencies
         run: npm ci
@@ -41,16 +43,16 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-      - name: Build Tauri app
-        run: npx tauri build
+      - name: Build universal Tauri app
+        run: npx tauri build --target universal-apple-darwin
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macos-bundle
           path: |
-            src-tauri/target/release/bundle/dmg/*.dmg
-            src-tauri/target/release/bundle/macos/*.app.tar.gz
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz
 
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary

- Updates the release workflow to produce a **universal macOS binary** (Apple Silicon + Intel) instead of ARM64-only
- Uses Tauri's built-in `--target universal-apple-darwin`, which compiles both `aarch64-apple-darwin` and `x86_64-apple-darwin` slices and combines them with `lipo`
- The resulting `.dmg` and `.app` run natively on both Apple Silicon and Intel Macs — no Rosetta needed on Intel

### Changes
- Install both Rust targets (`aarch64-apple-darwin`, `x86_64-apple-darwin`) in the build job
- Build with `npx tauri build --target universal-apple-darwin`
- Update artifact upload paths from `target/release/bundle/` to `target/universal-apple-darwin/release/bundle/`
- Update Cargo cache key to avoid stale ARM64-only cache conflicts

### Why this approach (Option A: universal binary)

Investigated two options:
1. **Option A** — `universal-apple-darwin` target (single job, Tauri handles lipo) 
2. **Option B** — Two separate jobs (macos-14 for ARM64, macos-13 for x86_64)

Chose Option A because:
- `whisper-rs-sys` builds whisper.cpp via cmake without setting `CMAKE_OSX_ARCHITECTURES`, so it inherits the target arch from Cargo's environment
- Metal and CoreML are system frameworks with universal SDK headers — cross-compilation from ARM64 to x86_64 is supported via the Xcode toolchain
- Tauri v2 officially supports `--target universal-apple-darwin` ([confirmed in Discussion #9419](https://github.com/tauri-apps/tauri/discussions/9419))
- Single binary is better UX — users don't need to identify their chip architecture

### Fallback plan

If the universal build fails in CI due to whisper.cpp cross-compilation issues (e.g., Metal shader compilation targeting x86_64), fall back to Option B with two separate build jobs and architecture-labeled artifacts.

## Test plan

- [ ] Push a test tag (e.g., `v0.0.0-test-universal`) to trigger the release workflow
- [ ] Verify the build completes successfully on GitHub Actions
- [ ] Download the `.dmg` and verify with `lipo -info` that the binary contains both `arm64` and `x86_64` slices
- [ ] Test the app launches on an Apple Silicon Mac
- [ ] (If available) Test the app launches on an Intel Mac or under Rosetta

🤖 Generated with [Claude Code](https://claude.com/claude-code)