### PR TITLE
fix: onboarding settings overwrite + CLI model management

### DIFF
--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -525,15 +525,17 @@ mod tests {
 
     #[test]
     fn valid_keys_count_matches_settings_struct() {
-        // Settings has 7 user-facing fields. If a new field is added to Settings
-        // but not to VALID_KEYS, this test will catch it.
+        // Internal fields that are serialized but not user-configurable via `config`.
+        // These have dedicated CLI commands instead (e.g. `reset-onboarding`).
+        const INTERNAL_FIELDS: &[&str] = &["has_completed_onboarding"];
+
         let settings = Settings::default();
         let json = serde_json::to_value(&settings).unwrap();
-        let field_count = json.as_object().unwrap().len();
+        let field_count = json.as_object().unwrap().len() - INTERNAL_FIELDS.len();
         assert_eq!(
             VALID_KEYS.len(),
             field_count,
-            "VALID_KEYS has {} entries but Settings has {} fields — did you forget to add a new setting?",
+            "VALID_KEYS has {} entries but Settings has {} user-facing fields — did you forget to add a new setting?",
             VALID_KEYS.len(),
             field_count
         );

--- a/src-tauri/src/cli/models.rs
+++ b/src-tauri/src/cli/models.rs
@@ -61,6 +61,39 @@ pub fn list(args: ListModelsArgs) -> Result<(), DictationError> {
     Ok(())
 }
 
+#[derive(Args)]
+pub struct DeleteModelArgs {
+    /// Model ID to delete [see: sagascript list-models]
+    pub model: String,
+}
+
+pub fn delete(args: DeleteModelArgs) -> Result<(), DictationError> {
+    let whisper_model = parse_model(&args.model)?;
+
+    if !model::is_model_downloaded(whisper_model) {
+        eprintln!(
+            "Model '{}' is not downloaded.",
+            whisper_model.display_name()
+        );
+        return Ok(());
+    }
+
+    let path = model::model_path(whisper_model);
+    std::fs::remove_file(&path).map_err(|e| {
+        DictationError::SettingsError(format!(
+            "Failed to delete model file '{}': {e}",
+            path.display()
+        ))
+    })?;
+
+    eprintln!(
+        "Deleted {} ({})",
+        whisper_model.display_name(),
+        path.display()
+    );
+    Ok(())
+}
+
 pub async fn download(args: DownloadModelArgs) -> Result<(), DictationError> {
     let whisper_model = parse_model(&args.model)?;
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -112,6 +112,18 @@ pub async fn set_language(
 }
 
 #[tauri::command]
+pub async fn set_onboarding_completed(
+    controller: State<'_, SharedController>,
+) -> Result<(), String> {
+    let mut ctrl = controller.lock().unwrap();
+    ctrl.settings_mut().has_completed_onboarding = true;
+    drop(ctrl);
+    persist_settings(&controller)?;
+    info!("Onboarding marked as completed");
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn set_whisper_model(
     controller: State<'_, SharedController>,
     model: WhisperModel,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -205,14 +205,8 @@ fn main() {
 
             // Auto-open onboarding on first launch
             {
-                use tauri_plugin_store::StoreExt;
-                let store = app.store("sagascript-settings.json")
-                    .map_err(|e| format!("Failed to open store: {e}"))?;
-                let completed = store
-                    .get("hasCompletedOnboarding")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                if !completed {
+                let settings = crate::settings::store::load();
+                if !settings.has_completed_onboarding {
                     info!("First launch detected, opening onboarding");
                     open_settings_window(app.handle(), Some("onboarding"));
                 }
@@ -257,6 +251,7 @@ fn main() {
             commands::check_microphone_permission,
             commands::request_microphone_permission,
             commands::get_platform,
+            commands::set_onboarding_completed,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Sagascript")

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -320,6 +320,8 @@ pub struct Settings {
     pub auto_select_model: bool,
     /// Hotkey shortcut string (e.g. "Control+Shift+Space")
     pub hotkey: String,
+    /// Whether the user has completed the first-launch onboarding
+    pub has_completed_onboarding: bool,
 }
 
 impl Default for Settings {
@@ -332,6 +334,7 @@ impl Default for Settings {
             auto_paste: true,
             auto_select_model: true,
             hotkey: "Control+Shift+Space".to_string(),
+            has_completed_onboarding: false,
         }
     }
 }

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -10,6 +10,7 @@
     requestMicrophonePermission,
     checkAccessibilityPermission,
     requestAccessibilityPermission,
+    setOnboardingCompleted,
   } from "./api";
 
   let { oncomplete }: { oncomplete: () => void } = $props();
@@ -154,10 +155,7 @@
 
   async function finish() {
     stopPoll();
-    const { load } = await import("@tauri-apps/plugin-store");
-    const store = await load("sagascript-settings.json");
-    await store.set("hasCompletedOnboarding", true);
-    await store.save();
+    await setOnboardingCompleted();
     oncomplete();
   }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -139,3 +139,7 @@ export async function requestMicrophonePermission(): Promise<boolean> {
 export async function getPlatform(): Promise<string> {
   return invoke("get_platform");
 }
+
+export async function setOnboardingCompleted(): Promise<void> {
+  return invoke("set_onboarding_completed");
+}


### PR DESCRIPTION
## Summary

- **Fix onboarding settings overwrite bug**: The `finish()` function in Onboarding.svelte used Tauri plugin-store's `save()` which overwrote the entire settings file with just `{"hasCompletedOnboarding": true}`, nuking any language/model changes made during onboarding. Moved the onboarding flag into the backend `Settings` struct so it uses the same merge-on-save system as all other settings.
- **Add `sagascript delete-model <id>`**: Remove a downloaded Whisper model from disk to free space or reset for testing.
- **Add `sagascript reset-onboarding`**: Reset the onboarding flag so the setup wizard runs again on next GUI launch.

## Test plan

- [ ] Run `sagascript reset-onboarding`, launch app, verify onboarding wizard appears
- [ ] Complete onboarding with Swedish language, verify settings file contains both `has_completed_onboarding: true` and `language: "sv"`
- [ ] Run `sagascript config get language` to confirm language persisted
- [ ] Run `sagascript delete-model base.en`, verify model file removed
- [ ] Run `sagascript list-models` to confirm model shows as not downloaded
- [ ] Run `cargo test` — 176 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)