### PR TITLE
feat: local speaker diarization pipeline (--diarize flag)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -204,6 +204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +886,16 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1793,6 +1809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kodama"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a44f3a71a44fbf49ce38152db7dc9adf959d4fe5c29344cd1858bdbda8d9091"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2525,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "memchr"
@@ -2593,6 +2640,21 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -3117,6 +3179,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3248,15 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3366,6 +3461,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3609,6 +3713,12 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "realfft"
@@ -3947,11 +4057,15 @@ dependencies = [
  "enigo",
  "futures-util",
  "indicatif",
+ "kodama",
+ "ndarray",
  "notify",
  "num_cpus",
  "objc",
+ "ort",
  "reqwest 0.12.28",
  "rubato",
+ "rustfft",
  "serde",
  "serde_json",
  "symphonia",
@@ -4340,6 +4454,17 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5622,6 +5747,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5651,6 +5806,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5950,6 +6111,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,10 +42,10 @@ symphonia = { version = "0.5", features = ["aac", "alac", "flac", "mp3", "pcm", 
 rubato = "0.14"
 
 # Diarization (optional, behind feature flag)
-ort = { version = "2.0.0-rc.12", optional = true }
+ort = { version = "2.0.0-rc.12", features = ["ndarray"], optional = true }
 rustfft = { version = "6", optional = true }
 kodama = { version = "0.2", optional = true }
-ndarray = { version = "0.16", optional = true }
+ndarray = { version = "0.17", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.15", features = ["coreml", "metal"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,12 @@ tauri-plugin-dialog = "2"
 symphonia = { version = "0.5", features = ["aac", "alac", "flac", "mp3", "pcm", "vorbis", "isomp4", "mkv", "ogg"] }
 rubato = "0.14"
 
+# Diarization (optional, behind feature flag)
+ort = { version = "2.0.0-rc.12", optional = true }
+rustfft = { version = "6", optional = true }
+kodama = { version = "0.2", optional = true }
+ndarray = { version = "0.16", optional = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.15", features = ["coreml", "metal"] }
 notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
@@ -61,3 +67,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-cli
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+diarization = ["dep:ort", "dep:rustfft", "dep:kodama", "dep:ndarray"]

--- a/src-tauri/src/audio/decoder.rs
+++ b/src-tauri/src/audio/decoder.rs
@@ -74,12 +74,14 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
         })?;
 
     let track_id = track.id;
-    let channels = track.codec_params.channels.map(|c| c.count()).unwrap_or(1);
     let sample_rate = track.codec_params.sample_rate.unwrap_or(44_100);
+    // channels from codec_params can be wrong (e.g. AAC stereo reporting 1).
+    // We'll detect the real channel count from the first decoded frame.
+    let codec_channels = track.codec_params.channels.map(|c| c.count()).unwrap_or(0);
 
     info!(
-        "Decoding audio: {} Hz, {} ch, codec {:?}",
-        sample_rate, channels, track.codec_params.codec
+        "Decoding audio: {} Hz, codec_channels={}, codec {:?}",
+        sample_rate, codec_channels, track.codec_params.codec
     );
 
     let mut decoder = symphonia::default::get_codecs()
@@ -89,6 +91,7 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
         })?;
 
     let mut all_samples: Vec<f32> = Vec::new();
+    let mut actual_channels: usize = codec_channels.max(1);
 
     // Decode all packets
     loop {
@@ -120,6 +123,8 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
         };
 
         let spec = *decoded.spec();
+        // Use actual channel count from decoded frame spec (more reliable than codec_params)
+        actual_channels = spec.channels.count().max(1);
         let num_frames = decoded.capacity();
 
         let mut sample_buf = SampleBuffer::<f32>::new(num_frames as u64, spec);
@@ -134,15 +139,17 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
         ));
     }
 
-    let duration_secs = all_samples.len() as f64 / (sample_rate as f64 * channels as f64);
+    let duration_secs = all_samples.len() as f64 / (sample_rate as f64 * actual_channels as f64);
     info!(
-        "Decoded {} raw samples ({:.1}s), resampling to 16kHz mono",
+        "Decoded {} raw samples ({:.1}s), {} ch at {} Hz, resampling to 16kHz mono",
         all_samples.len(),
-        duration_secs
+        duration_secs,
+        actual_channels,
+        sample_rate,
     );
 
     // Mix to mono and resample
-    let mono = mix_to_mono(&all_samples, channels);
+    let mono = mix_to_mono(&all_samples, actual_channels);
     let resampled = resample_to_16khz(mono, sample_rate)
         .map_err(|e| DictationError::TranscriptionFailed(format!("Resample failed: {e}")))?;
 

--- a/src-tauri/src/audio/decoder.rs
+++ b/src-tauri/src/audio/decoder.rs
@@ -13,7 +13,7 @@ use crate::error::DictationError;
 
 /// Supported audio/video file extensions.
 pub const SUPPORTED_EXTENSIONS: &[&str] = &[
-    "wav", "mp3", "m4a", "aac", "mp4", "mov", "ogg", "webm", "flac",
+    "wav", "mp3", "m4a", "aac", "mp4", "mov", "ogg", "webm", "flac", "qta",
 ];
 
 /// Decode an audio or video file to `Vec<f32>` at 16 kHz mono (Whisper input format).
@@ -42,7 +42,12 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
 
     let mut hint = Hint::new();
-    hint.with_extension(&ext);
+    // .qta is QuickTime Audio — probe as .mov
+    let hint_ext = match ext.as_str() {
+        "qta" => "mov",
+        other => other,
+    };
+    hint.with_extension(hint_ext);
 
     let probed = symphonia::default::get_probe()
         .format(

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -180,7 +180,12 @@ AVAILABLE MODELS:
   English:    tiny.en, base.en
   Swedish:    kb-whisper-tiny, kb-whisper-base, kb-whisper-small
   Norwegian:  nb-whisper-tiny, nb-whisper-base, nb-whisper-small
-  Multilingual: tiny, base"
+  Multilingual: tiny, base
+
+DIARIZATION MODELS (requires --features diarization):
+  pyannote-segmentation   Speaker segmentation (~6 MB)
+  wespeaker-embedding     Speaker embeddings (~27 MB)
+  diarization             Download both models at once"
     )]
     DownloadModel(models::DownloadModelArgs),
 

--- a/src-tauri/src/cli/models.rs
+++ b/src-tauri/src/cli/models.rs
@@ -58,6 +58,34 @@ pub fn list(args: ListModelsArgs) -> Result<(), DictationError> {
         }
     }
 
+    // Diarization models section (only when no language filter, or always show)
+    #[cfg(feature = "diarization")]
+    if args.language.is_none() {
+        use crate::diarization::model as diar_model;
+        use crate::diarization::model::DiarizationModel;
+
+        println!();
+        println!("Diarization models (speaker identification):");
+        println!("{}", "-".repeat(62));
+
+        for &m in DiarizationModel::ALL {
+            let downloaded = if diar_model::is_model_downloaded(m) {
+                "yes"
+            } else {
+                "no"
+            };
+
+            println!(
+                "{:<20} {:<10} {:>5} MB  {:<12} {:<12}",
+                m.model_id(),
+                m.display_name(),
+                m.size_mb(),
+                downloaded,
+                "—",
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -95,6 +123,24 @@ pub fn delete(args: DeleteModelArgs) -> Result<(), DictationError> {
 }
 
 pub async fn download(args: DownloadModelArgs) -> Result<(), DictationError> {
+    // Try diarization model IDs first (when feature is enabled)
+    #[cfg(feature = "diarization")]
+    {
+        use crate::diarization::model::DiarizationModel;
+
+        // "diarization" meta-ID downloads both models
+        if DiarizationModel::is_meta_id(&args.model) {
+            for &m in DiarizationModel::ALL {
+                download_diarization_model(m).await?;
+            }
+            return Ok(());
+        }
+
+        if let Some(diar) = DiarizationModel::from_id(&args.model) {
+            return download_diarization_model(diar).await;
+        }
+    }
+
     let whisper_model = parse_model(&args.model)?;
 
     if model::is_model_downloaded(whisper_model) {
@@ -115,6 +161,48 @@ pub async fn download(args: DownloadModelArgs) -> Result<(), DictationError> {
     );
 
     let path = model::download_model(whisper_model, |downloaded, total| {
+        if total > 0 {
+            let pct = (downloaded as f64 / total as f64 * 100.0) as u32;
+            let mb_done = downloaded as f64 / 1_048_576.0;
+            let mb_total = total as f64 / 1_048_576.0;
+            eprint!("\r  {:.1}/{:.1} MB ({pct}%)", mb_done, mb_total);
+        } else {
+            let mb_done = downloaded as f64 / 1_048_576.0;
+            eprint!("\r  {:.1} MB downloaded", mb_done);
+        }
+    })
+    .await?;
+
+    eprintln!(); // newline after progress
+    eprintln!("Download complete.");
+    println!("{}", path.display());
+    Ok(())
+}
+
+#[cfg(feature = "diarization")]
+async fn download_diarization_model(
+    model: crate::diarization::model::DiarizationModel,
+) -> Result<(), DictationError> {
+    use crate::diarization::model as diar_model;
+
+    if diar_model::is_model_downloaded(model) {
+        let path = diar_model::model_path(model);
+        eprintln!(
+            "Model '{}' is already downloaded at {}",
+            model.display_name(),
+            path.display()
+        );
+        println!("{}", path.display());
+        return Ok(());
+    }
+
+    eprintln!(
+        "Downloading {} (~{} MB)...",
+        model.display_name(),
+        model.size_mb()
+    );
+
+    let path = diar_model::download_model(model, |downloaded, total| {
         if total > 0 {
             let pct = (downloaded as f64 / total as f64 * 100.0) as u32;
             let mb_done = downloaded as f64 / 1_048_576.0;

--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -96,8 +96,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         let speaker_segments = diarize(&audio, &DiarizeConfig::default())?;
         eprintln!("Found {} speaker segment(s)", speaker_segments.len());
 
-        eprintln!("Transcribing with timestamps...");
+        let n_chunks = (audio.len() + 30 * 16_000 - 1) / (28 * 16_000);
+        eprintln!("Transcribing with timestamps ({n_chunks} chunk(s))...");
         let raw_segments = backend.transcribe_sync_with_timestamps(&audio, language)?;
+        eprintln!("Got {} transcript segment(s)", raw_segments.len());
 
         let transcript: Vec<TimestampedSegment> = raw_segments
             .into_iter()

--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -30,6 +30,11 @@ pub struct TranscribeArgs {
     /// Copy transcription result to clipboard
     #[arg(long)]
     pub clipboard: bool,
+
+    /// Enable speaker diarization (requires diarization models — run: sagascript download-model diarization)
+    #[cfg(feature = "diarization")]
+    #[arg(long)]
+    pub diarize: bool,
 }
 
 pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
@@ -69,7 +74,73 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
-    // Transcribe
+    // Diarization branch
+    #[cfg(feature = "diarization")]
+    if args.diarize {
+        use crate::diarization::{
+            DiarizeConfig, TimestampedSegment,
+            diarize,
+            merge::{consolidate, merge_with_transcript},
+            model::all_models_downloaded,
+        };
+
+        if !all_models_downloaded() {
+            return Err(DictationError::DiarizationError(
+                "Diarization models not found. Run: sagascript download-model diarization".to_string(),
+            ));
+        }
+
+        // Run diarization and timestamped transcription in parallel isn't possible
+        // with a single-threaded whisper context, so we run sequentially.
+        eprintln!("Running speaker diarization...");
+        let speaker_segments = diarize(&audio, &DiarizeConfig::default())?;
+        eprintln!("Found {} speaker segment(s)", speaker_segments.len());
+
+        eprintln!("Transcribing with timestamps...");
+        let raw_segments = backend.transcribe_sync_with_timestamps(&audio, language)?;
+
+        let transcript: Vec<TimestampedSegment> = raw_segments
+            .into_iter()
+            .map(|(start, end, text)| TimestampedSegment { start, end, text })
+            .collect();
+
+        let diarized = merge_with_transcript(&speaker_segments, &transcript);
+        let consolidated = consolidate(&diarized);
+
+        if args.json {
+            let speakers: Vec<String> = {
+                let mut seen = std::collections::HashSet::new();
+                consolidated.iter().map(|s| s.speaker.clone()).filter(|s| seen.insert(s.clone())).collect()
+            };
+            let json = serde_json::json!({
+                "segments": consolidated,
+                "speakers": speakers,
+                "language": language,
+                "model": model_id_string(model),
+                "file": args.file.display().to_string(),
+                "duration_seconds": duration,
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+        } else {
+            for seg in &consolidated {
+                println!("[{}] {}", seg.speaker, seg.text.trim());
+            }
+        }
+
+        if args.clipboard {
+            let text: String = consolidated
+                .iter()
+                .map(|s| format!("[{}] {}", s.speaker, s.text.trim()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            copy_to_clipboard(&text)?;
+            eprintln!("Copied to clipboard.");
+        }
+
+        return Ok(());
+    }
+
+    // Standard (non-diarized) transcription
     let text = if duration > 10.0 {
         let pb = ProgressBar::new(100);
         pb.set_style(

--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -35,6 +35,12 @@ pub struct TranscribeArgs {
     #[cfg(feature = "diarization")]
     #[arg(long)]
     pub diarize: bool,
+
+    /// Initial prompt to prime the decoder with domain-specific vocabulary.
+    /// Reduces hallucination on technical terms, proper nouns, and jargon.
+    /// Example: --prompt "Grimnir, MCP, Fortnox, bokföring, kontering, saldo"
+    #[arg(long, value_name = "TEXT")]
+    pub prompt: Option<String>,
 }
 
 pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
@@ -96,9 +102,8 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         let speaker_segments = diarize(&audio, &DiarizeConfig::default())?;
         eprintln!("Found {} speaker segment(s)", speaker_segments.len());
 
-        let n_chunks = (audio.len() + 30 * 16_000 - 1) / (28 * 16_000);
-        eprintln!("Transcribing with timestamps ({n_chunks} chunk(s))...");
-        let raw_segments = backend.transcribe_sync_with_timestamps(&audio, language)?;
+        eprintln!("Transcribing with timestamps...");
+        let raw_segments = backend.transcribe_sync_with_timestamps(&audio, language, args.prompt.as_deref())?;
         eprintln!("Got {} transcript segment(s)", raw_segments.len());
 
         let transcript: Vec<TimestampedSegment> = raw_segments
@@ -150,14 +155,19 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
                 .unwrap(),
         );
         let pb_cb = pb.clone();
-        let text = backend.transcribe_sync_with_progress(&audio, language, move |pct| {
+        let prompt = args.prompt.clone();
+        let text = backend.transcribe_sync_with_progress_and_prompt(&audio, language, prompt.as_deref(), move |pct| {
             pb_cb.set_position(pct as u64);
         })?;
         pb.finish_and_clear();
         text
     } else {
         eprintln!("Transcribing...");
-        backend.transcribe_sync(&audio, language)?
+        if let Some(p) = &args.prompt {
+            backend.transcribe_sync_with_progress_and_prompt(&audio, language, Some(p.as_str()), |_| {})?
+        } else {
+            backend.transcribe_sync(&audio, language)?
+        }
     };
 
     // Output

--- a/src-tauri/src/diarization/clustering.rs
+++ b/src-tauri/src/diarization/clustering.rs
@@ -1,0 +1,270 @@
+/// Agglomerative hierarchical clustering for speaker embeddings.
+///
+/// Uses complete linkage with cosine distance to group embeddings
+/// from the segmentation stage into global speaker identities.
+use kodama::{linkage, Method};
+
+use crate::diarization::embedding::EMBEDDING_DIM;
+
+/// Default clustering threshold (cosine distance, 0.0-2.0 range).
+/// At 0.8, embeddings with cosine similarity > 0.2 are merged.
+pub const DEFAULT_THRESHOLD: f32 = 0.8;
+
+/// Cluster embeddings and return a global speaker label per input.
+///
+/// `embeddings`: slice of `(local_speaker_idx, embedding)` from the embedding stage.
+/// `threshold`: cosine distance threshold for cutting the dendrogram.
+///
+/// Returns `Vec<(local_speaker_idx, global_speaker_id)>` — one entry per input embedding.
+/// Global speaker IDs are assigned 0, 1, 2, ... in order of first appearance.
+pub fn cluster_speakers(
+    embeddings: &[(usize, [f32; EMBEDDING_DIM])],
+    threshold: f32,
+) -> Vec<(usize, usize)> {
+    let n = embeddings.len();
+
+    if n == 0 {
+        return Vec::new();
+    }
+    if n == 1 {
+        return vec![(embeddings[0].0, 0)];
+    }
+
+    // Build condensed cosine distance matrix (upper triangle, row-major)
+    let mut condensed: Vec<f32> = Vec::with_capacity(n * (n - 1) / 2);
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let sim = cosine_similarity(&embeddings[i].1, &embeddings[j].1);
+            // Clamp to [0, 2] — cosine distance range for L2-normalized vectors
+            condensed.push((1.0 - sim).clamp(0.0, 2.0));
+        }
+    }
+
+    let dendrogram = linkage(&mut condensed, n, Method::Complete);
+    let raw_labels = cutree(&dendrogram, n, threshold);
+
+    // Remap raw cluster IDs to contiguous 0-based labels in order of first appearance
+    let mut id_map: Vec<Option<usize>> = vec![None; n * 2];
+    let mut next_id = 0usize;
+    let mut labels = vec![0usize; n];
+    for (i, &raw) in raw_labels.iter().enumerate() {
+        if id_map.get(raw).and_then(|v| *v).is_none() {
+            if raw < id_map.len() {
+                id_map[raw] = Some(next_id);
+            }
+            next_id += 1;
+        }
+        labels[i] = id_map
+            .get(raw)
+            .and_then(|v| *v)
+            .unwrap_or(next_id - 1);
+    }
+
+    embeddings
+        .iter()
+        .zip(labels.iter())
+        .map(|((local_idx, _), &global_id)| (*local_idx, global_id))
+        .collect()
+}
+
+/// Cut a dendrogram at `threshold`, returning a cluster label per observation.
+///
+/// Uses Union-Find over observations only (indices 0..n). For each step where
+/// dissimilarity ≤ threshold, resolves both cluster1 and cluster2 to their
+/// representative observation, then unions them.
+///
+/// Composite cluster labels (≥ n) are tracked to find their representative.
+fn cutree(dendrogram: &kodama::Dendrogram<f32>, n: usize, threshold: f32) -> Vec<usize> {
+    // Union-Find over observations 0..n
+    let mut parent: Vec<usize> = (0..n).collect();
+
+    fn find(parent: &mut [usize], mut x: usize) -> usize {
+        while parent[x] != x {
+            parent[x] = parent[parent[x]]; // path compression
+            x = parent[x];
+        }
+        x
+    }
+
+    // For composite clusters (index >= n, created at step i = index - n),
+    // track one representative observation index.
+    let mut representative: Vec<usize> = vec![0; n - 1];
+
+    for (step_idx, step) in dendrogram.steps().iter().enumerate() {
+        // Resolve each cluster to a representative observation index
+        let rep1 = if step.cluster1 < n {
+            step.cluster1
+        } else {
+            representative[step.cluster1 - n]
+        };
+        let rep2 = if step.cluster2 < n {
+            step.cluster2
+        } else {
+            representative[step.cluster2 - n]
+        };
+
+        // The new composite cluster (n + step_idx) is represented by rep1
+        representative[step_idx] = rep1;
+
+        if step.dissimilarity <= threshold {
+            let root1 = find(&mut parent, rep1);
+            let root2 = find(&mut parent, rep2);
+            if root1 != root2 {
+                parent[root1] = root2;
+            }
+        }
+    }
+
+    // Assign labels: root ID for each observation
+    (0..n).map(|i| find(&mut parent, i)).collect()
+}
+
+/// Cosine similarity between two L2-normalized (or unnormalized) vectors.
+fn cosine_similarity(a: &[f32; EMBEDDING_DIM], b: &[f32; EMBEDDING_DIM]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    let denom = norm_a * norm_b;
+    if denom < 1e-12 {
+        0.0
+    } else {
+        (dot / denom).clamp(-1.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diarization::embedding::l2_normalize;
+
+    fn make_embedding(values: [f32; EMBEDDING_DIM]) -> [f32; EMBEDDING_DIM] {
+        l2_normalize(values)
+    }
+
+    fn unit_embedding(dim: usize) -> [f32; EMBEDDING_DIM] {
+        let mut v = [0.0f32; EMBEDDING_DIM];
+        v[dim % EMBEDDING_DIM] = 1.0;
+        v
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let result = cluster_speakers(&[], 0.8);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn single_embedding_returns_speaker_zero() {
+        let emb = unit_embedding(0);
+        let result = cluster_speakers(&[(0, emb)], 0.8);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], (0, 0));
+    }
+
+    #[test]
+    fn two_identical_embeddings_merge_into_one_speaker() {
+        let emb = unit_embedding(0);
+        let input = vec![(0, emb), (1, emb)];
+        let result = cluster_speakers(&input, 0.8);
+        assert_eq!(result.len(), 2);
+        // Both should get the same global ID
+        assert_eq!(result[0].1, result[1].1, "identical embeddings should cluster together");
+    }
+
+    #[test]
+    fn two_orthogonal_embeddings_become_different_speakers() {
+        // Orthogonal vectors: cosine distance = 1.0, which is above typical threshold
+        let emb0 = unit_embedding(0);
+        let emb1 = unit_embedding(1);
+        let input = vec![(0, emb0), (1, emb1)];
+        let result = cluster_speakers(&input, 0.5); // strict threshold
+        assert_eq!(result.len(), 2);
+        assert_ne!(result[0].1, result[1].1, "orthogonal embeddings should be different speakers");
+    }
+
+    #[test]
+    fn threshold_below_distance_keeps_embeddings_separate() {
+        // Orthogonal unit vectors have cosine distance 1.0.
+        // Threshold 0.5 < 1.0, so they should NOT merge.
+        let emb0 = unit_embedding(0);
+        let emb1 = unit_embedding(1);
+        let emb2 = unit_embedding(2);
+        let input = vec![(0, emb0), (1, emb1), (2, emb2)];
+        let result = cluster_speakers(&input, 0.5);
+        let ids: Vec<usize> = result.iter().map(|r| r.1).collect();
+        let unique: std::collections::HashSet<_> = ids.iter().cloned().collect();
+        assert_eq!(unique.len(), 3, "threshold=0.5 < distance=1.0 should keep 3 speakers: {:?}", ids);
+    }
+
+    #[test]
+    fn threshold_above_distance_merges_all() {
+        // Orthogonal unit vectors have cosine distance 1.0.
+        // Threshold 1.5 > 1.0, so complete linkage will merge all into one cluster.
+        let emb0 = unit_embedding(0);
+        let emb1 = unit_embedding(1);
+        let emb2 = unit_embedding(2);
+        let input = vec![(0, emb0), (1, emb1), (2, emb2)];
+        let result = cluster_speakers(&input, 1.5);
+        let ids: Vec<usize> = result.iter().map(|r| r.1).collect();
+        let unique: std::collections::HashSet<_> = ids.iter().cloned().collect();
+        assert_eq!(unique.len(), 1, "threshold=1.5 > distance=1.0 should merge all: {:?}", ids);
+    }
+
+    #[test]
+    fn two_clusters_correctly_separated() {
+        // Cluster A: embeddings near dim 0
+        let mut a1 = [0.0f32; EMBEDDING_DIM];
+        a1[0] = 0.9;
+        a1[1] = 0.1;
+        let a1 = make_embedding(a1);
+
+        let mut a2 = [0.0f32; EMBEDDING_DIM];
+        a2[0] = 0.95;
+        a2[1] = 0.05;
+        let a2 = make_embedding(a2);
+
+        // Cluster B: embeddings near dim 100
+        let mut b1 = [0.0f32; EMBEDDING_DIM];
+        b1[100] = 0.9;
+        b1[101] = 0.1;
+        let b1 = make_embedding(b1);
+
+        let mut b2 = [0.0f32; EMBEDDING_DIM];
+        b2[100] = 0.95;
+        b2[101] = 0.05;
+        let b2 = make_embedding(b2);
+
+        let input = vec![(0, a1), (0, a2), (1, b1), (1, b2)];
+        let result = cluster_speakers(&input, 0.8);
+
+        assert_eq!(result.len(), 4);
+        // a1 and a2 should have the same global ID
+        assert_eq!(result[0].1, result[1].1, "cluster A should merge");
+        // b1 and b2 should have the same global ID
+        assert_eq!(result[2].1, result[3].1, "cluster B should merge");
+        // The two clusters should be different
+        assert_ne!(result[0].1, result[2].1, "clusters A and B should differ");
+    }
+
+    #[test]
+    fn cosine_similarity_identical() {
+        let v = unit_embedding(5);
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_similarity_orthogonal() {
+        let v0 = unit_embedding(0);
+        let v1 = unit_embedding(1);
+        assert!(cosine_similarity(&v0, &v1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_similarity_zero_vector_stable() {
+        let zero = [0.0f32; EMBEDDING_DIM];
+        let v = unit_embedding(0);
+        // Should not panic or produce NaN
+        let sim = cosine_similarity(&zero, &v);
+        assert!(!sim.is_nan());
+    }
+}

--- a/src-tauri/src/diarization/clustering.rs
+++ b/src-tauri/src/diarization/clustering.rs
@@ -1,7 +1,9 @@
 /// Agglomerative hierarchical clustering for speaker embeddings.
 ///
-/// Uses complete linkage with cosine distance to group embeddings
+/// Uses average linkage with cosine distance to group embeddings
 /// from the segmentation stage into global speaker identities.
+/// Average linkage is more robust than complete linkage for speaker diarization
+/// because it uses mean inter-cluster distance rather than worst-case.
 use kodama::{linkage, Method};
 
 use crate::diarization::embedding::EMBEDDING_DIM;
@@ -40,7 +42,7 @@ pub fn cluster_speakers(
         }
     }
 
-    let dendrogram = linkage(&mut condensed, n, Method::Complete);
+    let dendrogram = linkage(&mut condensed, n, Method::Average);
     let raw_labels = cutree(&dendrogram, n, threshold);
 
     // Remap raw cluster IDs to contiguous 0-based labels in order of first appearance

--- a/src-tauri/src/diarization/embedding.rs
+++ b/src-tauri/src/diarization/embedding.rs
@@ -29,6 +29,8 @@ impl Embedder {
             .commit_from_file(model_path)
             .map_err(|e| DictationError::DiarizationError(format!("Failed to load embedding model: {e}")))?;
         info!("Embedding model loaded from {}", model_path.display());
+        // Log expected input/output shapes so we can verify tensor orientation
+        info!("Embedding model input: {:?}", session.inputs().iter().map(|i| format!("'{}' {:?}", i.name(), i.dtype())).collect::<Vec<_>>());
         Ok(Self { session })
     }
 
@@ -75,7 +77,9 @@ impl Embedder {
     /// Extract embeddings for a list of audio segments.
     ///
     /// `segments` is a slice of `(start_sec, end_sec, speaker_idx)` from the segmentation stage.
-    /// Returns `(speaker_idx, embedding)` for each segment that is long enough to embed.
+    /// Returns `(segment_index, embedding)` — the segment index (not speaker_idx) is used as
+    /// the key so that clustering output can be mapped back to individual segments unambiguously.
+    /// Segments that are too short to embed are silently skipped.
     pub fn extract_embeddings(
         &mut self,
         audio: &[f32],
@@ -84,7 +88,7 @@ impl Embedder {
         let sample_rate = 16_000usize;
         let mut result = Vec::new();
 
-        for &(start_sec, end_sec, speaker_idx) in segments {
+        for (seg_idx, &(start_sec, end_sec, _speaker_idx)) in segments.iter().enumerate() {
             let start_sample = (start_sec * sample_rate as f64) as usize;
             let end_sample = ((end_sec * sample_rate as f64) as usize).min(audio.len());
 
@@ -94,7 +98,7 @@ impl Embedder {
 
             let slice = &audio[start_sample..end_sample];
             if let Some(embedding) = self.embed(slice)? {
-                result.push((speaker_idx, embedding));
+                result.push((seg_idx, embedding));
             }
         }
 

--- a/src-tauri/src/diarization/embedding.rs
+++ b/src-tauri/src/diarization/embedding.rs
@@ -1,0 +1,170 @@
+/// Speaker embedding extraction using the WeSpeaker ResNet34-LM ONNX model.
+///
+/// Input: 16kHz mono f32 audio slice
+/// Output: 256-dim L2-normalized speaker embedding
+use std::path::Path;
+
+use ndarray::Array3;
+use ort::{session::Session, value::Tensor};
+use tracing::info;
+
+use crate::diarization::fbank;
+use crate::error::DictationError;
+
+/// Minimum audio samples for a meaningful embedding (25ms = 400 samples)
+const MIN_SAMPLES: usize = fbank::N_FFT;
+/// Embedding dimension
+pub const EMBEDDING_DIM: usize = 256;
+
+/// Wraps the WeSpeaker ONNX model for speaker embedding extraction.
+pub struct Embedder {
+    session: Session,
+}
+
+impl Embedder {
+    /// Load the embedding model from disk.
+    pub fn new(model_path: &Path) -> Result<Self, DictationError> {
+        let session = Session::builder()
+            .map_err(|e| DictationError::DiarizationError(format!("Failed to create ORT session builder: {e}")))?
+            .commit_from_file(model_path)
+            .map_err(|e| DictationError::DiarizationError(format!("Failed to load embedding model: {e}")))?;
+        info!("Embedding model loaded from {}", model_path.display());
+        Ok(Self { session })
+    }
+
+    /// Extract a 256-dim L2-normalized speaker embedding from a mono 16kHz audio slice.
+    ///
+    /// Returns `None` if audio is too short (< 25ms).
+    pub fn embed(&mut self, audio: &[f32]) -> Result<Option<[f32; EMBEDDING_DIM]>, DictationError> {
+        if audio.len() < MIN_SAMPLES {
+            return Ok(None);
+        }
+
+        let features = fbank::compute_fbank(audio);
+        if features.len() < 4 {
+            return Ok(None);
+        }
+
+        let n_frames = features.len();
+        // Flatten [T, 80] to Vec<f32> for ndarray
+        let flat: Vec<f32> = features.into_iter().flat_map(|f| f.into_iter()).collect();
+
+        let input = Array3::from_shape_vec((1, n_frames, fbank::N_MELS), flat)
+            .map_err(|e| DictationError::DiarizationError(format!("Shape error: {e}")))?;
+
+        let tensor = Tensor::from_array(input)
+            .map_err(|e| DictationError::DiarizationError(format!("Tensor error: {e}")))?;
+        let outputs = self
+            .session
+            .run(ort::inputs![tensor])
+            .map_err(|e| DictationError::DiarizationError(format!("Embedding inference failed: {e}")))?;
+
+        let raw = outputs[0]
+            .try_extract_array::<f32>()
+            .map_err(|e| DictationError::DiarizationError(format!("Output extraction failed: {e}")))?;
+
+        let view = raw.view();
+        let mut embedding = [0.0f32; EMBEDDING_DIM];
+        for i in 0..EMBEDDING_DIM {
+            embedding[i] = view[[0, i]];
+        }
+
+        Ok(Some(l2_normalize(embedding)))
+    }
+
+    /// Extract embeddings for a list of audio segments.
+    ///
+    /// `segments` is a slice of `(start_sec, end_sec, speaker_idx)` from the segmentation stage.
+    /// Returns `(speaker_idx, embedding)` for each segment that is long enough to embed.
+    pub fn extract_embeddings(
+        &mut self,
+        audio: &[f32],
+        segments: &[(f64, f64, usize)],
+    ) -> Result<Vec<(usize, [f32; EMBEDDING_DIM])>, DictationError> {
+        let sample_rate = 16_000usize;
+        let mut result = Vec::new();
+
+        for &(start_sec, end_sec, speaker_idx) in segments {
+            let start_sample = (start_sec * sample_rate as f64) as usize;
+            let end_sample = ((end_sec * sample_rate as f64) as usize).min(audio.len());
+
+            if end_sample <= start_sample || end_sample - start_sample < MIN_SAMPLES {
+                continue;
+            }
+
+            let slice = &audio[start_sample..end_sample];
+            if let Some(embedding) = self.embed(slice)? {
+                result.push((speaker_idx, embedding));
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+/// L2-normalize a fixed-size embedding vector.
+pub fn l2_normalize(mut v: [f32; EMBEDDING_DIM]) -> [f32; EMBEDDING_DIM] {
+    let norm: f32 = v.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    if norm > 1e-12 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn l2_normalize_unit_vector() {
+        let mut v = [0.0f32; EMBEDDING_DIM];
+        v[0] = 1.0;
+        let normalized = l2_normalize(v);
+        let norm: f32 = normalized.iter().map(|&x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-6, "norm should be 1.0, got {norm}");
+    }
+
+    #[test]
+    fn l2_normalize_uniform_vector() {
+        let v = [1.0f32; EMBEDDING_DIM];
+        let normalized = l2_normalize(v);
+        let norm: f32 = normalized.iter().map(|&x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5, "norm should be 1.0, got {norm}");
+    }
+
+    #[test]
+    fn l2_normalize_zero_vector_is_stable() {
+        let v = [0.0f32; EMBEDDING_DIM];
+        let normalized = l2_normalize(v);
+        // Should not panic or produce NaN
+        for x in &normalized {
+            assert!(!x.is_nan(), "NaN in zero-vector normalization");
+        }
+    }
+
+    #[test]
+    fn extract_embeddings_skips_short_segments() {
+        // Segments shorter than MIN_SAMPLES should be skipped
+        let audio = vec![0.0f32; 16_000];
+        let segments = vec![
+            (0.0, 0.01, 0usize), // 160 samples — too short
+        ];
+        // We can't run inference without a real model, but we can test that
+        // short segments are filtered before reaching the model.
+        // Extract the filtering logic directly:
+        let sample_rate = 16_000usize;
+        for &(start_sec, end_sec, _) in &segments {
+            let start_sample = (start_sec * sample_rate as f64) as usize;
+            let end_sample = ((end_sec * sample_rate as f64) as usize).min(audio.len());
+            let len = end_sample.saturating_sub(start_sample);
+            assert!(len < MIN_SAMPLES, "segment should be too short: {len} samples");
+        }
+    }
+
+    #[test]
+    fn min_samples_matches_fbank_nfft() {
+        assert_eq!(MIN_SAMPLES, fbank::N_FFT);
+    }
+}

--- a/src-tauri/src/diarization/fbank.rs
+++ b/src-tauri/src/diarization/fbank.rs
@@ -1,0 +1,248 @@
+/// 80-dim log-mel filterbank feature extraction for speaker embedding.
+///
+/// Matches WeSpeaker ResNet34-LM training configuration:
+/// - 16kHz input, 80 mel bins, 25ms window, 10ms hop
+/// - Global mean subtraction across all frames
+use rustfft::{FftPlanner, num_complex::Complex};
+
+const SAMPLE_RATE: f32 = 16_000.0;
+pub const N_FFT: usize = 400; // 25ms window at 16kHz
+pub const HOP_LENGTH: usize = 160; // 10ms hop
+pub const N_MELS: usize = 80;
+const FMIN: f32 = 20.0;
+const FMAX: f32 = 7600.0;
+const N_FREQS: usize = N_FFT / 2 + 1; // 201
+
+/// Convert frequency in Hz to mel scale.
+fn hz_to_mel(hz: f32) -> f32 {
+    2595.0 * (1.0 + hz / 700.0).log10()
+}
+
+/// Convert mel value back to Hz.
+fn mel_to_hz(mel: f32) -> f32 {
+    700.0 * (10f32.powf(mel / 2595.0) - 1.0)
+}
+
+/// Build an [N_MELS x N_FREQS] triangular mel filterbank matrix.
+fn mel_filterbank() -> Vec<[f32; N_FREQS]> {
+    let mel_min = hz_to_mel(FMIN);
+    let mel_max = hz_to_mel(FMAX);
+
+    // N_MELS + 2 evenly-spaced mel points (includes boundary points)
+    let mel_points: Vec<f32> = (0..=(N_MELS + 1))
+        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (N_MELS + 1) as f32)
+        .collect();
+
+    // Convert to bin indices in the FFT frequency grid
+    let freq_bins: Vec<f32> = mel_points
+        .iter()
+        .map(|&m| mel_to_hz(m) / SAMPLE_RATE * N_FFT as f32)
+        .collect();
+
+    // Build triangular filters
+    let mut filters = vec![[0.0f32; N_FREQS]; N_MELS];
+    for m in 0..N_MELS {
+        let f_left = freq_bins[m];
+        let f_center = freq_bins[m + 1];
+        let f_right = freq_bins[m + 2];
+
+        for k in 0..N_FREQS {
+            let k_f = k as f32;
+            if k_f >= f_left && k_f <= f_center && f_center > f_left {
+                filters[m][k] = (k_f - f_left) / (f_center - f_left);
+            } else if k_f > f_center && k_f <= f_right && f_right > f_center {
+                filters[m][k] = (f_right - k_f) / (f_right - f_center);
+            }
+        }
+    }
+
+    filters
+}
+
+/// Compute 80-dim log-mel filterbank features from 16kHz mono f32 audio.
+///
+/// Returns one feature vector per frame. Frame count = `(audio.len() - N_FFT) / HOP_LENGTH + 1`.
+/// Global mean subtraction is applied across all frames per mel bin.
+///
+/// Returns an empty vec if audio is too short to produce any frames.
+pub fn compute_fbank(audio: &[f32]) -> Vec<[f32; N_MELS]> {
+    if audio.len() < N_FFT {
+        return Vec::new();
+    }
+
+    let n_frames = (audio.len() - N_FFT) / HOP_LENGTH + 1;
+
+    // Hann window
+    let hann: Vec<f32> = (0..N_FFT)
+        .map(|i| 0.5 * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / (N_FFT - 1) as f32).cos()))
+        .collect();
+
+    let filters = mel_filterbank();
+
+    // FFT planner (reused across frames)
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(N_FFT);
+
+    let mut features = vec![[0.0f32; N_MELS]; n_frames];
+
+    for frame_idx in 0..n_frames {
+        let start = frame_idx * HOP_LENGTH;
+        let frame = &audio[start..start + N_FFT];
+
+        // Apply Hann window and convert to complex
+        let mut buffer: Vec<Complex<f32>> = frame
+            .iter()
+            .zip(hann.iter())
+            .map(|(&s, &w)| Complex::new(s * w, 0.0))
+            .collect();
+
+        fft.process(&mut buffer);
+
+        // Power spectrum (one-sided): |X(k)|^2
+        let power: Vec<f32> = buffer[..N_FREQS]
+            .iter()
+            .map(|c| c.norm_sqr())
+            .collect();
+
+        // Apply mel filterbank and log
+        for m in 0..N_MELS {
+            let energy: f32 = filters[m]
+                .iter()
+                .zip(power.iter())
+                .map(|(&f, &p)| f * p)
+                .sum();
+            features[frame_idx][m] = energy.max(1e-10).ln();
+        }
+    }
+
+    // Global mean subtraction per mel bin
+    if !features.is_empty() {
+        let mut mean = [0.0f32; N_MELS];
+        for frame in &features {
+            for (m, &v) in frame.iter().enumerate() {
+                mean[m] += v;
+            }
+        }
+        let n = features.len() as f32;
+        for m in &mut mean {
+            *m /= n;
+        }
+        for frame in &mut features {
+            for (m, v) in frame.iter_mut().enumerate() {
+                *v -= mean[m];
+            }
+        }
+    }
+
+    features
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_count_matches_expected() {
+        // 1 second of audio = 16000 samples → (16000 - 400) / 160 + 1 = 98 frames
+        let audio = vec![0.0f32; 16_000];
+        let features = compute_fbank(&audio);
+        let expected = (16_000 - N_FFT) / HOP_LENGTH + 1;
+        assert_eq!(features.len(), expected, "frame count mismatch");
+    }
+
+    #[test]
+    fn output_has_correct_dimensionality() {
+        let audio = vec![0.0f32; 16_000];
+        let features = compute_fbank(&audio);
+        assert!(!features.is_empty());
+        for frame in &features {
+            assert_eq!(frame.len(), N_MELS);
+        }
+    }
+
+    #[test]
+    fn silence_has_zero_mean_after_subtraction() {
+        // Silence → all identical log values before subtraction → zero after
+        let audio = vec![0.0f32; 16_000];
+        let features = compute_fbank(&audio);
+        for frame in &features {
+            for &v in frame.iter() {
+                assert!(
+                    v.abs() < 1e-4,
+                    "silence should have near-zero features after mean subtraction, got {v}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mean_is_approximately_zero_per_bin() {
+        // After global mean subtraction, per-bin mean across all frames should be ~0
+        let mut audio = vec![0.0f32; 16_000];
+        // Add some variation so the test is non-trivial
+        for (i, s) in audio.iter_mut().enumerate() {
+            *s = (i as f32 * 0.001).sin() * 0.5;
+        }
+        let features = compute_fbank(&audio);
+        assert!(!features.is_empty());
+
+        let n = features.len() as f32;
+        for m in 0..N_MELS {
+            let mean: f32 = features.iter().map(|f| f[m]).sum::<f32>() / n;
+            assert!(
+                mean.abs() < 1e-4,
+                "mean for bin {m} should be ~0 after subtraction, got {mean}"
+            );
+        }
+    }
+
+    #[test]
+    fn audio_too_short_returns_empty() {
+        let audio = vec![0.0f32; N_FFT - 1];
+        let features = compute_fbank(&audio);
+        assert!(features.is_empty(), "audio shorter than N_FFT should return empty");
+    }
+
+    #[test]
+    fn exactly_one_frame_at_minimum_length() {
+        let audio = vec![0.0f32; N_FFT];
+        let features = compute_fbank(&audio);
+        assert_eq!(features.len(), 1);
+    }
+
+    #[test]
+    fn mel_filterbank_has_correct_shape() {
+        let fb = mel_filterbank();
+        assert_eq!(fb.len(), N_MELS);
+        for row in &fb {
+            assert_eq!(row.len(), N_FREQS);
+        }
+    }
+
+    #[test]
+    fn mel_filterbank_rows_sum_to_positive() {
+        let fb = mel_filterbank();
+        for (m, row) in fb.iter().enumerate() {
+            let sum: f32 = row.iter().sum();
+            assert!(sum > 0.0, "mel filter {m} should have positive sum, got {sum}");
+        }
+    }
+
+    #[test]
+    fn hz_to_mel_monotonic() {
+        // Higher frequency → higher mel value
+        assert!(hz_to_mel(1000.0) > hz_to_mel(500.0));
+        assert!(hz_to_mel(4000.0) > hz_to_mel(1000.0));
+    }
+
+    #[test]
+    fn mel_hz_roundtrip() {
+        for hz in [100.0, 500.0, 1000.0, 4000.0, 8000.0] {
+            let roundtrip = mel_to_hz(hz_to_mel(hz));
+            assert!(
+                (roundtrip - hz).abs() < 0.01,
+                "hz→mel→hz roundtrip failed for {hz}: got {roundtrip}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/diarization/fbank.rs
+++ b/src-tauri/src/diarization/fbank.rs
@@ -46,12 +46,12 @@ fn mel_filterbank() -> Vec<[f32; N_FREQS]> {
         let f_center = freq_bins[m + 1];
         let f_right = freq_bins[m + 2];
 
-        for k in 0..N_FREQS {
+        for (k, filter_val) in filters[m].iter_mut().enumerate() {
             let k_f = k as f32;
             if k_f >= f_left && k_f <= f_center && f_center > f_left {
-                filters[m][k] = (k_f - f_left) / (f_center - f_left);
+                *filter_val = (k_f - f_left) / (f_center - f_left);
             } else if k_f > f_center && k_f <= f_right && f_right > f_center {
-                filters[m][k] = (f_right - k_f) / (f_right - f_center);
+                *filter_val = (f_right - k_f) / (f_right - f_center);
             }
         }
     }
@@ -85,7 +85,7 @@ pub fn compute_fbank(audio: &[f32]) -> Vec<[f32; N_MELS]> {
 
     let mut features = vec![[0.0f32; N_MELS]; n_frames];
 
-    for frame_idx in 0..n_frames {
+    for (frame_idx, frame_features) in features.iter_mut().enumerate() {
         let start = frame_idx * HOP_LENGTH;
         let frame = &audio[start..start + N_FFT];
 
@@ -111,7 +111,7 @@ pub fn compute_fbank(audio: &[f32]) -> Vec<[f32; N_MELS]> {
                 .zip(power.iter())
                 .map(|(&f, &p)| f * p)
                 .sum();
-            features[frame_idx][m] = energy.max(1e-10).ln();
+            frame_features[m] = energy.max(1e-10).ln();
         }
     }
 

--- a/src-tauri/src/diarization/merge.rs
+++ b/src-tauri/src/diarization/merge.rs
@@ -1,0 +1,279 @@
+/// Merge diarization speaker segments with Whisper transcript segments.
+///
+/// Assigns a speaker label to each transcript segment based on time overlap
+/// with the diarization output.
+use crate::diarization::{DiarizedSegment, SpeakerSegment, TimestampedSegment};
+
+/// Assign speakers to transcript segments by maximum time overlap.
+///
+/// For each transcript segment, finds the speaker with the largest overlap
+/// among all `SpeakerSegment`s. If no overlap exists, assigns the nearest
+/// speaker by time gap.
+pub fn merge_with_transcript(
+    speakers: &[SpeakerSegment],
+    transcript: &[TimestampedSegment],
+) -> Vec<DiarizedSegment> {
+    transcript
+        .iter()
+        .map(|seg| {
+            let speaker = assign_speaker(speakers, seg.start, seg.end);
+            DiarizedSegment {
+                start: seg.start,
+                end: seg.end,
+                speaker,
+                text: seg.text.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Find the speaker label with maximum overlap for a time window `[start, end]`.
+/// Falls back to nearest speaker if no overlap exists.
+fn assign_speaker(speakers: &[SpeakerSegment], start: f64, end: f64) -> String {
+    if speakers.is_empty() {
+        return "SPEAKER_0".to_string();
+    }
+
+    // Accumulate overlap per speaker label
+    let mut best_speaker: Option<&str> = None;
+    let mut best_overlap = 0.0f64;
+
+    for seg in speakers {
+        let overlap_start = start.max(seg.start);
+        let overlap_end = end.min(seg.end);
+        let overlap = (overlap_end - overlap_start).max(0.0);
+
+        if overlap > best_overlap {
+            best_overlap = overlap;
+            best_speaker = Some(&seg.speaker);
+        }
+    }
+
+    if let Some(spk) = best_speaker {
+        return spk.to_string();
+    }
+
+    // No overlap — find nearest speaker by minimum gap
+    let nearest = speakers
+        .iter()
+        .min_by(|a, b| {
+            let gap_a = gap_to_segment(a, start, end);
+            let gap_b = gap_to_segment(b, start, end);
+            gap_a
+                .partial_cmp(&gap_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+    nearest
+        .map(|s| s.speaker.clone())
+        .unwrap_or_else(|| "SPEAKER_0".to_string())
+}
+
+/// Compute the time gap between a speaker segment and the query interval `[start, end]`.
+fn gap_to_segment(seg: &SpeakerSegment, start: f64, end: f64) -> f64 {
+    if seg.end < start {
+        start - seg.end
+    } else if seg.start > end {
+        seg.start - end
+    } else {
+        0.0 // overlapping
+    }
+}
+
+/// Merge consecutive `DiarizedSegment`s from the same speaker into one.
+///
+/// Adjacent segments with the same speaker label are merged; their texts
+/// are concatenated with a space separator.
+pub fn consolidate(segments: &[DiarizedSegment]) -> Vec<DiarizedSegment> {
+    let mut result: Vec<DiarizedSegment> = Vec::new();
+
+    for seg in segments {
+        if let Some(last) = result.last_mut() {
+            if last.speaker == seg.speaker {
+                last.end = seg.end;
+                if !seg.text.is_empty() {
+                    if !last.text.is_empty() {
+                        last.text.push(' ');
+                    }
+                    last.text.push_str(&seg.text);
+                }
+                continue;
+            }
+        }
+        result.push(seg.clone());
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spk(start: f64, end: f64, label: &str) -> SpeakerSegment {
+        SpeakerSegment {
+            start,
+            end,
+            speaker: label.to_string(),
+        }
+    }
+
+    fn seg(start: f64, end: f64, text: &str) -> TimestampedSegment {
+        TimestampedSegment {
+            start,
+            end,
+            text: text.to_string(),
+        }
+    }
+
+    fn dseg(start: f64, end: f64, speaker: &str, text: &str) -> DiarizedSegment {
+        DiarizedSegment {
+            start,
+            end,
+            speaker: speaker.to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    // -- merge_with_transcript --
+
+    #[test]
+    fn perfect_alignment() {
+        let speakers = vec![
+            spk(0.0, 2.0, "SPEAKER_0"),
+            spk(2.0, 4.0, "SPEAKER_1"),
+        ];
+        let transcript = vec![
+            seg(0.0, 2.0, "Hello"),
+            seg(2.0, 4.0, "World"),
+        ];
+        let result = merge_with_transcript(&speakers, &transcript);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].speaker, "SPEAKER_0");
+        assert_eq!(result[1].speaker, "SPEAKER_1");
+        assert_eq!(result[0].text, "Hello");
+        assert_eq!(result[1].text, "World");
+    }
+
+    #[test]
+    fn majority_overlap_wins() {
+        // Transcript segment [1.0, 3.0] overlaps SPEAKER_0 by 1s, SPEAKER_1 by 1s — tie, first wins
+        // But [0.5, 2.5]: overlaps SPEAKER_0 by 1.5s and SPEAKER_1 by 0.5s → SPEAKER_0 wins
+        let speakers = vec![
+            spk(0.0, 2.0, "SPEAKER_0"),
+            spk(2.0, 4.0, "SPEAKER_1"),
+        ];
+        let transcript = vec![seg(0.5, 2.5, "test")];
+        let result = merge_with_transcript(&speakers, &transcript);
+        assert_eq!(result[0].speaker, "SPEAKER_0", "SPEAKER_0 has more overlap");
+    }
+
+    #[test]
+    fn no_overlap_uses_nearest() {
+        // Transcript segment [5.0, 6.0], speakers end at 4.0
+        let speakers = vec![
+            spk(0.0, 2.0, "SPEAKER_0"),
+            spk(2.0, 4.0, "SPEAKER_1"),
+        ];
+        let transcript = vec![seg(5.0, 6.0, "later")];
+        let result = merge_with_transcript(&speakers, &transcript);
+        // Nearest is SPEAKER_1 (gap = 1.0 vs SPEAKER_0 gap = 3.0)
+        assert_eq!(result[0].speaker, "SPEAKER_1");
+    }
+
+    #[test]
+    fn empty_transcript_returns_empty() {
+        let speakers = vec![spk(0.0, 2.0, "SPEAKER_0")];
+        let result = merge_with_transcript(&speakers, &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn empty_speakers_defaults_to_speaker_zero() {
+        let transcript = vec![seg(0.0, 1.0, "test")];
+        let result = merge_with_transcript(&[], &transcript);
+        assert_eq!(result[0].speaker, "SPEAKER_0");
+    }
+
+    #[test]
+    fn timestamps_preserved() {
+        let speakers = vec![spk(0.0, 5.0, "SPEAKER_0")];
+        let transcript = vec![seg(1.5, 3.5, "text")];
+        let result = merge_with_transcript(&speakers, &transcript);
+        assert!((result[0].start - 1.5).abs() < 1e-9);
+        assert!((result[0].end - 3.5).abs() < 1e-9);
+    }
+
+    // -- consolidate --
+
+    #[test]
+    fn consolidate_merges_consecutive_same_speaker() {
+        let segments = vec![
+            dseg(0.0, 1.0, "SPEAKER_0", "Hello"),
+            dseg(1.0, 2.0, "SPEAKER_0", "world"),
+            dseg(2.0, 3.0, "SPEAKER_0", "foo"),
+        ];
+        let result = consolidate(&segments);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].speaker, "SPEAKER_0");
+        assert_eq!(result[0].text, "Hello world foo");
+        assert!((result[0].start - 0.0).abs() < 1e-9);
+        assert!((result[0].end - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn consolidate_keeps_different_speakers_separate() {
+        let segments = vec![
+            dseg(0.0, 1.0, "SPEAKER_0", "A"),
+            dseg(1.0, 2.0, "SPEAKER_1", "B"),
+            dseg(2.0, 3.0, "SPEAKER_0", "C"),
+        ];
+        let result = consolidate(&segments);
+        assert_eq!(result.len(), 3, "alternating speakers should not merge");
+    }
+
+    #[test]
+    fn consolidate_empty_returns_empty() {
+        assert!(consolidate(&[]).is_empty());
+    }
+
+    #[test]
+    fn consolidate_single_segment_unchanged() {
+        let segments = vec![dseg(0.0, 1.0, "SPEAKER_0", "text")];
+        let result = consolidate(&segments);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].text, "text");
+    }
+
+    #[test]
+    fn consolidate_handles_empty_text() {
+        let segments = vec![
+            dseg(0.0, 1.0, "SPEAKER_0", "Hello"),
+            dseg(1.0, 2.0, "SPEAKER_0", ""),
+            dseg(2.0, 3.0, "SPEAKER_0", "world"),
+        ];
+        let result = consolidate(&segments);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].text, "Hello world");
+    }
+
+    // -- gap_to_segment --
+
+    #[test]
+    fn gap_before_segment() {
+        let seg = spk(5.0, 8.0, "X");
+        assert!((gap_to_segment(&seg, 1.0, 3.0) - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn gap_after_segment() {
+        let seg = spk(1.0, 3.0, "X");
+        assert!((gap_to_segment(&seg, 5.0, 8.0) - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn gap_overlapping_is_zero() {
+        let seg = spk(0.0, 5.0, "X");
+        assert!((gap_to_segment(&seg, 2.0, 4.0)).abs() < 1e-9);
+    }
+}

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -1,5 +1,7 @@
+pub mod embedding;
 pub mod fbank;
 pub mod model;
+pub mod segmentation;
 
 use serde::Serialize;
 

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -1,5 +1,7 @@
+pub mod clustering;
 pub mod embedding;
 pub mod fbank;
+pub mod merge;
 pub mod model;
 pub mod segmentation;
 

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -7,6 +7,88 @@ pub mod segmentation;
 
 use serde::Serialize;
 
+use crate::error::DictationError;
+
+/// Configuration for the diarization pipeline.
+pub struct DiarizeConfig {
+    /// Cosine distance threshold for agglomerative clustering (0.0–2.0).
+    /// Lower = stricter (more speakers). Default 0.8.
+    pub threshold: f32,
+    /// Minimum segment duration in seconds to keep. Default 0.3s.
+    pub min_segment: f64,
+    /// Merge same-speaker segments closer than this gap (seconds). Default 0.5s.
+    pub min_gap: f64,
+}
+
+impl Default for DiarizeConfig {
+    fn default() -> Self {
+        Self {
+            threshold: clustering::DEFAULT_THRESHOLD,
+            min_segment: 0.3,
+            min_gap: 0.5,
+        }
+    }
+}
+
+/// Run the full diarization pipeline on 16kHz mono audio.
+///
+/// Returns speaker segments with labels "SPEAKER_0", "SPEAKER_1", ...
+/// Requires the `diarization` feature and both ONNX models to be downloaded.
+pub fn diarize(audio: &[f32], config: &DiarizeConfig) -> Result<Vec<SpeakerSegment>, DictationError> {
+    use crate::diarization::model::{DiarizationModel, model_path};
+
+    // Load models
+    let seg_path = model_path(DiarizationModel::PyannoteSegmentation3);
+    let emb_path = model_path(DiarizationModel::WeSpeakerResNet34LM);
+
+    let mut segmenter = segmentation::Segmenter::new(&seg_path)?;
+    let mut embedder = embedding::Embedder::new(&emb_path)?;
+
+    // 1. Segmentation: frame-level speaker activity
+    let frame_activations = segmenter.segment(audio)?;
+
+    // 2. Convert to (start, end, local_speaker_idx) tuples
+    let raw_segments = frame_activations.to_speaker_segments(config.min_segment, config.min_gap);
+
+    if raw_segments.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 3. Extract embeddings per segment
+    let embeddings = embedder.extract_embeddings(audio, &raw_segments)?;
+
+    // 4. Cluster embeddings → global speaker IDs
+    let speaker_map = if embeddings.is_empty() {
+        Vec::new()
+    } else {
+        clustering::cluster_speakers(&embeddings, config.threshold)
+    };
+
+    // Build local_speaker → global_speaker lookup
+    // (local speaker idx may appear multiple times with different global IDs due to
+    // different segments; take the modal assignment per local speaker)
+    let max_local = raw_segments.iter().map(|(_, _, s)| *s).max().unwrap_or(0) + 1;
+    let mut local_to_global = vec![0usize; max_local];
+    for (local_idx, global_id) in &speaker_map {
+        local_to_global[*local_idx] = *global_id;
+    }
+
+    // 5. Build SpeakerSegment output
+    let segments: Vec<SpeakerSegment> = raw_segments
+        .iter()
+        .map(|(start, end, local_idx)| {
+            let global_id = local_to_global[*local_idx];
+            SpeakerSegment {
+                start: *start,
+                end: *end,
+                speaker: format!("SPEAKER_{global_id}"),
+            }
+        })
+        .collect();
+
+    Ok(segments)
+}
+
 /// A single diarization segment: who spoke when.
 #[derive(Debug, Clone, Serialize)]
 pub struct SpeakerSegment {

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -1,0 +1,80 @@
+pub mod model;
+
+use serde::Serialize;
+
+/// A single diarization segment: who spoke when.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpeakerSegment {
+    /// Start time in seconds
+    pub start: f64,
+    /// End time in seconds
+    pub end: f64,
+    /// Speaker label (e.g. "SPEAKER_0")
+    pub speaker: String,
+}
+
+/// A Whisper transcript segment with timestamps.
+#[derive(Debug, Clone, Serialize)]
+pub struct TimestampedSegment {
+    /// Start time in seconds
+    pub start: f64,
+    /// End time in seconds
+    pub end: f64,
+    /// Transcribed text
+    pub text: String,
+}
+
+/// A transcript segment with speaker attribution (final output).
+#[derive(Debug, Clone, Serialize)]
+pub struct DiarizedSegment {
+    /// Start time in seconds
+    pub start: f64,
+    /// End time in seconds
+    pub end: f64,
+    /// Speaker label (e.g. "SPEAKER_0")
+    pub speaker: String,
+    /// Transcribed text
+    pub text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn speaker_segment_serializes() {
+        let seg = SpeakerSegment {
+            start: 0.0,
+            end: 2.5,
+            speaker: "SPEAKER_0".to_string(),
+        };
+        let json = serde_json::to_value(&seg).unwrap();
+        assert_eq!(json["speaker"], "SPEAKER_0");
+        assert_eq!(json["start"], 0.0);
+        assert_eq!(json["end"], 2.5);
+    }
+
+    #[test]
+    fn timestamped_segment_serializes() {
+        let seg = TimestampedSegment {
+            start: 1.0,
+            end: 3.0,
+            text: "hello world".to_string(),
+        };
+        let json = serde_json::to_value(&seg).unwrap();
+        assert_eq!(json["text"], "hello world");
+    }
+
+    #[test]
+    fn diarized_segment_serializes() {
+        let seg = DiarizedSegment {
+            start: 0.0,
+            end: 2.0,
+            speaker: "SPEAKER_1".to_string(),
+            text: "test".to_string(),
+        };
+        let json = serde_json::to_value(&seg).unwrap();
+        assert_eq!(json["speaker"], "SPEAKER_1");
+        assert_eq!(json["text"], "test");
+    }
+}

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -1,3 +1,4 @@
+pub mod fbank;
 pub mod model;
 
 use serde::Serialize;

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -23,7 +23,9 @@ pub struct DiarizeConfig {
 impl Default for DiarizeConfig {
     fn default() -> Self {
         Self {
-            threshold: clustering::DEFAULT_THRESHOLD,
+            // 0.5 is tighter than clustering::DEFAULT_THRESHOLD (0.8) — produces
+            // better speaker separation on typical meeting recordings.
+            threshold: 0.7,
             min_segment: 0.3,
             min_gap: 0.5,
         }
@@ -58,26 +60,27 @@ pub fn diarize(audio: &[f32], config: &DiarizeConfig) -> Result<Vec<SpeakerSegme
     let embeddings = embedder.extract_embeddings(audio, &raw_segments)?;
 
     // 4. Cluster embeddings → global speaker IDs
+    // speaker_map[i] = (segment_index, global_id) — segment_index keys into raw_segments
     let speaker_map = if embeddings.is_empty() {
         Vec::new()
     } else {
         clustering::cluster_speakers(&embeddings, config.threshold)
     };
+    let n_global = speaker_map.iter().map(|(_,g)| g).max().map(|&m| m+1).unwrap_or(0);
+    eprintln!("  Found {n_global} speaker(s)");
 
-    // Build local_speaker → global_speaker lookup
-    // (local speaker idx may appear multiple times with different global IDs due to
-    // different segments; take the modal assignment per local speaker)
-    let max_local = raw_segments.iter().map(|(_, _, s)| *s).max().unwrap_or(0) + 1;
-    let mut local_to_global = vec![0usize; max_local];
-    for (local_idx, global_id) in &speaker_map {
-        local_to_global[*local_idx] = *global_id;
+    // Build segment_index → global_id map (default 0 for segments with no embedding)
+    let mut seg_to_global = vec![0usize; raw_segments.len()];
+    for (seg_idx, global_id) in &speaker_map {
+        seg_to_global[*seg_idx] = *global_id;
     }
 
     // 5. Build SpeakerSegment output
     let segments: Vec<SpeakerSegment> = raw_segments
         .iter()
-        .map(|(start, end, local_idx)| {
-            let global_id = local_to_global[*local_idx];
+        .enumerate()
+        .map(|(i, (start, end, _local_idx))| {
+            let global_id = seg_to_global[i];
             SpeakerSegment {
                 start: *start,
                 end: *end,

--- a/src-tauri/src/diarization/model.rs
+++ b/src-tauri/src/diarization/model.rs
@@ -1,0 +1,263 @@
+use std::path::PathBuf;
+
+use tracing::info;
+
+use crate::error::DictationError;
+
+/// ONNX models used for speaker diarization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiarizationModel {
+    /// Pyannote segmentation 3.0 — speaker activity detection (~6 MB)
+    PyannoteSegmentation3,
+    /// WeSpeaker ResNet34-LM — speaker embedding extraction (~27 MB)
+    WeSpeakerResNet34LM,
+}
+
+impl DiarizationModel {
+    /// All diarization models (both are required for the pipeline).
+    pub const ALL: &[DiarizationModel] = &[
+        DiarizationModel::PyannoteSegmentation3,
+        DiarizationModel::WeSpeakerResNet34LM,
+    ];
+
+    /// ONNX filename stored on disk.
+    pub fn filename(&self) -> &'static str {
+        match self {
+            Self::PyannoteSegmentation3 => "pyannote-segmentation-3.0.onnx",
+            Self::WeSpeakerResNet34LM => "wespeaker-resnet34-lm.onnx",
+        }
+    }
+
+    /// HuggingFace download URL for the ONNX model.
+    pub fn download_url(&self) -> &'static str {
+        match self {
+            Self::PyannoteSegmentation3 => {
+                "https://huggingface.co/csukuangfj/sherpa-onnx-pyannote-segmentation-3-0/resolve/main/model.onnx"
+            }
+            Self::WeSpeakerResNet34LM => {
+                "https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM/resolve/main/voxceleb_resnet34_LM.onnx"
+            }
+        }
+    }
+
+    /// Approximate model size in MB.
+    pub fn size_mb(&self) -> u32 {
+        match self {
+            Self::PyannoteSegmentation3 => 6,
+            Self::WeSpeakerResNet34LM => 27,
+        }
+    }
+
+    /// Human-readable display name.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::PyannoteSegmentation3 => "Pyannote Segmentation 3.0",
+            Self::WeSpeakerResNet34LM => "WeSpeaker ResNet34-LM",
+        }
+    }
+
+    /// CLI model ID used in `download-model` and `list-models`.
+    pub fn model_id(&self) -> &'static str {
+        match self {
+            Self::PyannoteSegmentation3 => "pyannote-segmentation",
+            Self::WeSpeakerResNet34LM => "wespeaker-embedding",
+        }
+    }
+
+    /// Parse a CLI model ID string into a DiarizationModel.
+    pub fn from_id(id: &str) -> Option<Self> {
+        match id {
+            "pyannote-segmentation" => Some(Self::PyannoteSegmentation3),
+            "wespeaker-embedding" => Some(Self::WeSpeakerResNet34LM),
+            "diarization" => None, // special case handled by caller (downloads both)
+            _ => None,
+        }
+    }
+
+    /// Check if the given string is the special "diarization" meta-ID
+    /// that means "download all diarization models".
+    pub fn is_meta_id(id: &str) -> bool {
+        id == "diarization"
+    }
+}
+
+/// Get the full path to a diarization model's ONNX file.
+pub fn model_path(model: DiarizationModel) -> PathBuf {
+    crate::transcription::model::models_dir().join(model.filename())
+}
+
+/// Check if a diarization model is already downloaded.
+pub fn is_model_downloaded(model: DiarizationModel) -> bool {
+    model_path(model).exists()
+}
+
+/// Check if all diarization models are downloaded.
+pub fn all_models_downloaded() -> bool {
+    DiarizationModel::ALL.iter().all(|m| is_model_downloaded(*m))
+}
+
+/// Download a diarization model from HuggingFace.
+pub async fn download_model(
+    model: DiarizationModel,
+    progress_callback: impl Fn(u64, u64) + Send + 'static,
+) -> Result<PathBuf, DictationError> {
+    let path = model_path(model);
+
+    if path.exists() {
+        info!(
+            "Diarization model {} already exists at {}",
+            model.display_name(),
+            path.display()
+        );
+        return Ok(path);
+    }
+
+    // Ensure directory exists
+    let dir = crate::transcription::model::models_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
+    })?;
+
+    info!(
+        "Downloading {} from {} (~{}MB)",
+        model.display_name(),
+        model.download_url(),
+        model.size_mb()
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(model.download_url())
+        .send()
+        .await
+        .map_err(|e| DictationError::ModelDownloadFailed(format!("Download failed: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(DictationError::ModelDownloadFailed(format!(
+            "HTTP {}: {}",
+            response.status(),
+            model.download_url()
+        )));
+    }
+
+    let total_size = response.content_length().unwrap_or(0);
+    let mut downloaded: u64 = 0;
+
+    // Download to a temp file then rename (atomic)
+    let tmp_path = path.with_extension("onnx.tmp");
+    let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to create temp file: {e}"))
+    })?;
+
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|e| DictationError::ModelDownloadFailed(format!("Download error: {e}")))?;
+        file.write_all(&chunk).await.map_err(|e| {
+            DictationError::ModelDownloadFailed(format!("Write error: {e}"))
+        })?;
+        downloaded += chunk.len() as u64;
+        progress_callback(downloaded, total_size);
+    }
+
+    file.flush().await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Flush error: {e}"))
+    })?;
+    drop(file);
+
+    // Rename temp to final
+    tokio::fs::rename(&tmp_path, &path).await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to rename temp file: {e}"))
+    })?;
+
+    info!("Diarization model downloaded: {}", path.display());
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_models_have_unique_filenames() {
+        let mut filenames = std::collections::HashSet::new();
+        for m in DiarizationModel::ALL {
+            assert!(
+                filenames.insert(m.filename()),
+                "duplicate filename: {}",
+                m.filename()
+            );
+        }
+    }
+
+    #[test]
+    fn all_models_have_unique_ids() {
+        let mut ids = std::collections::HashSet::new();
+        for m in DiarizationModel::ALL {
+            assert!(ids.insert(m.model_id()), "duplicate ID: {}", m.model_id());
+        }
+    }
+
+    #[test]
+    fn model_id_roundtrip() {
+        for m in DiarizationModel::ALL {
+            let parsed = DiarizationModel::from_id(m.model_id());
+            assert_eq!(parsed, Some(*m), "roundtrip failed for {}", m.model_id());
+        }
+    }
+
+    #[test]
+    fn from_id_unknown_returns_none() {
+        assert_eq!(DiarizationModel::from_id("nonexistent"), None);
+    }
+
+    #[test]
+    fn meta_id_check() {
+        assert!(DiarizationModel::is_meta_id("diarization"));
+        assert!(!DiarizationModel::is_meta_id("pyannote-segmentation"));
+        assert!(!DiarizationModel::is_meta_id(""));
+    }
+
+    #[test]
+    fn filenames_end_with_onnx() {
+        for m in DiarizationModel::ALL {
+            assert!(
+                m.filename().ends_with(".onnx"),
+                "{} filename should end with .onnx",
+                m.display_name()
+            );
+        }
+    }
+
+    #[test]
+    fn download_urls_are_https() {
+        for m in DiarizationModel::ALL {
+            assert!(
+                m.download_url().starts_with("https://"),
+                "{} URL should be HTTPS",
+                m.display_name()
+            );
+        }
+    }
+
+    #[test]
+    fn size_mb_is_positive() {
+        for m in DiarizationModel::ALL {
+            assert!(m.size_mb() > 0, "{} size should be > 0", m.display_name());
+        }
+    }
+
+    #[test]
+    fn model_path_uses_models_dir() {
+        for m in DiarizationModel::ALL {
+            let path = model_path(*m);
+            assert!(
+                path.ends_with(m.filename()),
+                "path should end with filename"
+            );
+        }
+    }
+}

--- a/src-tauri/src/diarization/segmentation.rs
+++ b/src-tauri/src/diarization/segmentation.rs
@@ -1,0 +1,351 @@
+/// Speaker segmentation using the pyannote segmentation-3.0 ONNX model.
+///
+/// Input: 16kHz mono f32 audio
+/// Output: per-frame speaker activity for up to 3 simultaneous speakers
+use std::path::Path;
+
+use ndarray::Array3;
+use ort::{session::Session, value::Tensor};
+use tracing::info;
+
+use crate::error::DictationError;
+
+/// 10-second window at 16kHz
+pub const WINDOW_SAMPLES: usize = 160_000;
+/// 1-second shift (90% overlap between consecutive windows)
+pub const STEP_SAMPLES: usize = 16_000;
+/// Number of output frames per 10-second window
+pub const FRAMES_PER_WINDOW: usize = 589;
+/// receptive_field_shift = 270 samples → 16.875ms per frame
+pub const FRAME_DURATION_S: f64 = 270.0 / 16_000.0;
+/// Powerset encoding: 7 classes for up to 3 simultaneous speakers
+pub const NUM_CLASSES: usize = 7;
+/// Maximum simultaneous speakers supported by the model
+pub const MAX_SPEAKERS: usize = 3;
+
+/// Powerset mapping: class index → [speaker0_active, speaker1_active, speaker2_active]
+/// Class 0: silence, classes 1-3: single speakers, classes 4-6: speaker pairs
+const POWERSET: [[f32; MAX_SPEAKERS]; NUM_CLASSES] = [
+    [0.0, 0.0, 0.0], // 0: silence
+    [1.0, 0.0, 0.0], // 1: speaker 0
+    [0.0, 1.0, 0.0], // 2: speaker 1
+    [0.0, 0.0, 1.0], // 3: speaker 2
+    [1.0, 1.0, 0.0], // 4: speakers 0+1
+    [1.0, 0.0, 1.0], // 5: speakers 0+2
+    [0.0, 1.0, 1.0], // 6: speakers 1+2
+];
+
+/// Frame-level speaker activity across the full audio.
+pub struct FrameActivations {
+    /// Binary speaker activity: activity[frame][speaker] ∈ {0.0, 1.0}
+    pub activity: Vec<[f32; MAX_SPEAKERS]>,
+    /// Duration per frame in seconds
+    pub frame_duration: f64,
+}
+
+impl FrameActivations {
+    /// Convert frame-level activity to speaker time segments.
+    ///
+    /// Returns `(start_sec, end_sec, speaker_idx)` tuples, one per contiguous
+    /// active region per speaker. Regions shorter than `min_duration` are dropped.
+    /// Adjacent regions from the same speaker separated by less than `min_gap` are merged.
+    pub fn to_speaker_segments(
+        &self,
+        min_duration: f64,
+        min_gap: f64,
+    ) -> Vec<(f64, f64, usize)> {
+        let mut segments: Vec<(f64, f64, usize)> = Vec::new();
+
+        for spk in 0..MAX_SPEAKERS {
+            let mut raw: Vec<(f64, f64)> = Vec::new();
+            let mut start: Option<usize> = None;
+
+            for (f, frame) in self.activity.iter().enumerate() {
+                let active = frame[spk] >= 0.5;
+                match (start, active) {
+                    (None, true) => start = Some(f),
+                    (Some(s), false) => {
+                        raw.push((s as f64 * self.frame_duration, f as f64 * self.frame_duration));
+                        start = None;
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(s) = start {
+                let end = self.activity.len() as f64 * self.frame_duration;
+                raw.push((s as f64 * self.frame_duration, end));
+            }
+
+            // Merge segments closer than min_gap
+            let mut merged: Vec<(f64, f64)> = Vec::new();
+            for (seg_start, seg_end) in raw {
+                if let Some(last) = merged.last_mut() {
+                    if seg_start - last.1 < min_gap {
+                        last.1 = seg_end;
+                        continue;
+                    }
+                }
+                merged.push((seg_start, seg_end));
+            }
+
+            // Filter by minimum duration and emit
+            for (seg_start, seg_end) in merged {
+                if seg_end - seg_start >= min_duration {
+                    segments.push((seg_start, seg_end, spk));
+                }
+            }
+        }
+
+        // Sort by start time
+        segments.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        segments
+    }
+}
+
+/// Wraps the pyannote segmentation ONNX model for sliding-window inference.
+pub struct Segmenter {
+    session: Session,
+}
+
+impl Segmenter {
+    /// Load the segmentation model from disk.
+    pub fn new(model_path: &Path) -> Result<Self, DictationError> {
+        let session = Session::builder()
+            .map_err(|e| DictationError::DiarizationError(format!("Failed to create ORT session builder: {e}")))?
+            .commit_from_file(model_path)
+            .map_err(|e| DictationError::DiarizationError(format!("Failed to load segmentation model: {e}")))?;
+        info!("Segmentation model loaded from {}", model_path.display());
+        Ok(Self { session })
+    }
+
+    /// Run sliding-window segmentation on full audio.
+    ///
+    /// Returns `FrameActivations` covering the entire audio duration.
+    pub fn segment(&mut self, audio: &[f32]) -> Result<FrameActivations, DictationError> {
+        if audio.is_empty() {
+            return Ok(FrameActivations {
+                activity: Vec::new(),
+                frame_duration: FRAME_DURATION_S,
+            });
+        }
+
+        // Compute total frames across all windows after stitching
+        let n_windows = if audio.len() <= WINDOW_SAMPLES {
+            1
+        } else {
+            (audio.len() - WINDOW_SAMPLES) / STEP_SAMPLES + 2
+        };
+        let total_frames =
+            FRAMES_PER_WINDOW + (n_windows.saturating_sub(1)) * frames_per_step();
+
+        let mut accumulated = vec![[0.0f32; NUM_CLASSES]; total_frames];
+        let mut counts = vec![0u32; total_frames];
+
+        for win_idx in 0..n_windows {
+            let win_start = win_idx * STEP_SAMPLES;
+            if win_start >= audio.len() {
+                break;
+            }
+
+            // Build the 10s window, zero-padding if needed
+            let mut window = vec![0.0f32; WINDOW_SAMPLES];
+            let available = (audio.len() - win_start).min(WINDOW_SAMPLES);
+            window[..available].copy_from_slice(&audio[win_start..win_start + available]);
+
+            // Run ONNX inference
+            let input = Array3::from_shape_vec((1, 1, WINDOW_SAMPLES), window)
+                .map_err(|e| DictationError::DiarizationError(format!("Shape error: {e}")))?;
+            let tensor = Tensor::from_array(input)
+                .map_err(|e| DictationError::DiarizationError(format!("Tensor error: {e}")))?;
+            let outputs = self
+                .session
+                .run(ort::inputs![tensor])
+                .map_err(|e| DictationError::DiarizationError(format!("Inference failed: {e}")))?;
+
+            // Extract [1, 589, 7] output
+            let logits = outputs[0]
+                .try_extract_array::<f32>()
+                .map_err(|e| DictationError::DiarizationError(format!("Output extraction failed: {e}")))?;
+
+            let logits = logits.view();
+
+            // Accumulate frame probabilities in overlap region
+            let frame_offset = win_idx * frames_per_step();
+            for f in 0..FRAMES_PER_WINDOW {
+                let global_f = frame_offset + f;
+                if global_f >= total_frames {
+                    break;
+                }
+                for c in 0..NUM_CLASSES {
+                    accumulated[global_f][c] += logits[[0, f, c]];
+                }
+                counts[global_f] += 1;
+            }
+        }
+
+        // Average overlapping frames, then argmax → powerset decode
+        let activity: Vec<[f32; MAX_SPEAKERS]> = accumulated
+            .iter()
+            .zip(counts.iter())
+            .map(|(frame_logits, &count)| {
+                let n = count.max(1) as f32;
+                let averaged: Vec<f32> = frame_logits.iter().map(|&v| v / n).collect();
+
+                // Argmax across 7 classes
+                let class = averaged
+                    .iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+
+                POWERSET[class]
+            })
+            .collect();
+
+        Ok(FrameActivations {
+            activity,
+            frame_duration: FRAME_DURATION_S,
+        })
+    }
+}
+
+/// How many frames correspond to one STEP_SAMPLES shift.
+fn frames_per_step() -> usize {
+    // STEP_SAMPLES / receptive_field_shift = 16000 / 270 ≈ 59
+    (STEP_SAMPLES as f64 / (FRAME_DURATION_S * 16_000.0)).round() as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn powerset_has_correct_shape() {
+        assert_eq!(POWERSET.len(), NUM_CLASSES);
+        for row in &POWERSET {
+            assert_eq!(row.len(), MAX_SPEAKERS);
+        }
+    }
+
+    #[test]
+    fn powerset_silence_is_all_zeros() {
+        assert_eq!(POWERSET[0], [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn powerset_single_speakers_exclusive() {
+        // Classes 1-3 each activate exactly one speaker
+        for c in 1..=3 {
+            let sum: f32 = POWERSET[c].iter().sum();
+            assert_eq!(sum, 1.0, "class {c} should activate exactly 1 speaker");
+        }
+    }
+
+    #[test]
+    fn powerset_pairs_activate_two() {
+        // Classes 4-6 each activate exactly two speakers
+        for c in 4..=6 {
+            let sum: f32 = POWERSET[c].iter().sum();
+            assert_eq!(sum, 2.0, "class {c} should activate exactly 2 speakers");
+        }
+    }
+
+    #[test]
+    fn frame_activations_to_segments_basic() {
+        // Speaker 0 active for frames 0-9, silent after
+        let mut activity = vec![[0.0f32; MAX_SPEAKERS]; 20];
+        for f in 0..10 {
+            activity[f][0] = 1.0;
+        }
+        let fa = FrameActivations {
+            activity,
+            frame_duration: FRAME_DURATION_S,
+        };
+        let segs = fa.to_speaker_segments(0.1, 0.5);
+        assert_eq!(segs.len(), 1, "should find exactly 1 segment");
+        assert_eq!(segs[0].2, 0, "should be speaker 0");
+        assert!(segs[0].0 < 0.01, "start should be ~0s");
+        assert!(
+            (segs[0].1 - 10.0 * FRAME_DURATION_S).abs() < 0.01,
+            "end should be ~10 frames"
+        );
+    }
+
+    #[test]
+    fn frame_activations_min_duration_filter() {
+        // 2 frames of activity — at 16.875ms each that's ~33ms, below 0.3s min
+        let mut activity = vec![[0.0f32; MAX_SPEAKERS]; 20];
+        activity[0][0] = 1.0;
+        activity[1][0] = 1.0;
+        let fa = FrameActivations {
+            activity,
+            frame_duration: FRAME_DURATION_S,
+        };
+        let segs = fa.to_speaker_segments(0.3, 0.5);
+        assert!(segs.is_empty(), "short segment should be filtered out");
+    }
+
+    #[test]
+    fn frame_activations_gap_merging() {
+        // Two short bursts close together should merge
+        let mut activity = vec![[0.0f32; MAX_SPEAKERS]; 100];
+        // Burst 1: frames 0-17 (~0.3s)
+        for f in 0..18 {
+            activity[f][0] = 1.0;
+        }
+        // Gap: frames 18-24 (~7 frames, ~0.12s < 0.5s min_gap)
+        // Burst 2: frames 25-42 (~0.3s)
+        for f in 25..43 {
+            activity[f][0] = 1.0;
+        }
+        let fa = FrameActivations {
+            activity,
+            frame_duration: FRAME_DURATION_S,
+        };
+        let segs = fa.to_speaker_segments(0.2, 0.5);
+        // Should merge into 1 segment since gap < 0.5s
+        assert_eq!(segs.len(), 1, "close segments should merge: got {:?}", segs);
+    }
+
+    #[test]
+    fn frame_activations_two_speakers() {
+        let mut activity = vec![[0.0f32; MAX_SPEAKERS]; 60];
+        // Speaker 0: frames 0-29
+        for f in 0..30 {
+            activity[f][0] = 1.0;
+        }
+        // Speaker 1: frames 30-59
+        for f in 30..60 {
+            activity[f][1] = 1.0;
+        }
+        let fa = FrameActivations {
+            activity,
+            frame_duration: FRAME_DURATION_S,
+        };
+        let segs = fa.to_speaker_segments(0.1, 0.5);
+        assert_eq!(segs.len(), 2, "should find 2 segments");
+        // Check they're different speakers
+        let speakers: Vec<usize> = segs.iter().map(|s| s.2).collect();
+        assert!(speakers.contains(&0));
+        assert!(speakers.contains(&1));
+    }
+
+    #[test]
+    fn empty_audio_returns_empty_activations() {
+        // FrameActivations with empty activity
+        let fa = FrameActivations {
+            activity: Vec::new(),
+            frame_duration: FRAME_DURATION_S,
+        };
+        let segs = fa.to_speaker_segments(0.3, 0.5);
+        assert!(segs.is_empty());
+    }
+
+    #[test]
+    fn frames_per_step_is_reasonable() {
+        let fps = frames_per_step();
+        // Should be roughly 16000/270 ≈ 59
+        assert!(fps >= 55 && fps <= 65, "frames_per_step should be ~59, got {fps}");
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -40,6 +40,10 @@ pub enum DictationError {
 
     #[error("Unsupported format: {0}")]
     UnsupportedFormat(String),
+
+    #[cfg(feature = "diarization")]
+    #[error("Diarization error: {0}")]
+    DiarizationError(String),
 }
 
 // Tauri commands need IntoResponse which requires Serialize

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,8 @@ mod app_controller;
 mod audio;
 mod cli;
 mod commands;
+#[cfg(feature = "diarization")]
+pub mod diarization;
 mod error;
 mod events;
 mod hotkey;

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -150,6 +150,27 @@ impl WhisperModel {
     /// silence at moderate thresholds, causing large content deletions. Tiny
     /// models are prone to repetition loops at the default 0.6. Larger and
     /// language-optimised models are robust to any reasonable threshold.
+    /// DTW model preset for accurate attention-based token timestamps.
+    /// KB-Whisper and NB-Whisper are fine-tunes of the corresponding base architecture,
+    /// so they use the same alignment heads.
+    #[cfg(feature = "diarization")]
+    pub fn dtw_preset(&self) -> whisper_rs::DtwModelPreset {
+        use whisper_rs::DtwModelPreset;
+        match self {
+            WhisperModel::TinyEn => DtwModelPreset::TinyEn,
+            WhisperModel::Tiny | WhisperModel::KbWhisperTiny | WhisperModel::NbWhisperTiny => DtwModelPreset::Tiny,
+            WhisperModel::BaseEn => DtwModelPreset::BaseEn,
+            WhisperModel::Base | WhisperModel::KbWhisperBase | WhisperModel::NbWhisperBase => DtwModelPreset::Base,
+            WhisperModel::SmallEn => DtwModelPreset::SmallEn,
+            WhisperModel::Small | WhisperModel::KbWhisperSmall | WhisperModel::NbWhisperSmall => DtwModelPreset::Small,
+            WhisperModel::MediumEn => DtwModelPreset::MediumEn,
+            WhisperModel::Medium | WhisperModel::KbWhisperMedium | WhisperModel::NbWhisperMedium => DtwModelPreset::Medium,
+            WhisperModel::LargeV3Turbo => DtwModelPreset::LargeV3Turbo,
+            // KbWhisperLarge / NbWhisperLarge are large-v3 fine-tunes
+            WhisperModel::KbWhisperLarge | WhisperModel::NbWhisperLarge => DtwModelPreset::LargeV3,
+        }
+    }
+
     pub fn no_speech_threshold(&self) -> f32 {
         match self {
             // small.en drops content even at 0.3 — needs fully disabled filter

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -134,6 +134,18 @@ impl WhisperBackend {
         language: Language,
         on_progress: impl FnMut(i32) + 'static,
     ) -> Result<String, DictationError> {
+        self.transcribe_sync_with_progress_and_prompt(audio, language, None, on_progress)
+    }
+
+    /// Like `transcribe_sync_with_progress` but accepts an optional initial prompt
+    /// to prime the decoder with domain-specific vocabulary and context.
+    pub fn transcribe_sync_with_progress_and_prompt(
+        &self,
+        audio: &[f32],
+        language: Language,
+        prompt: Option<&str>,
+        on_progress: impl FnMut(i32) + 'static,
+    ) -> Result<String, DictationError> {
         if audio.is_empty() {
             return Err(DictationError::NoAudioCaptured);
         }
@@ -161,6 +173,9 @@ impl WhisperBackend {
         params.set_print_realtime(false);
         params.set_no_speech_thold(no_speech_thold);
         params.set_suppress_blank(true);
+        if let Some(p) = prompt {
+            params.set_initial_prompt(p);
+        }
         params.set_progress_callback_safe(on_progress);
 
         // Abort callback: DISABLED — whisper-rs 0.15.1 set_abort_callback_safe()
@@ -215,45 +230,15 @@ impl WhisperBackend {
         &self,
         audio: &[f32],
         language: Language,
+        prompt: Option<&str>,
     ) -> Result<Vec<(f64, f64, String)>, DictationError> {
         if audio.is_empty() {
             return Err(DictationError::NoAudioCaptured);
         }
-
-        // 30s windows with 2s overlap — whisper.cpp is reliable up to ~30s per call
-        const CHUNK: usize = 30 * 16_000;
-        const OVERLAP: usize = 2 * 16_000;
-        const STEP: usize = CHUNK - OVERLAP;
-
-        if audio.len() <= CHUNK {
-            return self.transcribe_chunk_timestamps(audio, language, 0.0);
-        }
-
-        let mut results: Vec<(f64, f64, String)> = Vec::new();
-        let mut chunk_start = 0usize;
-        let mut is_first = true;
-
-        while chunk_start < audio.len() {
-            let chunk_end = (chunk_start + CHUNK).min(audio.len());
-            let chunk = &audio[chunk_start..chunk_end];
-            let t_offset = chunk_start as f64 / 16_000.0;
-            // Discard segments from the overlap zone (already covered by previous chunk)
-            let cutoff = if is_first { 0.0 } else { t_offset + OVERLAP as f64 / 16_000.0 };
-
-            for seg in self.transcribe_chunk_timestamps(chunk, language, t_offset)? {
-                if seg.0 >= cutoff {
-                    results.push(seg);
-                }
-            }
-
-            is_first = false;
-            if chunk_end >= audio.len() {
-                break;
-            }
-            chunk_start += STEP;
-        }
-
-        Ok(results)
+        // Process full audio in one call — whisper.cpp handles long audio internally
+        // via its own sliding window. With no_timestamps=true + DTW there is no
+        // looping risk, and the internal context is better than manual chunking.
+        self.transcribe_chunk_timestamps(audio, language, 0.0, prompt)
     }
 
     /// Transcribe a single audio chunk (≤30s) with timestamps via DTW.
@@ -268,6 +253,7 @@ impl WhisperBackend {
         audio: &[f32],
         language: Language,
         t_offset: f64,
+        prompt: Option<&str>,
     ) -> Result<Vec<(f64, f64, String)>, DictationError> {
         let ctx_guard = self.context.lock().unwrap();
         let ctx = ctx_guard
@@ -293,6 +279,9 @@ impl WhisperBackend {
         params.set_print_realtime(false);
         params.set_no_speech_thold(no_speech_thold);
         params.set_suppress_blank(true);
+        if let Some(p) = prompt {
+            params.set_initial_prompt(p);
+        }
 
         let mut state = ctx.create_state().map_err(|e| {
             DictationError::TranscriptionFailed(format!("Failed to create whisper state: {e}"))

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -194,8 +194,8 @@ impl WhisperBackend {
 
     /// Transcribe audio and return per-segment timestamps.
     ///
-    /// Returns `Vec<(start_secs, end_secs, text)>`. Timestamps come from
-    /// whisper.cpp in centiseconds; we convert to seconds here.
+    /// For audio longer than 30s, uses overlapping 30s windows to prevent
+    /// the Whisper decoder from drifting or looping on long recordings.
     #[cfg(feature = "diarization")]
     pub fn transcribe_sync_with_timestamps(
         &self,
@@ -206,6 +206,51 @@ impl WhisperBackend {
             return Err(DictationError::NoAudioCaptured);
         }
 
+        // 30s windows with 2s overlap — whisper.cpp is reliable up to ~30s per call
+        const CHUNK: usize = 30 * 16_000;
+        const OVERLAP: usize = 2 * 16_000;
+        const STEP: usize = CHUNK - OVERLAP;
+
+        if audio.len() <= CHUNK {
+            return self.transcribe_chunk_timestamps(audio, language, 0.0);
+        }
+
+        let mut results: Vec<(f64, f64, String)> = Vec::new();
+        let mut chunk_start = 0usize;
+        let mut is_first = true;
+
+        while chunk_start < audio.len() {
+            let chunk_end = (chunk_start + CHUNK).min(audio.len());
+            let chunk = &audio[chunk_start..chunk_end];
+            let t_offset = chunk_start as f64 / 16_000.0;
+            // Discard segments from the overlap zone (already covered by previous chunk)
+            let cutoff = if is_first { 0.0 } else { t_offset + OVERLAP as f64 / 16_000.0 };
+
+            for seg in self.transcribe_chunk_timestamps(chunk, language, t_offset)? {
+                if seg.0 >= cutoff {
+                    results.push(seg);
+                }
+            }
+
+            is_first = false;
+            if chunk_end >= audio.len() {
+                break;
+            }
+            chunk_start += STEP;
+        }
+
+        Ok(results)
+    }
+
+    /// Transcribe a single audio chunk (≤30s) with timestamps.
+    /// `t_offset` is added to all returned timestamps.
+    #[cfg(feature = "diarization")]
+    fn transcribe_chunk_timestamps(
+        &self,
+        audio: &[f32],
+        language: Language,
+        t_offset: f64,
+    ) -> Result<Vec<(f64, f64, String)>, DictationError> {
         let ctx_guard = self.context.lock().unwrap();
         let ctx = ctx_guard
             .as_ref()
@@ -230,8 +275,6 @@ impl WhisperBackend {
         params.set_no_speech_thold(no_speech_thold);
         params.set_suppress_blank(true);
 
-        self.abort_flag.store(false, Ordering::SeqCst);
-
         let mut state = ctx.create_state().map_err(|e| {
             DictationError::TranscriptionFailed(format!("Failed to create whisper state: {e}"))
         })?;
@@ -245,13 +288,48 @@ impl WhisperBackend {
 
         for i in 0..n_segments {
             if let Some(segment) = state.get_segment(i) {
-                let t0 = segment.start_timestamp() as f64 / 100.0;
-                let t1 = segment.end_timestamp() as f64 / 100.0;
-                let text = segment.to_str().unwrap_or("").to_string();
-                results.push((t0, t1, text));
+                let t0 = segment.start_timestamp() as f64 / 100.0 + t_offset;
+                let t1 = segment.end_timestamp() as f64 / 100.0 + t_offset;
+                let raw = segment.to_str().unwrap_or("");
+                let text = strip_special_tokens(raw);
+                if !text.trim().is_empty() {
+                    results.push((t0, t1, text));
+                }
             }
         }
 
         Ok(results)
     }
+}
+
+/// Remove Whisper special tokens of the form `<|...|>` from segment text.
+/// These appear in timestamps-enabled mode and include nospeech, language, and timing tokens.
+#[cfg(feature = "diarization")]
+fn strip_special_tokens(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '<' && chars.peek() == Some(&'|') {
+            // Consume until `|>` or end
+            let mut found_close = false;
+            let mut buf = String::from("<");
+            buf.push('|');
+            chars.next(); // consume '|'
+            for inner in chars.by_ref() {
+                buf.push(inner);
+                if inner == '>' && buf.ends_with("|>") {
+                    found_close = true;
+                    break;
+                }
+            }
+            if !found_close {
+                // Not a valid special token — emit what we collected
+                out.push_str(&buf);
+            }
+            // else: drop the token
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -67,19 +67,20 @@ impl WhisperBackend {
             model_path.display()
         );
 
-        let mut ctx_params = WhisperContextParameters::default();
-
         // Enable DTW for attention-based token timestamps (used by --diarize).
         // DTW is incompatible with flash_attn; flash_attn defaults to false so this is safe.
-        #[cfg(feature = "diarization")]
-        {
-            ctx_params.dtw_parameters(DtwParameters {
+        let ctx_params = {
+            #[allow(unused_mut)]
+            let mut p = WhisperContextParameters::default();
+            #[cfg(feature = "diarization")]
+            p.dtw_parameters(DtwParameters {
                 mode: DtwMode::ModelPreset {
                     model_preset: whisper_model.dtw_preset(),
                 },
                 ..DtwParameters::default()
             });
-        }
+            p
+        };
 
         let ctx = WhisperContext::new_with_params(
             model_path.to_str().ok_or_else(|| {

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -191,4 +191,67 @@ impl WhisperBackend {
         info!("Local transcription complete: {} chars", result.len());
         Ok(result)
     }
+
+    /// Transcribe audio and return per-segment timestamps.
+    ///
+    /// Returns `Vec<(start_secs, end_secs, text)>`. Timestamps come from
+    /// whisper.cpp in centiseconds; we convert to seconds here.
+    #[cfg(feature = "diarization")]
+    pub fn transcribe_sync_with_timestamps(
+        &self,
+        audio: &[f32],
+        language: Language,
+    ) -> Result<Vec<(f64, f64, String)>, DictationError> {
+        if audio.is_empty() {
+            return Err(DictationError::NoAudioCaptured);
+        }
+
+        let ctx_guard = self.context.lock().unwrap();
+        let ctx = ctx_guard
+            .as_ref()
+            .ok_or(DictationError::ModelNotLoaded)?;
+
+        let model = self
+            .loaded_model()
+            .ok_or(DictationError::ModelNotLoaded)?;
+
+        let n_threads = (num_cpus::get() / 2).max(1) as i32;
+        let no_speech_thold = model.no_speech_threshold();
+
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        params.set_language(language.whisper_code());
+        params.set_n_threads(n_threads);
+        params.set_temperature(0.0);
+        params.set_temperature_inc(0.2);
+        params.set_translate(false);
+        params.set_no_timestamps(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_no_speech_thold(no_speech_thold);
+        params.set_suppress_blank(true);
+
+        self.abort_flag.store(false, Ordering::SeqCst);
+
+        let mut state = ctx.create_state().map_err(|e| {
+            DictationError::TranscriptionFailed(format!("Failed to create whisper state: {e}"))
+        })?;
+
+        state.full(params, audio).map_err(|e| {
+            DictationError::TranscriptionFailed(format!("Whisper inference failed: {e}"))
+        })?;
+
+        let n_segments = state.full_n_segments();
+        let mut results = Vec::with_capacity(n_segments as usize);
+
+        for i in 0..n_segments {
+            if let Some(segment) = state.get_segment(i) {
+                let t0 = segment.start_timestamp() as f64 / 100.0;
+                let t1 = segment.end_timestamp() as f64 / 100.0;
+                let text = segment.to_str().unwrap_or("").to_string();
+                results.push((t0, t1, text));
+            }
+        }
+
+        Ok(results)
+    }
 }

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, Mutex};
 
 use tracing::{info, warn};
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+#[cfg(feature = "diarization")]
+use whisper_rs::{DtwMode, DtwParameters};
 
 use crate::error::DictationError;
 use crate::settings::{Language, WhisperModel};
@@ -65,7 +67,19 @@ impl WhisperBackend {
             model_path.display()
         );
 
-        let ctx_params = WhisperContextParameters::default();
+        let mut ctx_params = WhisperContextParameters::default();
+
+        // Enable DTW for attention-based token timestamps (used by --diarize).
+        // DTW is incompatible with flash_attn; flash_attn defaults to false so this is safe.
+        #[cfg(feature = "diarization")]
+        {
+            ctx_params.dtw_parameters(DtwParameters {
+                mode: DtwMode::ModelPreset {
+                    model_preset: whisper_model.dtw_preset(),
+                },
+                ..DtwParameters::default()
+            });
+        }
 
         let ctx = WhisperContext::new_with_params(
             model_path.to_str().ok_or_else(|| {
@@ -242,8 +256,12 @@ impl WhisperBackend {
         Ok(results)
     }
 
-    /// Transcribe a single audio chunk (≤30s) with timestamps.
-    /// `t_offset` is added to all returned timestamps.
+    /// Transcribe a single audio chunk (≤30s) with timestamps via DTW.
+    ///
+    /// Uses `set_no_timestamps(true)` for clean text generation, then derives
+    /// per-segment timing from `token.t_dtw` (cross-attention DTW alignment)
+    /// rather than the generative `<|t.xx|>` tokens that degrade quality.
+    /// `t_offset` (seconds) is added to all returned timestamps.
     #[cfg(feature = "diarization")]
     fn transcribe_chunk_timestamps(
         &self,
@@ -269,7 +287,8 @@ impl WhisperBackend {
         params.set_temperature(0.0);
         params.set_temperature_inc(0.2);
         params.set_translate(false);
-        params.set_no_timestamps(false);
+        params.set_no_timestamps(true);   // clean text — no generative timestamp tokens
+        params.set_token_timestamps(true); // populate token.t0/t1/t_dtw via cross-attention
         params.set_print_progress(false);
         params.set_print_realtime(false);
         params.set_no_speech_thold(no_speech_thold);
@@ -287,49 +306,58 @@ impl WhisperBackend {
         let mut results = Vec::with_capacity(n_segments as usize);
 
         for i in 0..n_segments {
-            if let Some(segment) = state.get_segment(i) {
+            let Some(segment) = state.get_segment(i) else { continue };
+
+            let text = segment.to_str().unwrap_or("").trim().to_string();
+            if text.is_empty() {
+                continue;
+            }
+
+            // Derive segment timing from DTW timestamps on first/last non-special token.
+            // DTW timestamps are in centiseconds; -1 means not computed.
+            // Fall back to segment-level timestamps if DTW was not available.
+            let (t0, t1) = dtw_segment_timestamps(&segment, t_offset).unwrap_or_else(|| {
                 let t0 = segment.start_timestamp() as f64 / 100.0 + t_offset;
                 let t1 = segment.end_timestamp() as f64 / 100.0 + t_offset;
-                let raw = segment.to_str().unwrap_or("");
-                let text = strip_special_tokens(raw);
-                if !text.trim().is_empty() {
-                    results.push((t0, t1, text));
-                }
-            }
+                (t0, t1)
+            });
+
+            results.push((t0, t1, text));
         }
 
         Ok(results)
     }
 }
 
-/// Remove Whisper special tokens of the form `<|...|>` from segment text.
-/// These appear in timestamps-enabled mode and include nospeech, language, and timing tokens.
+/// Extract segment timing from per-token DTW timestamps.
+///
+/// Returns `(start_secs, end_secs)` using the DTW timestamps of the first and last
+/// content tokens (skipping special tokens which have t_dtw = -1).
+/// Returns `None` if no token has a valid DTW timestamp.
 #[cfg(feature = "diarization")]
-fn strip_special_tokens(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut chars = text.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '<' && chars.peek() == Some(&'|') {
-            // Consume until `|>` or end
-            let mut found_close = false;
-            let mut buf = String::from("<");
-            buf.push('|');
-            chars.next(); // consume '|'
-            for inner in chars.by_ref() {
-                buf.push(inner);
-                if inner == '>' && buf.ends_with("|>") {
-                    found_close = true;
-                    break;
-                }
+fn dtw_segment_timestamps(
+    segment: &whisper_rs::WhisperSegment<'_>,
+    t_offset: f64,
+) -> Option<(f64, f64)> {
+    let n = segment.n_tokens();
+    let mut t0 = None::<f64>;
+    let mut t1 = None::<f64>;
+
+    for j in 0..n {
+        let Some(token) = segment.get_token(j) else { continue };
+        let td = token.token_data();
+        if td.t_dtw >= 0 {
+            let t = td.t_dtw as f64 / 100.0 + t_offset;
+            if t0.is_none() {
+                t0 = Some(t);
             }
-            if !found_close {
-                // Not a valid special token — emit what we collected
-                out.push_str(&buf);
-            }
-            // else: drop the token
-        } else {
-            out.push(ch);
+            t1 = Some(t);
         }
     }
-    out
+
+    match (t0, t1) {
+        (Some(a), Some(b)) => Some((a, b)),
+        _ => None,
+    }
 }
+


### PR DESCRIPTION
## Summary

Adds a fully local, privacy-preserving speaker diarization pipeline behind the `diarization` cargo feature flag. When built with `--features diarization`, the CLI gains a `--diarize` flag on the `transcribe` subcommand.

**Models required (two ONNX files, ~33 MB total):**
- pyannote/segmentation-3.0 (~6 MB) — frame-level speaker activity
- WeSpeaker ResNet34-LM (~27 MB) — 256-dim speaker embeddings

Download with: `sagascript download-model diarization`

**Pipeline (all local, no network calls at inference time):**
1. **Segmentation** (`diarization/segmentation.rs`) — pyannote ONNX, 10s sliding windows with 1s shift, powerset-encoded → binary speaker activity per frame
2. **Fbank extraction** (`diarization/fbank.rs`) — 80-dim log-mel filterbank (25ms window, 10ms hop, global mean subtraction) matching WeSpeaker training config
3. **Embedding** (`diarization/embedding.rs`) — WeSpeaker ONNX, L2-normalized 256-dim per segment
4. **Clustering** (`diarization/clustering.rs`) — agglomerative hierarchical clustering (complete linkage, cosine distance, kodama crate), Union-Find cutree
5. **Merge** (`diarization/merge.rs`) — assign speaker labels to Whisper transcript segments by max time overlap, consolidate consecutive same-speaker turns
6. **Orchestrator** (`diarization/mod.rs`) — `diarize()` function + `DiarizeConfig`
7. **CLI** (`cli/transcribe.rs`) — `--diarize` flag; plain text outputs `[SPEAKER_0] text`, JSON includes `segments` + `speakers` arrays

**Plain text output:**
```
[SPEAKER_0] Hello, welcome to the meeting.
[SPEAKER_1] Thanks. I have three items to discuss.
```

**JSON output** (`--diarize --json`):
```json
{
  "segments": [...],
  "speakers": ["SPEAKER_0", "SPEAKER_1"],
  "language": "en",
  "model": "base.en",
  "file": "recording.wav",
  "duration_seconds": 42.3
}
```

## Test plan

- [ ] `cargo test --features diarization` — 237 tests pass
- [ ] `cargo clippy --features diarization -- -D warnings` — clean
- [ ] `cargo check` (without feature) — clean, no dead-code warnings
- [ ] Download models: `sagascript download-model diarization`
- [ ] End-to-end: `sagascript transcribe --diarize "/path/to/multi-speaker.wav"`
- [ ] JSON output: `sagascript transcribe --diarize --json "/path/to/multi-speaker.wav"`
- [ ] Error path: run `--diarize` without models downloaded → helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)