### PR TITLE
style: fix pre-existing clippy lints (-D warnings clean)

### DIFF
--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -299,8 +299,7 @@ mod tests {
 
     #[test]
     fn initial_language_from_settings() {
-        let mut settings = Settings::default();
-        settings.language = crate::settings::Language::Swedish;
+        let settings = Settings { language: crate::settings::Language::Swedish, ..Default::default() };
         let ctrl = AppController::new(settings);
         assert_eq!(ctrl.language(), crate::settings::Language::Swedish);
     }
@@ -323,9 +322,7 @@ mod tests {
     #[test]
     fn update_settings_replaces() {
         let mut ctrl = default_controller();
-        let mut new_settings = Settings::default();
-        new_settings.auto_paste = false;
-        new_settings.language = crate::settings::Language::Swedish;
+        let new_settings = Settings { auto_paste: false, language: crate::settings::Language::Swedish, ..Default::default() };
         ctrl.update_settings(new_settings);
         assert!(!ctrl.settings().auto_paste);
         assert_eq!(ctrl.settings().language, crate::settings::Language::Swedish);

--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -596,8 +596,8 @@ mod tests {
 
     #[test]
     fn parse_bool_valid() {
-        assert_eq!(parse_bool("true", "test").unwrap(), true);
-        assert_eq!(parse_bool("false", "test").unwrap(), false);
+        assert!(parse_bool("true", "test").unwrap());
+        assert!(!parse_bool("false", "test").unwrap());
     }
 
     #[test]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -526,13 +526,6 @@ mod tests {
 
     // -- Help text content --
 
-    fn get_help_text(args: &[&str]) -> String {
-        let err = Cli::command()
-            .try_get_matches_from(args)
-            .unwrap_err();
-        err.to_string()
-    }
-
     fn get_long_help(cmd: &clap::Command) -> String {
         cmd.clone().render_long_help().to_string()
     }

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -674,8 +674,7 @@ mod tests {
 
     #[test]
     fn settings_effective_model_with_auto_select() {
-        let mut s = Settings::default();
-        s.auto_select_model = true;
+        let mut s = Settings { auto_select_model: true, ..Default::default() };
 
         s.language = Language::English;
         assert_eq!(s.effective_model(), WhisperModel::BaseEn);
@@ -692,10 +691,7 @@ mod tests {
 
     #[test]
     fn settings_effective_model_without_auto_select() {
-        let mut s = Settings::default();
-        s.auto_select_model = false;
-        s.whisper_model = WhisperModel::KbWhisperSmall;
-        s.language = Language::English; // shouldn't matter
+        let s = Settings { auto_select_model: false, whisper_model: WhisperModel::KbWhisperSmall, language: Language::English, ..Default::default() }; // language shouldn't matter
 
         assert_eq!(s.effective_model(), WhisperModel::KbWhisperSmall);
     }

--- a/src-tauri/src/settings/store.rs
+++ b/src-tauri/src/settings/store.rs
@@ -111,9 +111,7 @@ mod tests {
     fn save_and_load_roundtrip() {
         with_temp_settings(|path| {
             let dir = path.parent().unwrap();
-            let mut settings = Settings::default();
-            settings.language = Language::Swedish;
-            settings.hotkey = "Alt+Space".to_string();
+            let settings = Settings { language: Language::Swedish, hotkey: "Alt+Space".to_string(), ..Default::default() };
 
             // Write directly to temp path (bypassing app_data_dir)
             fs::create_dir_all(dir).unwrap();
@@ -143,8 +141,7 @@ mod tests {
             fs::write(&path, serde_json::to_string_pretty(&initial).unwrap()).unwrap();
 
             // Save settings via merge
-            let mut settings = Settings::default();
-            settings.language = Language::Norwegian;
+            let settings = Settings { language: Language::Norwegian, ..Default::default() };
 
             // Simulate save's merge logic directly on this path
             let mut map: serde_json::Map<String, serde_json::Value> =


### PR DESCRIPTION
Resolves the 8 clippy errors that were failing `cargo clippy --all-targets -- -D warnings` on `main` — all in test code or one dead helper. **No behavior change.**

- `cli/mod.rs`: remove unused `get_help_text()` (dead_code)
- `cli/config.rs`: `assert_eq!(x, true/false)` → `assert!(x)` / `assert!(!x)` (bool_assert_comparison)
- `app_controller.rs`, `settings/manager.rs`, `settings/store.rs`: `let mut s = Settings::default(); s.field = …` → struct-literal init (field_reassign_with_default)

Independent of the perf/transcription stack; merging this first turns clippy green for the other PRs after rebase. `cargo clippy --all-targets -- -D warnings` clean; 176 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)