### PR TITLE
feat(gui): add prompt textarea and diarize checkbox to file transcription UI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -388,6 +388,8 @@ pub async fn transcribe_file(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
     file_path: String,
+    prompt: Option<String>,
+    diarize: Option<bool>,
 ) -> Result<String, String> {
     use tauri::Emitter;
 
@@ -402,6 +404,10 @@ pub async fn transcribe_file(
     if audio.is_empty() {
         return Err("No audio decoded from file".to_string());
     }
+
+    // Suppress unused-variable warning on `diarize` when the diarization feature is off
+    #[cfg(not(feature = "diarization"))]
+    let _ = &diarize;
 
     // Get transcription settings
     let (language, effective_model) = {
@@ -421,13 +427,117 @@ pub async fn transcribe_file(
 
     let _ = app.emit(crate::events::event::STATE_CHANGED, "transcribing");
 
-    // Run blocking transcription with progress reporting and timeout
+    // Diarization path — runs both diarization and timestamped transcription in parallel,
+    // then merges and consolidates speaker-attributed segments.
+    #[cfg(feature = "diarization")]
+    if diarize.unwrap_or(false) {
+        use crate::diarization::{
+            DiarizeConfig, TimestampedSegment,
+            diarize as run_diarize,
+            merge::{consolidate, merge_with_transcript},
+            model::all_models_downloaded,
+        };
+
+        if !all_models_downloaded() {
+            let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+            return Err(
+                "Diarization models not downloaded. Use Settings → Models to download them."
+                    .to_string(),
+            );
+        }
+
+        let whisper_ref = whisper.inner().clone();
+        let prompt_ref = prompt.clone();
+        let audio_for_diarize = audio.clone();
+        let audio_for_transcribe = audio.clone();
+
+        // Run diarization
+        let diarize_fut = tokio::task::spawn_blocking(move || {
+            run_diarize(&audio_for_diarize, &DiarizeConfig::default())
+        });
+
+        // Run timestamped transcription
+        let transcribe_fut = tokio::task::spawn_blocking(move || {
+            whisper_ref.transcribe_sync_with_timestamps(
+                &audio_for_transcribe,
+                language,
+                prompt_ref.as_deref(),
+            )
+        });
+
+        let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);
+        let (speaker_segments, raw_segments) =
+            match tokio::time::timeout(timeout, async { tokio::join!(diarize_fut, transcribe_fut) })
+                .await
+            {
+                Ok((Ok(Ok(spk)), Ok(Ok(trx)))) => (spk, trx),
+                Ok((Ok(Err(e)), _)) | Ok((_, Ok(Err(e)))) => {
+                    let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+                    return Err(e.to_string());
+                }
+                Ok((Err(e), _)) | Ok((_, Err(e))) => {
+                    let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+                    return Err(format!("Task join error: {e}"));
+                }
+                Err(_) => {
+                    whisper.request_abort();
+                    let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+                    return Err(format!(
+                        "Transcription timed out after {TRANSCRIPTION_TIMEOUT_SECS}s"
+                    ));
+                }
+            };
+
+        let transcript: Vec<TimestampedSegment> = raw_segments
+            .into_iter()
+            .map(|(start, end, text)| TimestampedSegment { start, end, text })
+            .collect();
+
+        let diarized = merge_with_transcript(&speaker_segments, &transcript);
+        let consolidated = consolidate(&diarized);
+
+        let text = consolidated
+            .iter()
+            .map(|s| format!("[{}] {}", s.speaker, s.text.trim()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        info!("Diarized file transcription complete: {} chars", text.len());
+
+        let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+
+        // Auto-paste if enabled
+        let should_paste = {
+            let c = controller.lock().unwrap();
+            c.settings().auto_paste
+        };
+        if should_paste {
+            let text_for_paste = text.clone();
+            if let Err(e) = app.run_on_main_thread(move || {
+                let paste_svc = crate::paste::PasteService::new();
+                if let Err(e) = paste_svc.paste(&text_for_paste) {
+                    error!("Auto-paste failed: {e}");
+                }
+            }) {
+                error!("Failed to dispatch paste to main thread: {e}");
+            }
+        }
+
+        return Ok(text);
+    }
+
+    // Standard (non-diarize) transcription path
     let whisper_ref = whisper.inner().clone();
     let app_progress = app.clone();
     let fut = tokio::task::spawn_blocking(move || {
-        whisper_ref.transcribe_sync_with_progress(&audio, language, move |pct| {
-            let _ = app_progress.emit(crate::events::event::TRANSCRIPTION_PROGRESS, pct);
-        })
+        whisper_ref.transcribe_sync_with_progress_and_prompt(
+            &audio,
+            language,
+            prompt.as_deref(),
+            move |pct| {
+                let _ = app_progress.emit(crate::events::event::TRANSCRIPTION_PROGRESS, pct);
+            },
+        )
     });
 
     let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -67,6 +67,8 @@
   let transcriptionResult: string = $state("");
   let transcribeError: string = $state("");
   let dragOver: boolean = $state(false);
+  let transcribePrompt: string = $state('');
+  let transcribeDiarize: boolean = $state(false);
 
   onMount(async () => {
     settings = await getSettings();
@@ -214,7 +216,10 @@
     transcribeError = "";
     transcriptionResult = "";
     try {
-      transcriptionResult = await transcribeFile(filePath);
+      transcriptionResult = await transcribeFile(filePath, {
+        prompt: transcribePrompt.trim() || undefined,
+        diarize: transcribeDiarize,
+      });
     } catch (e: any) {
       transcribeError = typeof e === "string" ? e : e.message || "Transcription failed";
     } finally {
@@ -503,6 +508,19 @@
 
         <div class="formats-hint">
           Supported: {supportedFormats.map(f => f.toUpperCase()).join(", ") || "WAV, MP3, M4A, AAC, MP4, MOV, OGG, WEBM, FLAC"}
+        </div>
+
+        <div class="transcribe-options">
+          <label class="diarize-option">
+            <input type="checkbox" bind:checked={transcribeDiarize} />
+            Speaker diarization
+          </label>
+          <textarea
+            class="prompt-input"
+            placeholder="Context / vocabulary hint (optional) — e.g. names, technical terms"
+            bind:value={transcribePrompt}
+            rows="2"
+          ></textarea>
         </div>
 
         {#if transcribeError}
@@ -977,6 +995,54 @@
     color: var(--text-muted);
     margin-top: 10px;
     text-align: center;
+  }
+
+  .transcribe-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 14px;
+  }
+
+  .diarize-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .diarize-option input[type="checkbox"] {
+    width: 15px;
+    height: 15px;
+    accent-color: var(--accent);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .prompt-input {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .prompt-input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .prompt-input:focus {
+    border-color: var(--accent);
   }
 
   .transcribe-error {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,8 +102,15 @@ export async function getBuildInfo(): Promise<BuildInfo> {
   return invoke("get_build_info");
 }
 
-export async function transcribeFile(filePath: string): Promise<string> {
-  return invoke("transcribe_file", { filePath });
+export async function transcribeFile(
+  filePath: string,
+  options?: { prompt?: string; diarize?: boolean }
+): Promise<string> {
+  return invoke("transcribe_file", {
+    filePath,
+    prompt: options?.prompt ?? null,
+    diarize: options?.diarize ?? false,
+  });
 }
 
 export async function getSupportedFormats(): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Adds a **Speaker diarization** checkbox to the file transcription drop zone
- Adds a **prompt textarea** for domain vocabulary / context hints (reduces hallucination on proper nouns and technical terms)
- Both options are passed through to the backend `transcribe_file` command, which already supports them via the CLI

## Changes

- `commands.rs`: `transcribe_file` now accepts `prompt: Option<String>` and `diarize: Option<bool>`; diarize path runs the full pipeline (behind `#[cfg(feature = "diarization")]`) and returns `[SPEAKER_N] text` lines
- `api.ts`: `transcribeFile(filePath, options?)` — optional `{ prompt, diarize }` second arg
- `Settings.svelte`: checkbox + textarea below the drop zone, styled to match existing design tokens

## Test plan
- [ ] CI passes
- [ ] Drop a file without enabling either option → behaves as before
- [ ] Check diarize, drop a file → output shows `[SPEAKER_0]` / `[SPEAKER_1]` labels
- [ ] Enter a prompt, drop a file → prompt is passed to Whisper decoder
- [ ] Diarize without models downloaded → error message shown

🤖 Generated with [Claude Code](https://claude.ai/claude-code)