### PR TITLE
fix(ci): artifact rename uses find for nested paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,13 +110,13 @@ jobs:
 
       - name: Rename artifacts to stable filenames
         run: |
-          # macOS
-          cp artifacts/macos-bundle/*.dmg artifacts/Sagascript.dmg
-          cp artifacts/macos-bundle/*.app.tar.gz artifacts/Sagascript.app.tar.gz
+          # macOS (upload-artifact preserves directory structure)
+          find artifacts/macos-bundle -name '*.dmg' -exec cp {} artifacts/Sagascript.dmg \;
+          find artifacts/macos-bundle -name '*.app.tar.gz' -exec cp {} artifacts/Sagascript.app.tar.gz \;
 
           # Windows
-          cp artifacts/windows-bundle/*.exe artifacts/Sagascript-Setup.exe
-          cp artifacts/windows-bundle/*.msi artifacts/Sagascript-Setup.msi
+          find artifacts/windows-bundle -name '*.exe' -exec cp {} artifacts/Sagascript-Setup.exe \;
+          find artifacts/windows-bundle -name '*.msi' -exec cp {} artifacts/Sagascript-Setup.msi \;
 
           echo "Stable artifacts:"
           ls -lh artifacts/Sagascript*

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,0 +1,57 @@
+# Installing Sagascript
+
+## macOS
+
+Download **Sagascript.dmg** from the [latest release](https://github.com/Magnus-Gille/sagascript/releases/latest). This is a universal binary that runs natively on both Apple Silicon and Intel Macs.
+
+### Unsigned build warning
+
+Sagascript is not yet code-signed with an Apple Developer certificate. macOS will block the app the first time you open it.
+
+**To open it:**
+
+1. Open the DMG and drag Sagascript to Applications
+2. Open Sagascript from Applications — macOS will show *"Sagascript can't be opened because Apple cannot check it for malicious software"*
+3. Open **System Settings > Privacy & Security**, scroll down to the Security section
+4. You'll see *"Sagascript was blocked from use because it is not from an identified developer"* — click **Open Anyway**
+5. Confirm in the dialog that appears
+
+Alternatively, run this in Terminal before the first launch:
+
+```
+xattr -cr /Applications/Sagascript.app
+```
+
+You only need to do this once. Subsequent launches will work normally.
+
+## Windows
+
+Download **Sagascript-Setup.exe** from the [latest release](https://github.com/Magnus-Gille/sagascript/releases/latest).
+
+### SmartScreen warning
+
+Sagascript is not yet signed with a Windows code-signing certificate. Windows Defender SmartScreen will show a warning on first run.
+
+**To proceed:**
+
+1. Run the installer — SmartScreen shows *"Windows protected your PC"*
+2. Click **More info**
+3. Click **Run anyway**
+
+The warning only appears once per downloaded file.
+
+## First launch
+
+On first launch, Sagascript will walk you through setup:
+
+1. **Language** — pick your primary dictation language (English, Swedish, or Norwegian)
+2. **Speech engine download** — downloads the recommended Whisper model for your language (55-142 MB)
+3. **Microphone permission** (macOS) — required for live dictation
+4. **Accessibility permission** (macOS) — allows auto-paste into any app after dictation
+
+All speech processing happens locally on your device. No audio is sent to any server.
+
+## System requirements
+
+- **macOS:** 13.0 (Ventura) or later, Apple Silicon or Intel
+- **Windows:** 10 or later, WebView2 runtime (installed automatically)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3930,7 +3930,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arboard",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sagascript"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 description = "Low-latency macOS/Windows dictation app"
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "identifier": "com.sagascript.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Fix release workflow rename step that failed on v0.0.1 build
- `upload-artifact@v4` preserves directory structure, so artifacts are nested under `src-tauri/target/...`
- Use `find` instead of direct glob to locate files regardless of nesting

Hotfix for the v0.0.1 release — builds succeeded but the publish step failed.