### PR TITLE
feat: add native .qta (QuickTime Audio) support

### DIFF
--- a/src-tauri/src/audio/decoder.rs
+++ b/src-tauri/src/audio/decoder.rs
@@ -41,12 +41,12 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
 
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
 
-    let mut hint = Hint::new();
-    // .qta is QuickTime Audio — probe as .mov
+    // Map format aliases: Symphonia doesn't know about .qta but decodes it as mov/isomp4
     let hint_ext = match ext.as_str() {
         "qta" => "mov",
         other => other,
     };
+    let mut hint = Hint::new();
     hint.with_extension(hint_ext);
 
     let probed = symphonia::default::get_probe()
@@ -176,6 +176,7 @@ mod tests {
         assert!(SUPPORTED_EXTENSIONS.contains(&"ogg"));
         assert!(SUPPORTED_EXTENSIONS.contains(&"mp4"));
         assert!(SUPPORTED_EXTENSIONS.contains(&"mov"));
+        assert!(SUPPORTED_EXTENSIONS.contains(&"qta"));
         assert!(SUPPORTED_EXTENSIONS.contains(&"webm"));
         assert!(SUPPORTED_EXTENSIONS.contains(&"aac"));
     }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -72,7 +72,7 @@ pub enum Command {
 Transcribe an audio or video file to text using a local Whisper model.
 
 The file is decoded to 16 kHz mono PCM, then processed by the selected \
-Whisper model. Supports WAV, MP3, M4A, AAC, MP4, MOV, OGG, WebM, and FLAC.
+Whisper model. Supports WAV, MP3, M4A, AAC, MP4, MOV, QTA, OGG, WebM, and FLAC.
 
 By default, uses the language and model from your persisted settings \
 (see 'sagascript config list'). Override with --language and --model.


### PR DESCRIPTION
## Summary
- Add `.qta` (QuickTime Audio) to supported file extensions — these are standard QuickTime/ISOMP4 containers, identical to `.mov`
- Map the `qta` extension to `mov` for Symphonia's format hint so the isomp4 prober is invoked correctly
- Update CLI help text to mention QTA

## Test plan
- [x] `cargo test` — 176 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `sagascript transcribe /path/to/file.qta` produces transcription output

🤖 Generated with [Claude Code](https://claude.com/claude-code)