### PR TITLE
docs: credit KB and NB for Whisper models

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and ho
 - [whisper-rs](https://github.com/tazz4843/whisper-rs) -- Rust bindings for whisper.cpp
 - [Tauri](https://tauri.app/) -- the framework powering the native app shell
 - [OpenAI Whisper](https://github.com/openai/whisper) -- the original speech recognition model
+- [KB (Kungliga biblioteket / National Library of Sweden)](https://www.kb.se/) -- Swedish-optimized [KB-Whisper](https://huggingface.co/KBLab) models (tiny, base, small, medium, large) by KBLab, used for Swedish transcription
+- [NB (Nasjonalbiblioteket / National Library of Norway)](https://www.nb.no/) -- Norwegian-optimized [NB-Whisper](https://huggingface.co/NbAiLab) models (tiny, base, small, medium, large) by NbAiLab, used for Norwegian transcription
 - [NbAiLab/NPSC](https://huggingface.co/datasets/NbAiLab/NPSC) -- Norwegian test audio (CC0, Norwegian National Library)
 
 ## License


### PR DESCRIPTION
## Summary
- Add Kungliga biblioteket (National Library of Sweden) to acknowledgments for the KB-Whisper model family used for Swedish transcription
- Add Nasjonalbiblioteket (National Library of Norway) to acknowledgments for the NB-Whisper model family used for Norwegian transcription

## Test plan
- [x] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)