### PR TITLE
fix(diarization): raise default clustering threshold to 0.85, add --diarize-threshold flag

### DIFF
--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -36,6 +36,12 @@ pub struct TranscribeArgs {
     #[arg(long)]
     pub diarize: bool,
 
+    /// Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.
+    #[cfg(feature = "diarization")]
+    #[arg(long, value_name = "THRESHOLD", default_value = "0.85",
+          help = "Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.")]
+    pub diarize_threshold: f32,
+
     /// Initial prompt to prime the decoder with domain-specific vocabulary.
     /// Reduces hallucination on technical terms, proper nouns, and jargon.
     /// Example: --prompt "Grimnir, MCP, Fortnox, bokföring, kontering, saldo"
@@ -99,7 +105,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         // Run diarization and timestamped transcription in parallel isn't possible
         // with a single-threaded whisper context, so we run sequentially.
         eprintln!("Running speaker diarization...");
-        let speaker_segments = diarize(&audio, &DiarizeConfig::default())?;
+        let speaker_segments = diarize(&audio, &DiarizeConfig {
+            threshold: args.diarize_threshold,
+            ..DiarizeConfig::default()
+        })?;
         eprintln!("Found {} speaker segment(s)", speaker_segments.len());
 
         eprintln!("Transcribing with timestamps...");

--- a/src-tauri/src/diarization/clustering.rs
+++ b/src-tauri/src/diarization/clustering.rs
@@ -42,6 +42,20 @@ pub fn cluster_speakers(
         }
     }
 
+    if !condensed.is_empty() {
+        let mut sorted = condensed.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let n_dist = sorted.len();
+        tracing::debug!(
+            "Embedding distances: n={}, p25={:.3}, p50={:.3}, p75={:.3}, p90={:.3}",
+            n_dist,
+            sorted[n_dist * 25 / 100],
+            sorted[n_dist * 50 / 100],
+            sorted[n_dist * 75 / 100],
+            sorted[(n_dist * 90 / 100).min(n_dist - 1)],
+        );
+    }
+
     let dendrogram = linkage(&mut condensed, n, Method::Average);
     let raw_labels = cutree(&dendrogram, n, threshold);
 

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -12,7 +12,7 @@ use crate::error::DictationError;
 /// Configuration for the diarization pipeline.
 pub struct DiarizeConfig {
     /// Cosine distance threshold for agglomerative clustering (0.0–2.0).
-    /// Lower = stricter (more speakers). Default 0.8.
+    /// Lower = stricter (more speakers). Default 0.85.
     pub threshold: f32,
     /// Minimum segment duration in seconds to keep. Default 0.3s.
     pub min_segment: f64,
@@ -23,9 +23,9 @@ pub struct DiarizeConfig {
 impl Default for DiarizeConfig {
     fn default() -> Self {
         Self {
-            // 0.5 is tighter than clustering::DEFAULT_THRESHOLD (0.8) — produces
-            // better speaker separation on typical meeting recordings.
-            threshold: 0.7,
+            // 0.85 produces fewer, broader clusters — better for typical 2-speaker
+            // recordings where over-clustering is the common failure mode.
+            threshold: 0.85,
             min_segment: 0.3,
             min_gap: 0.5,
         }


### PR DESCRIPTION
## Summary

- Raises the default agglomerative clustering threshold from 0.7 → 0.85 (average linkage, cosine distance). At 0.7 the pipeline was producing 8 clusters on a correctly-decoded stereo recording; 0.85 produces the right 2-speaker output for the test recording.
- Adds `--diarize-threshold <THRESHOLD>` CLI flag so users can tune per-recording without recompiling.
- Adds `debug!` logging of distance percentiles (p25/p50/p75/p90) in the clustering step to aid future threshold tuning.

## Why 0.85

Threshold sweep on the 178s 2-speaker Swedish test recording:
- `0.85` → 4 internal clusters, 2-speaker output ✓ (correct attribution)  
- `0.90` → 2 clusters, but merge step collapses all to one speaker (transcript segments too broad to split on fine turn boundaries)
- `1.00` → 1 cluster (over-merged)

The 4-cluster artefact at 0.85 occurs because pyannote segments one speaker's voice slightly differently across the recording (acoustic drift). The merge-with-transcript step handles this correctly — only the two dominant speaker clusters appear in the final output.

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes (both with and without `--features diarization`)
- [ ] `sagascript transcribe --diarize /path/to/two-speaker.m4a` → 2 speakers
- [ ] `sagascript transcribe --diarize --diarize-threshold 0.6 ...` → more speakers (stricter)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)