### PR TITLE
ci: rename release artifacts to stable filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,26 @@ jobs:
         with:
           path: artifacts
 
+      - name: Rename artifacts to stable filenames
+        run: |
+          # macOS
+          cp artifacts/macos-bundle/*.dmg artifacts/Sagascript.dmg
+          cp artifacts/macos-bundle/*.app.tar.gz artifacts/Sagascript.app.tar.gz
+
+          # Windows
+          cp artifacts/windows-bundle/*.exe artifacts/Sagascript-Setup.exe
+          cp artifacts/windows-bundle/*.msi artifacts/Sagascript-Setup.msi
+
+          echo "Stable artifacts:"
+          ls -lh artifacts/Sagascript*
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true
           files: |
-            artifacts/macos-bundle/**/*
-            artifacts/windows-bundle/**/*
+            artifacts/Sagascript.dmg
+            artifacts/Sagascript.app.tar.gz
+            artifacts/Sagascript-Setup.exe
+            artifacts/Sagascript-Setup.msi


### PR DESCRIPTION
## Summary
- Add a rename step in the `publish-release` job that copies versioned build artifacts to stable, version-free filenames
- Update the release `files:` list to attach only the stable-named files
- Enables the landing page to use GitHub's `/releases/latest/download/<filename>` pattern without updating URLs on each release

### Stable filenames
| Artifact | Filename |
|----------|----------|
| macOS universal DMG | `Sagascript.dmg` |
| macOS updater bundle | `Sagascript.app.tar.gz` |
| Windows NSIS installer | `Sagascript-Setup.exe` |
| Windows MSI installer | `Sagascript-Setup.msi` |

## Test plan
- [ ] Push a test tag (e.g. `v0.1.0-rc1`) and verify the release draft contains all four stable-named artifacts
- [ ] Verify download URLs like `https://github.com/Magnus-Gille/sagascript/releases/latest/download/Sagascript.dmg` resolve correctly after publishing the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)