### PR TITLE
fix(ci): add write permissions to SBOM workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   sbom:
     runs-on: macos-14


### PR DESCRIPTION
## Summary

- SBOM workflow failed with `HTTP 403: Resource not accessible by integration` when attaching SBOMs to the v0.0.1 release
- Root cause: the default `GITHUB_TOKEN` lacks write access to release assets without explicit `permissions: contents: write`

## Test plan

- [ ] CI passes on this PR
- [ ] Next release tag triggers SBOM generation and successful upload to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)