### PR TITLE
perf(transcription): latency + accuracy overhaul (Tiers 1–4) + opt-in modes

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,3 +68,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-cli
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 diarization = ["dep:ort", "dep:rustfft", "dep:kodama", "dep:ndarray"]
+
+# Optimize the Rust DSP/glue (rubato resampler, symphonia decode, audio mixing)
+# in release builds. whisper.cpp itself is compiled -O3 by whisper-rs's build
+# script in release; use `cargo tauri build` for production (`cargo tauri dev`
+# stays unoptimized). `panic = "abort"` is intentionally NOT set so a panic in
+# the blocking transcription thread still unwinds into a JoinError rather than
+# killing the whole app.
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -299,8 +299,7 @@ mod tests {
 
     #[test]
     fn initial_language_from_settings() {
-        let mut settings = Settings::default();
-        settings.language = crate::settings::Language::Swedish;
+        let settings = Settings { language: crate::settings::Language::Swedish, ..Default::default() };
         let ctrl = AppController::new(settings);
         assert_eq!(ctrl.language(), crate::settings::Language::Swedish);
     }
@@ -323,9 +322,7 @@ mod tests {
     #[test]
     fn update_settings_replaces() {
         let mut ctrl = default_controller();
-        let mut new_settings = Settings::default();
-        new_settings.auto_paste = false;
-        new_settings.language = crate::settings::Language::Swedish;
+        let new_settings = Settings { auto_paste: false, language: crate::settings::Language::Swedish, ..Default::default() };
         ctrl.update_settings(new_settings);
         assert!(!ctrl.settings().auto_paste);
         assert_eq!(ctrl.settings().language, crate::settings::Language::Swedish);

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -6,17 +7,23 @@ use cpal::SampleFormat;
 use tracing::{error, info};
 
 use crate::error::DictationError;
-use super::resample::{mix_to_mono, resample_to_16khz, TARGET_SAMPLE_RATE};
+use super::resample::{resample_to_16khz, TARGET_SAMPLE_RATE};
 
-/// Maximum buffer: 15 minutes at 16kHz
-const MAX_BUFFER_SAMPLES: usize = 16_000 * 60 * 15;
+/// Maximum recording length: 15 minutes. Capped in device-rate samples while
+/// recording (the buffer holds raw mono at the device rate), then resampled to
+/// 16 kHz on stop.
+const MAX_BUFFER_SECONDS: usize = 60 * 15;
 
 /// Audio capture service using cpal
 /// The cpal::Stream is !Send, so we spawn a dedicated thread to own it.
 /// Communication happens through shared buffers and a stop signal.
 pub struct AudioCaptureService {
+    /// Raw mono samples at the device sample rate (resampled to 16 kHz on stop).
     buffer: Arc<Mutex<Vec<f32>>>,
     stop_signal: Arc<Mutex<bool>>,
+    /// Device sample rate published by the capture thread once the input opens
+    /// (0 until known). Read by `stop_capture` to resample the whole buffer.
+    device_sample_rate: Arc<AtomicU32>,
     capture_thread: Option<thread::JoinHandle<()>>,
     /// Retained audio from last capture for retry
     last_captured: Option<Vec<f32>>,
@@ -31,6 +38,7 @@ impl AudioCaptureService {
         Self {
             buffer: Arc::new(Mutex::new(Vec::new())),
             stop_signal: Arc::new(Mutex::new(false)),
+            device_sample_rate: Arc::new(AtomicU32::new(0)),
             capture_thread: None,
             last_captured: None,
         }
@@ -50,10 +58,12 @@ impl AudioCaptureService {
 
         let buffer = Arc::clone(&self.buffer);
         let stop_signal = Arc::clone(&self.stop_signal);
+        let device_sample_rate = Arc::clone(&self.device_sample_rate);
+        device_sample_rate.store(0, Ordering::SeqCst);
 
         // Spawn a thread that owns the cpal::Stream
         let handle = thread::spawn(move || {
-            if let Err(e) = run_capture(buffer, stop_signal) {
+            if let Err(e) = run_capture(buffer, stop_signal, device_sample_rate) {
                 error!("Audio capture thread error: {e}");
             }
         });
@@ -80,16 +90,34 @@ impl AudioCaptureService {
             let _ = handle.join();
         }
 
-        let samples = {
+        let raw = {
             let mut buf = self.buffer.lock().unwrap();
             std::mem::take(&mut *buf)
         };
 
+        // Resample the entire recording to 16 kHz in a single pass. Doing it
+        // here (rather than per-callback) keeps the realtime audio thread cheap
+        // and avoids the filter-restart transient that a per-callback resampler
+        // injects at every chunk boundary.
+        let device_rate = self.device_sample_rate.load(Ordering::SeqCst);
+        let samples = if raw.is_empty() || device_rate == 0 {
+            raw
+        } else {
+            match resample_to_16khz(raw, device_rate) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("Resample failed, dropping recording: {e}");
+                    Vec::new()
+                }
+            }
+        };
+
         let duration = samples.len() as f64 / TARGET_SAMPLE_RATE as f64;
         info!(
-            "Audio capture stopped: {} samples ({:.2}s)",
+            "Audio capture stopped: {} samples ({:.2}s) [device {} Hz]",
             samples.len(),
-            duration
+            duration,
+            device_rate
         );
 
         // Retain for retry
@@ -114,6 +142,7 @@ impl AudioCaptureService {
 fn run_capture(
     buffer: Arc<Mutex<Vec<f32>>>,
     stop_signal: Arc<Mutex<bool>>,
+    device_sample_rate_out: Arc<AtomicU32>,
 ) -> Result<(), DictationError> {
     let host = cpal::default_host();
     let device = host
@@ -126,6 +155,9 @@ fn run_capture(
 
     let device_sample_rate = config.sample_rate().0;
     let device_channels = config.channels();
+
+    // Publish the rate so stop_capture can resample the buffer.
+    device_sample_rate_out.store(device_sample_rate, Ordering::SeqCst);
 
     info!(
         "Audio input: {} Hz, {} ch, {:?}",
@@ -208,18 +240,27 @@ fn process_samples(
     device_rate: u32,
     buffer: &Arc<Mutex<Vec<f32>>>,
 ) {
-    let mono = mix_to_mono(data, channels as usize);
-    let samples = match resample_to_16khz(mono, device_rate) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("Resample failed, dropping audio chunk: {e}");
-            return;
-        }
-    };
+    // Realtime-safe hot path: downmix to mono and append raw device-rate samples
+    // with a length cap. No resampling and no per-callback allocation here —
+    // resampling to 16 kHz happens once on stop (see stop_capture).
+    let max_samples = (device_rate as usize).saturating_mul(MAX_BUFFER_SECONDS);
+    let channels = channels.max(1) as usize;
 
-    // Append to buffer with size limit
     let mut buf = buffer.lock().unwrap();
-    if buf.len() + samples.len() <= MAX_BUFFER_SAMPLES {
-        buf.extend_from_slice(&samples);
+    if buf.len() >= max_samples {
+        return;
+    }
+
+    if channels == 1 {
+        let take = (max_samples - buf.len()).min(data.len());
+        buf.extend_from_slice(&data[..take]);
+    } else {
+        // Average channels into mono, pushing directly to avoid a temporary Vec.
+        for frame in data.chunks(channels) {
+            if buf.len() >= max_samples {
+                break;
+            }
+            buf.push(frame.iter().sum::<f32>() / channels as f32);
+        }
     }
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -194,10 +194,8 @@ fn run_capture(
                 .build_input_stream(
                     &config,
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                        let float_data: Vec<f32> =
-                            data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
-                        process_samples(
-                            &float_data,
+                        process_samples_i16(
+                            data,
                             device_channels,
                             device_sample_rate,
                             &buf_clone,
@@ -262,5 +260,104 @@ fn process_samples(
             }
             buf.push(frame.iter().sum::<f32>() / channels as f32);
         }
+    }
+}
+
+/// Like `process_samples` but for i16 input — converts to f32 and downmixes
+/// directly into the buffer, staying allocation-free on the realtime callback
+/// (no intermediate `Vec<f32>`).
+fn process_samples_i16(
+    data: &[i16],
+    channels: u16,
+    device_rate: u32,
+    buffer: &Arc<Mutex<Vec<f32>>>,
+) {
+    let max_samples = (device_rate as usize).saturating_mul(MAX_BUFFER_SECONDS);
+    let channels = channels.max(1) as usize;
+
+    let mut buf = buffer.lock().unwrap();
+    if buf.len() >= max_samples {
+        return;
+    }
+
+    if channels == 1 {
+        for &s in data {
+            if buf.len() >= max_samples {
+                break;
+            }
+            buf.push(s as f32 / i16::MAX as f32);
+        }
+    } else {
+        for frame in data.chunks(channels) {
+            if buf.len() >= max_samples {
+                break;
+            }
+            let avg =
+                frame.iter().map(|&s| s as f32 / i16::MAX as f32).sum::<f32>() / channels as f32;
+            buf.push(avg);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf() -> Arc<Mutex<Vec<f32>>> {
+        Arc::new(Mutex::new(Vec::new()))
+    }
+
+    #[test]
+    fn f32_mono_appends_raw() {
+        let b = buf();
+        process_samples(&[0.1, 0.2, 0.3], 1, 16_000, &b);
+        assert_eq!(*b.lock().unwrap(), vec![0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn f32_stereo_downmixes_to_mono() {
+        let b = buf();
+        process_samples(&[1.0, 0.0, 0.0, 1.0], 2, 16_000, &b);
+        let out = b.lock().unwrap();
+        assert_eq!(out.len(), 2);
+        assert!((out[0] - 0.5).abs() < 1e-6);
+        assert!((out[1] - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn i16_mono_converts_to_unit_range() {
+        let b = buf();
+        process_samples_i16(&[i16::MAX, 0, i16::MIN], 1, 16_000, &b);
+        let out = b.lock().unwrap();
+        assert_eq!(out.len(), 3);
+        assert!((out[0] - 1.0).abs() < 1e-4);
+        assert!(out[1].abs() < 1e-6);
+        assert!((out[2] - (-1.0)).abs() < 1e-3); // MIN/MAX ≈ -1.00003
+    }
+
+    #[test]
+    fn i16_stereo_downmix_averages_channels() {
+        let b = buf();
+        process_samples_i16(&[i16::MAX, 0, 0, i16::MAX], 2, 16_000, &b);
+        let out = b.lock().unwrap();
+        assert_eq!(out.len(), 2);
+        assert!((out[0] - 0.5).abs() < 1e-4);
+        assert!((out[1] - 0.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn cap_enforced_f32() {
+        let b = buf();
+        let cap = MAX_BUFFER_SECONDS; // rate = 1 → cap = MAX_BUFFER_SECONDS samples
+        process_samples(&vec![0.0f32; cap + 100], 1, 1, &b);
+        assert_eq!(b.lock().unwrap().len(), cap);
+    }
+
+    #[test]
+    fn cap_enforced_i16() {
+        let b = buf();
+        let cap = MAX_BUFFER_SECONDS;
+        process_samples_i16(&vec![0i16; cap + 100], 1, 1, &b);
+        assert_eq!(b.lock().unwrap().len(), cap);
     }
 }

--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -16,7 +16,8 @@ pub enum ConfigAction {
 Show all settings in a table with their current values and defaults.
 
 Valid keys: language, whisper_model, hotkey_mode, show_overlay, \
-auto_paste, auto_select_model, hotkey, initial_prompt")]
+auto_paste, auto_select_model, hotkey, initial_prompt, \
+beam_size, temperature_fallback, vad_enabled")]
     List,
 
     /// Get a single setting value
@@ -25,7 +26,8 @@ auto_paste, auto_select_model, hotkey, initial_prompt")]
 Print the current value of a single setting to stdout.
 
 Valid keys: language, whisper_model, hotkey_mode, show_overlay, \
-auto_paste, auto_select_model, hotkey, initial_prompt",
+auto_paste, auto_select_model, hotkey, initial_prompt, \
+beam_size, temperature_fallback, vad_enabled",
         after_long_help = "\
 EXAMPLES:
   sagascript config get language
@@ -33,7 +35,7 @@ EXAMPLES:
   sagascript config get initial_prompt"
     )]
     Get {
-        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt]
+        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt, beam_size, temperature_fallback, vad_enabled]
         key: String,
     },
 
@@ -44,16 +46,19 @@ Update a setting. The new value takes effect immediately — the GUI \
 hot-reloads changes made via CLI.
 
 Valid values per key:
-  language           en, sv, no, auto (auto uses a generic model — less accurate)
-  whisper_model      tiny.en, tiny, base.en, base, kb-whisper-tiny,
-                     kb-whisper-base, kb-whisper-small, nb-whisper-tiny,
-                     nb-whisper-base, nb-whisper-small
-  hotkey_mode        push, toggle
-  show_overlay       true, false
-  auto_paste         true, false
-  auto_select_model  true, false
-  hotkey             Modifier+Key (e.g. Control+Shift+Space, Option+Space)
-  initial_prompt     Any string (e.g. names, jargon, preferred spellings)",
+  language             en, sv, no, auto (auto uses a generic model — less accurate)
+  whisper_model        tiny.en, tiny, base.en, base, kb-whisper-tiny,
+                       kb-whisper-base, kb-whisper-small, nb-whisper-tiny,
+                       nb-whisper-base, nb-whisper-small
+  hotkey_mode          push, toggle
+  show_overlay         true, false
+  auto_paste           true, false
+  auto_select_model    true, false
+  hotkey               Modifier+Key (e.g. Control+Shift+Space, Option+Space)
+  initial_prompt       Any string (e.g. names, jargon, preferred spellings)
+  beam_size            Integer >= 0 (0 = greedy/fast, 5 = beam search/accurate)
+  temperature_fallback true, false
+  vad_enabled          true, false",
         after_long_help = "\
 EXAMPLES:
   sagascript config set language sv
@@ -63,7 +68,7 @@ EXAMPLES:
   sagascript config set initial_prompt 'Sagascript, Tauri, whisper-rs'"
     )]
     Set {
-        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt]
+        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt, beam_size, temperature_fallback, vad_enabled]
         key: String,
         /// New value for the setting
         value: String,
@@ -105,6 +110,9 @@ const VALID_KEYS: &[&str] = &[
     "auto_select_model",
     "hotkey",
     "initial_prompt",
+    "beam_size",
+    "temperature_fallback",
+    "vad_enabled",
 ];
 
 pub fn run(args: ConfigArgs) -> Result<(), DictationError> {
@@ -167,6 +175,18 @@ fn cmd_list() -> Result<(), DictationError> {
         "{:<20} {:<24} {}",
         "initial_prompt", current.initial_prompt, defaults.initial_prompt
     );
+    println!(
+        "{:<20} {:<24} {}",
+        "beam_size", current.beam_size, defaults.beam_size
+    );
+    println!(
+        "{:<20} {:<24} {}",
+        "temperature_fallback", current.temperature_fallback, defaults.temperature_fallback
+    );
+    println!(
+        "{:<20} {:<24} {}",
+        "vad_enabled", current.vad_enabled, defaults.vad_enabled
+    );
     Ok(())
 }
 
@@ -206,6 +226,19 @@ fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
             settings.hotkey = value.to_string();
         }
         "initial_prompt" => settings.initial_prompt = value.to_string(),
+        "beam_size" => {
+            settings.beam_size = value.parse::<u32>().map_err(|_| {
+                DictationError::SettingsError(format!(
+                    "beam_size must be a non-negative integer, got '{value}'"
+                ))
+            })?;
+        }
+        "temperature_fallback" => {
+            settings.temperature_fallback = parse_bool(value, "temperature_fallback")?;
+        }
+        "vad_enabled" => {
+            settings.vad_enabled = parse_bool(value, "vad_enabled")?;
+        }
         _ => unreachable!(), // validate_key already checked
     }
 
@@ -228,6 +261,9 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
             "auto_select_model" => settings.auto_select_model = defaults.auto_select_model,
             "hotkey" => settings.hotkey = defaults.hotkey,
             "initial_prompt" => settings.initial_prompt = defaults.initial_prompt,
+            "beam_size" => settings.beam_size = defaults.beam_size,
+            "temperature_fallback" => settings.temperature_fallback = defaults.temperature_fallback,
+            "vad_enabled" => settings.vad_enabled = defaults.vad_enabled,
             _ => unreachable!(),
         }
         settings::store::save(&settings).map_err(DictationError::SettingsError)?;
@@ -268,6 +304,9 @@ fn get_setting_value(settings: &Settings, key: &str) -> String {
         "auto_select_model" => settings.auto_select_model.to_string(),
         "hotkey" => settings.hotkey.clone(),
         "initial_prompt" => settings.initial_prompt.clone(),
+        "beam_size" => settings.beam_size.to_string(),
+        "temperature_fallback" => settings.temperature_fallback.to_string(),
+        "vad_enabled" => settings.vad_enabled.to_string(),
         _ => "unknown".to_string(),
     }
 }
@@ -642,6 +681,9 @@ mod tests {
         assert_eq!(get_setting_value(&settings, "auto_select_model"), "true");
         assert_eq!(get_setting_value(&settings, "hotkey"), "Control+Shift+Space");
         assert_eq!(get_setting_value(&settings, "initial_prompt"), "");
+        assert_eq!(get_setting_value(&settings, "beam_size"), "0");
+        assert_eq!(get_setting_value(&settings, "temperature_fallback"), "true");
+        assert_eq!(get_setting_value(&settings, "vad_enabled"), "false");
     }
 
     #[test]

--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -596,8 +596,8 @@ mod tests {
 
     #[test]
     fn parse_bool_valid() {
-        assert_eq!(parse_bool("true", "test").unwrap(), true);
-        assert_eq!(parse_bool("false", "test").unwrap(), false);
+        assert!(parse_bool("true", "test").unwrap());
+        assert!(!parse_bool("false", "test").unwrap());
     }
 
     #[test]

--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -16,7 +16,7 @@ pub enum ConfigAction {
 Show all settings in a table with their current values and defaults.
 
 Valid keys: language, whisper_model, hotkey_mode, show_overlay, \
-auto_paste, auto_select_model, hotkey")]
+auto_paste, auto_select_model, hotkey, initial_prompt")]
     List,
 
     /// Get a single setting value
@@ -25,14 +25,15 @@ auto_paste, auto_select_model, hotkey")]
 Print the current value of a single setting to stdout.
 
 Valid keys: language, whisper_model, hotkey_mode, show_overlay, \
-auto_paste, auto_select_model, hotkey",
+auto_paste, auto_select_model, hotkey, initial_prompt",
         after_long_help = "\
 EXAMPLES:
   sagascript config get language
-  sagascript config get hotkey"
+  sagascript config get hotkey
+  sagascript config get initial_prompt"
     )]
     Get {
-        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey]
+        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt]
         key: String,
     },
 
@@ -51,16 +52,18 @@ Valid values per key:
   show_overlay       true, false
   auto_paste         true, false
   auto_select_model  true, false
-  hotkey             Modifier+Key (e.g. Control+Shift+Space, Option+Space)",
+  hotkey             Modifier+Key (e.g. Control+Shift+Space, Option+Space)
+  initial_prompt     Any string (e.g. names, jargon, preferred spellings)",
         after_long_help = "\
 EXAMPLES:
   sagascript config set language sv
   sagascript config set whisper_model kb-whisper-base
   sagascript config set hotkey 'Option+Space'
-  sagascript config set auto_paste false"
+  sagascript config set auto_paste false
+  sagascript config set initial_prompt 'Sagascript, Tauri, whisper-rs'"
     )]
     Set {
-        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey]
+        /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt]
         key: String,
         /// New value for the setting
         value: String,
@@ -101,6 +104,7 @@ const VALID_KEYS: &[&str] = &[
     "auto_paste",
     "auto_select_model",
     "hotkey",
+    "initial_prompt",
 ];
 
 pub fn run(args: ConfigArgs) -> Result<(), DictationError> {
@@ -159,6 +163,10 @@ fn cmd_list() -> Result<(), DictationError> {
         "{:<20} {:<24} {}",
         "hotkey", current.hotkey, defaults.hotkey
     );
+    println!(
+        "{:<20} {:<24} {}",
+        "initial_prompt", current.initial_prompt, defaults.initial_prompt
+    );
     Ok(())
 }
 
@@ -197,6 +205,7 @@ fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
             validate_hotkey(value)?;
             settings.hotkey = value.to_string();
         }
+        "initial_prompt" => settings.initial_prompt = value.to_string(),
         _ => unreachable!(), // validate_key already checked
     }
 
@@ -218,6 +227,7 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
             "auto_paste" => settings.auto_paste = defaults.auto_paste,
             "auto_select_model" => settings.auto_select_model = defaults.auto_select_model,
             "hotkey" => settings.hotkey = defaults.hotkey,
+            "initial_prompt" => settings.initial_prompt = defaults.initial_prompt,
             _ => unreachable!(),
         }
         settings::store::save(&settings).map_err(DictationError::SettingsError)?;
@@ -257,6 +267,7 @@ fn get_setting_value(settings: &Settings, key: &str) -> String {
         "auto_paste" => settings.auto_paste.to_string(),
         "auto_select_model" => settings.auto_select_model.to_string(),
         "hotkey" => settings.hotkey.clone(),
+        "initial_prompt" => settings.initial_prompt.clone(),
         _ => "unknown".to_string(),
     }
 }
@@ -630,6 +641,7 @@ mod tests {
         assert_eq!(get_setting_value(&settings, "auto_paste"), "true");
         assert_eq!(get_setting_value(&settings, "auto_select_model"), "true");
         assert_eq!(get_setting_value(&settings, "hotkey"), "Control+Shift+Space");
+        assert_eq!(get_setting_value(&settings, "initial_prompt"), "");
     }
 
     #[test]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -526,13 +526,6 @@ mod tests {
 
     // -- Help text content --
 
-    fn get_help_text(args: &[&str]) -> String {
-        let err = Cli::command()
-            .try_get_matches_from(args)
-            .unwrap_err();
-        err.to_string()
-    }
-
     fn get_long_help(cmd: &clap::Command) -> String {
         cmd.clone().render_long_help().to_string()
     }

--- a/src-tauri/src/cli/models.rs
+++ b/src-tauri/src/cli/models.rs
@@ -150,6 +150,11 @@ pub async fn download(args: DownloadModelArgs) -> Result<(), DictationError> {
             whisper_model.display_name(),
             path.display()
         );
+        // Backfill the CoreML encoder if it's missing (no-op if already present
+        // or unavailable for this model).
+        if let Err(e) = model::backfill_coreml_encoder(whisper_model).await {
+            eprintln!("Note: CoreML encoder not installed: {e}");
+        }
         println!("{}", path.display());
         return Ok(());
     }

--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -246,6 +246,7 @@ pub fn parse_model(s: &str) -> Result<WhisperModel, DictationError> {
         "medium.en" => Ok(WhisperModel::MediumEn),
         "medium" => Ok(WhisperModel::Medium),
         "large-v3-turbo" => Ok(WhisperModel::LargeV3Turbo),
+        "large-v3-turbo-q8_0" => Ok(WhisperModel::LargeV3TurboQ8),
         other => Err(DictationError::SettingsError(format!(
             "Unknown model '{other}'. Run 'sagascript list-models' to see available models."
         ))),
@@ -273,6 +274,7 @@ pub fn model_id_string(model: WhisperModel) -> &'static str {
         WhisperModel::MediumEn => "medium.en",
         WhisperModel::Medium => "medium",
         WhisperModel::LargeV3Turbo => "large-v3-turbo",
+        WhisperModel::LargeV3TurboQ8 => "large-v3-turbo-q8_0",
     }
 }
 
@@ -346,6 +348,7 @@ mod tests {
             ("medium.en", WhisperModel::MediumEn),
             ("medium", WhisperModel::Medium),
             ("large-v3-turbo", WhisperModel::LargeV3Turbo),
+            ("large-v3-turbo-q8_0", WhisperModel::LargeV3TurboQ8),
         ];
         for (id, expected) in cases {
             assert_eq!(parse_model(id).unwrap(), expected, "parse_model({id})");
@@ -387,6 +390,7 @@ mod tests {
             (WhisperModel::MediumEn, "medium.en"),
             (WhisperModel::Medium, "medium"),
             (WhisperModel::LargeV3Turbo, "large-v3-turbo"),
+            (WhisperModel::LargeV3TurboQ8, "large-v3-turbo-q8_0"),
         ];
         for (model, expected) in models {
             assert_eq!(model_id_string(model), expected);
@@ -411,6 +415,7 @@ mod tests {
             WhisperModel::MediumEn,
             WhisperModel::Medium,
             WhisperModel::LargeV3Turbo,
+            WhisperModel::LargeV3TurboQ8,
         ];
         for model in all_models {
             let id = model_id_string(model);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,35 @@ const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 use crate::app_controller::{AppController, AppState};
 use crate::audio::decoder;
 use crate::settings::{HotkeyMode, Language, Settings, WhisperModel};
-use crate::transcription::{model, WhisperBackend};
+use crate::transcription::{model, TranscribeOptions, WhisperBackend};
+
+/// Build the per-transcription options from the current settings. Resolves the
+/// VAD model path only when VAD is enabled and the model is present (otherwise
+/// VAD is silently skipped — whisper would fail on a missing model).
+pub(crate) fn build_transcribe_options(settings: &Settings) -> TranscribeOptions {
+    let prompt = settings.initial_prompt.trim();
+    let vad_model_path = if settings.vad_enabled {
+        let p = model::vad_model_path();
+        if p.exists() {
+            p.to_str().map(str::to_string)
+        } else {
+            tracing::warn!("VAD enabled but model not downloaded — skipping VAD");
+            None
+        }
+    } else {
+        None
+    };
+    TranscribeOptions {
+        prompt: if prompt.is_empty() {
+            None
+        } else {
+            Some(prompt.to_string())
+        },
+        beam_size: settings.beam_size,
+        temperature_fallback: settings.temperature_fallback,
+        vad_model_path,
+    }
+}
 
 /// Shared app state type — uses std::sync::Mutex (not tokio) because
 /// cpal::Stream is !Send and we need sync access from Tauri commands
@@ -219,13 +247,13 @@ pub async fn stop_and_transcribe(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
 ) -> Result<String, String> {
-    let (audio, language, effective_model, prompt) = {
+    let (audio, language, effective_model, opts) = {
         let mut ctrl = controller.lock().unwrap();
         let audio = ctrl.stop_recording();
         let language = ctrl.language();
         let effective_model = ctrl.settings().effective_model();
-        let prompt = ctrl.settings().initial_prompt.clone();
-        (audio, language, effective_model, prompt)
+        let opts = build_transcribe_options(ctrl.settings());
+        (audio, language, effective_model, opts)
     };
 
     if audio.is_empty() {
@@ -245,8 +273,7 @@ pub async fn stop_and_transcribe(
     // task continues running and holds the context mutex until whisper finishes.
     let whisper_ref = whisper.inner().clone();
     let fut = tokio::task::spawn_blocking(move || {
-        let prompt = if prompt.trim().is_empty() { None } else { Some(prompt.as_str()) };
-        whisper_ref.transcribe_sync_with_prompt(&audio, language, prompt)
+        whisper_ref.transcribe_sync_with_options(&audio, language, &opts, |_| {})
     });
 
     let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);
@@ -393,6 +420,54 @@ pub async fn set_initial_prompt(
     drop(ctrl);
     persist_settings(&controller)?;
     info!("Initial prompt set ({} chars)", prompt.len());
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_beam_size(
+    controller: State<'_, SharedController>,
+    beam_size: u32,
+) -> Result<(), String> {
+    let mut ctrl = controller.lock().unwrap();
+    ctrl.settings_mut().beam_size = beam_size;
+    drop(ctrl);
+    persist_settings(&controller)?;
+    info!("Beam size: {beam_size}");
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_temperature_fallback(
+    controller: State<'_, SharedController>,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut ctrl = controller.lock().unwrap();
+    ctrl.settings_mut().temperature_fallback = enabled;
+    drop(ctrl);
+    persist_settings(&controller)?;
+    info!("Temperature fallback: {enabled}");
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_vad_enabled(
+    controller: State<'_, SharedController>,
+    enabled: bool,
+) -> Result<(), String> {
+    {
+        let mut ctrl = controller.lock().unwrap();
+        ctrl.settings_mut().vad_enabled = enabled;
+    }
+    persist_settings(&controller)?;
+    // Fetch the Silero VAD model so it's ready for the next dictation. Done
+    // after releasing the lock (no lock held across await).
+    if enabled && !model::is_vad_model_downloaded() {
+        info!("Downloading VAD model...");
+        model::download_vad_model(|_, _| {})
+            .await
+            .map_err(|e| format!("Failed to download VAD model: {e}"))?;
+    }
+    info!("VAD enabled: {enabled}");
     Ok(())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -219,12 +219,13 @@ pub async fn stop_and_transcribe(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
 ) -> Result<String, String> {
-    let (audio, language, effective_model) = {
+    let (audio, language, effective_model, prompt) = {
         let mut ctrl = controller.lock().unwrap();
         let audio = ctrl.stop_recording();
         let language = ctrl.language();
         let effective_model = ctrl.settings().effective_model();
-        (audio, language, effective_model)
+        let prompt = ctrl.settings().initial_prompt.clone();
+        (audio, language, effective_model, prompt)
     };
 
     if audio.is_empty() {
@@ -243,7 +244,10 @@ pub async fn stop_and_transcribe(
     // On timeout, request_abort() is called but has no effect — the blocking
     // task continues running and holds the context mutex until whisper finishes.
     let whisper_ref = whisper.inner().clone();
-    let fut = tokio::task::spawn_blocking(move || whisper_ref.transcribe_sync(&audio, language));
+    let fut = tokio::task::spawn_blocking(move || {
+        let prompt = if prompt.trim().is_empty() { None } else { Some(prompt.as_str()) };
+        whisper_ref.transcribe_sync_with_prompt(&audio, language, prompt)
+    });
 
     let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);
     let result = match tokio::time::timeout(timeout, fut).await {
@@ -376,6 +380,19 @@ pub async fn set_show_overlay(
     drop(ctrl);
     persist_settings(&controller)?;
     info!("Show overlay: {enabled}");
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_initial_prompt(
+    controller: State<'_, SharedController>,
+    prompt: String,
+) -> Result<(), String> {
+    let mut ctrl = controller.lock().unwrap();
+    ctrl.settings_mut().initial_prompt = prompt.clone();
+    drop(ctrl);
+    persist_settings(&controller)?;
+    info!("Initial prompt set ({} chars)", prompt.len());
     Ok(())
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -243,7 +243,6 @@ pub async fn stop_and_transcribe(
     // On timeout, request_abort() is called but has no effect — the blocking
     // task continues running and holds the context mutex until whisper finishes.
     let whisper_ref = whisper.inner().clone();
-    let audio = audio.clone();
     let fut = tokio::task::spawn_blocking(move || whisper_ref.transcribe_sync(&audio, language));
 
     let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -221,10 +221,14 @@ fn main() {
             {
                 let whisper: tauri::State<'_, SharedWhisper> = app.state();
                 let whisper = whisper.inner().clone();
-                let (model, language) = {
+                let (model, language, vad_enabled) = {
                     let ctrl: tauri::State<'_, SharedController> = app.state();
                     let c = ctrl.lock().unwrap();
-                    (c.settings().effective_model(), c.language())
+                    (
+                        c.settings().effective_model(),
+                        c.language(),
+                        c.settings().vad_enabled,
+                    )
                 };
                 std::thread::spawn(move || {
                     if let Err(e) = whisper.ensure_model(model) {
@@ -237,6 +241,18 @@ fn main() {
                         info!("Model preloaded and warmed: {}", model.display_name());
                     }
                 });
+
+                // If VAD is enabled (e.g. set via the CLI), make sure the Silero
+                // model is present for the next dictation.
+                if vad_enabled && !crate::transcription::model::is_vad_model_downloaded() {
+                    tauri::async_runtime::spawn(async {
+                        if let Err(e) =
+                            crate::transcription::model::download_vad_model(|_, _| {}).await
+                        {
+                            warn!("VAD model preload failed: {e}");
+                        }
+                    });
+                }
             }
 
             Ok(())
@@ -271,6 +287,9 @@ fn main() {
             commands::set_auto_paste,
             commands::set_show_overlay,
             commands::set_initial_prompt,
+            commands::set_beam_size,
+            commands::set_temperature_fallback,
+            commands::set_vad_enabled,
             commands::get_build_info,
             commands::transcribe_file,
             commands::get_supported_formats,
@@ -448,12 +467,12 @@ fn stop_recording_and_transcribe(
         let whisper: tauri::State<'_, SharedWhisper> = app_handle.state();
 
         // Extract what we need for transcription (lock briefly)
-        let (language, effective_model, prompt) = {
+        let (language, effective_model, opts) = {
             let c = ctrl.lock().unwrap();
             (
                 c.language(),
                 c.settings().effective_model(),
-                c.settings().initial_prompt.clone(),
+                commands::build_transcribe_options(c.settings()),
             )
         };
 
@@ -475,12 +494,7 @@ fn stop_recording_and_transcribe(
             // task continues running and holds the context mutex until whisper finishes.
             let whisper_ref = whisper.inner().clone();
             let fut = tokio::task::spawn_blocking(move || {
-                let prompt = if prompt.trim().is_empty() {
-                    None
-                } else {
-                    Some(prompt.as_str())
-                };
-                whisper_ref.transcribe_sync_with_prompt(&audio, language, prompt)
+                whisper_ref.transcribe_sync_with_options(&audio, language, &opts, |_| {})
             });
 
             let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -253,6 +253,21 @@ fn main() {
                         }
                     });
                 }
+
+                // Best-effort: backfill the CoreML encoder for the effective
+                // model — covers models downloaded before CoreML support, so the
+                // encoder moves to the Neural Engine without a manual re-download.
+                // Only when the GGML model itself is present (don't fetch an
+                // encoder for a model the user hasn't downloaded yet).
+                if crate::transcription::model::is_model_downloaded(model) {
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) =
+                            crate::transcription::model::backfill_coreml_encoder(model).await
+                        {
+                            warn!("CoreML encoder backfill skipped: {e}");
+                        }
+                    });
+                }
             }
 
             Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,7 +33,7 @@ use tauri::{
     Emitter, Manager,
 };
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use app_controller::{AppController, HotkeyDownResult};
@@ -212,6 +212,31 @@ fn main() {
                     info!("First launch detected, opening onboarding");
                     open_settings_window(app.handle(), Some("onboarding"));
                 }
+            }
+
+            // Preload + warm the whisper model in the background so the first
+            // dictation of the session doesn't pay model-load and Metal/CoreML
+            // kernel-compile latency. Best-effort: if the model isn't downloaded
+            // yet (fresh install) we just skip and load lazily on first use.
+            {
+                let whisper: tauri::State<'_, SharedWhisper> = app.state();
+                let whisper = whisper.inner().clone();
+                let (model, language) = {
+                    let ctrl: tauri::State<'_, SharedController> = app.state();
+                    let c = ctrl.lock().unwrap();
+                    (c.settings().effective_model(), c.language())
+                };
+                std::thread::spawn(move || {
+                    if let Err(e) = whisper.ensure_model(model) {
+                        warn!("Model preload skipped: {e}");
+                        return;
+                    }
+                    if let Err(e) = whisper.warmup(language) {
+                        warn!("Model warmup failed: {e}");
+                    } else {
+                        info!("Model preloaded and warmed: {}", model.display_name());
+                    }
+                });
             }
 
             Ok(())
@@ -444,7 +469,6 @@ fn stop_recording_and_transcribe(
             // On timeout, request_abort() is called but has no effect — the blocking
             // task continues running and holds the context mutex until whisper finishes.
             let whisper_ref = whisper.inner().clone();
-            let audio = audio.clone();
             let fut = tokio::task::spawn_blocking(move || {
                 whisper_ref.transcribe_sync(&audio, language)
             });

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -270,6 +270,7 @@ fn main() {
             commands::download_model,
             commands::set_auto_paste,
             commands::set_show_overlay,
+            commands::set_initial_prompt,
             commands::get_build_info,
             commands::transcribe_file,
             commands::get_supported_formats,
@@ -447,9 +448,13 @@ fn stop_recording_and_transcribe(
         let whisper: tauri::State<'_, SharedWhisper> = app_handle.state();
 
         // Extract what we need for transcription (lock briefly)
-        let (language, effective_model) = {
+        let (language, effective_model, prompt) = {
             let c = ctrl.lock().unwrap();
-            (c.language(), c.settings().effective_model())
+            (
+                c.language(),
+                c.settings().effective_model(),
+                c.settings().initial_prompt.clone(),
+            )
         };
 
         info!("Transcribing with model: {}", effective_model.display_name());
@@ -470,7 +475,12 @@ fn stop_recording_and_transcribe(
             // task continues running and holds the context mutex until whisper finishes.
             let whisper_ref = whisper.inner().clone();
             let fut = tokio::task::spawn_blocking(move || {
-                whisper_ref.transcribe_sync(&audio, language)
+                let prompt = if prompt.trim().is_empty() {
+                    None
+                } else {
+                    Some(prompt.as_str())
+                };
+                whisper_ref.transcribe_sync_with_prompt(&audio, language, prompt)
             });
 
             let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -79,6 +79,8 @@ pub enum WhisperModel {
     Medium,
     #[serde(rename = "large-v3-turbo")]
     LargeV3Turbo,
+    #[serde(rename = "large-v3-turbo-q8_0")]
+    LargeV3TurboQ8,
 }
 
 impl WhisperModel {
@@ -103,6 +105,7 @@ impl WhisperModel {
             WhisperModel::MediumEn => "Whisper Medium (EN)",
             WhisperModel::Medium => "Whisper Medium",
             WhisperModel::LargeV3Turbo => "Whisper Large v3 Turbo",
+            WhisperModel::LargeV3TurboQ8 => "Whisper Large v3 Turbo (Q8_0)",
         }
     }
 
@@ -127,6 +130,7 @@ impl WhisperModel {
             WhisperModel::MediumEn => "OpenAI Whisper, English-only. High accuracy, slow",
             WhisperModel::Medium => "OpenAI Whisper, multilingual. High accuracy, slow",
             WhisperModel::LargeV3Turbo => "OpenAI Whisper, multilingual. Highest accuracy, slowest",
+            WhisperModel::LargeV3TurboQ8 => "OpenAI Whisper large-v3-turbo, q8_0 quantised. High accuracy, multilingual, 834 MB",
         }
     }
 
@@ -165,7 +169,7 @@ impl WhisperModel {
             WhisperModel::Small | WhisperModel::KbWhisperSmall | WhisperModel::NbWhisperSmall => DtwModelPreset::Small,
             WhisperModel::MediumEn => DtwModelPreset::MediumEn,
             WhisperModel::Medium | WhisperModel::KbWhisperMedium | WhisperModel::NbWhisperMedium => DtwModelPreset::Medium,
-            WhisperModel::LargeV3Turbo => DtwModelPreset::LargeV3Turbo,
+            WhisperModel::LargeV3Turbo | WhisperModel::LargeV3TurboQ8 => DtwModelPreset::LargeV3Turbo,
             // KbWhisperLarge / NbWhisperLarge are large-v3 fine-tunes
             WhisperModel::KbWhisperLarge | WhisperModel::NbWhisperLarge => DtwModelPreset::LargeV3,
         }
@@ -211,6 +215,7 @@ impl WhisperModel {
             WhisperModel::MediumEn => "ggml-medium.en.bin",
             WhisperModel::Medium => "ggml-medium.bin",
             WhisperModel::LargeV3Turbo => "ggml-large-v3-turbo.bin",
+            WhisperModel::LargeV3TurboQ8 => "ggml-large-v3-turbo-q8_0.bin",
         }
     }
 
@@ -236,29 +241,57 @@ impl WhisperModel {
             WhisperModel::MediumEn => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
             WhisperModel::Medium => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin",
             WhisperModel::LargeV3Turbo => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
+            WhisperModel::LargeV3TurboQ8 => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q8_0.bin",
         }
     }
 
+    /// CoreML encoder basename whisper.cpp derives from the GGML filename: strip
+    /// `.bin`, then strip a trailing `-qX_X` quantisation suffix (mirrors
+    /// whisper.cpp's `whisper_get_coreml_path_encoder`). The CoreML encoder is
+    /// FP16 and shared across quantisations of a model — so `large-v3-turbo-q8_0`
+    /// reuses the same `ggml-large-v3-turbo-encoder.mlmodelc`. Returns `None` for
+    /// models without a CoreML encoder: only the OpenAI models in the
+    /// ggerganov/whisper.cpp repo ship one; the KB/NB fine-tunes live in their
+    /// own repos and have none.
+    #[cfg(target_os = "macos")]
+    fn coreml_encoder_stem(&self) -> Option<&'static str> {
+        if !self
+            .download_url()
+            .starts_with("https://huggingface.co/ggerganov/whisper.cpp/")
+        {
+            return None;
+        }
+        let stem = self.ggml_filename().strip_suffix(".bin")?;
+        // Strip a trailing "-qX_X" (e.g. "-q8_0"), exactly as whisper.cpp does.
+        let stem = match stem.rfind('-') {
+            Some(pos) => {
+                let suffix = &stem.as_bytes()[pos..];
+                if suffix.len() == 5 && suffix[1] == b'q' && suffix[3] == b'_' {
+                    &stem[..pos]
+                } else {
+                    stem
+                }
+            }
+            None => stem,
+        };
+        Some(stem)
+    }
+
     /// HuggingFace URL of the CoreML encoder bundle (`*-encoder.mlmodelc.zip`),
-    /// or `None` if this model has no CoreML encoder. CoreML encoders are
-    /// published alongside the GGML weights in the ggerganov/whisper.cpp repo;
-    /// the KB/NB fine-tunes live in their own repos and ship none.
+    /// or `None` if this model has no CoreML encoder.
     #[cfg(target_os = "macos")]
     pub fn coreml_encoder_url(&self) -> Option<String> {
-        let url = self.download_url();
-        let base = url
-            .strip_prefix("https://huggingface.co/ggerganov/whisper.cpp/")
-            .and(url.strip_suffix(".bin"))?;
-        Some(format!("{base}-encoder.mlmodelc.zip"))
+        let stem = self.coreml_encoder_stem()?;
+        Some(format!(
+            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/{stem}-encoder.mlmodelc.zip"
+        ))
     }
 
     /// Directory name whisper.cpp expects the CoreML encoder to have next to the
-    /// GGML file (`ggml-<name>-encoder.mlmodelc`). Mirrors whisper.cpp's own
-    /// `.bin` → `-encoder.mlmodelc` derivation. `None` if no CoreML encoder.
+    /// GGML file (`ggml-<name>-encoder.mlmodelc`). `None` if no CoreML encoder.
     #[cfg(target_os = "macos")]
     pub fn coreml_encoder_dirname(&self) -> Option<String> {
-        self.coreml_encoder_url()?;
-        let stem = self.ggml_filename().strip_suffix(".bin")?;
+        let stem = self.coreml_encoder_stem()?;
         Some(format!("{stem}-encoder.mlmodelc"))
     }
 
@@ -284,6 +317,7 @@ impl WhisperModel {
             WhisperModel::MediumEn => 1530,
             WhisperModel::Medium => 1530,
             WhisperModel::LargeV3Turbo => 1620,
+            WhisperModel::LargeV3TurboQ8 => 834,
         }
     }
 
@@ -326,6 +360,7 @@ impl WhisperModel {
                 WhisperModel::Small,
                 WhisperModel::Medium,
                 WhisperModel::LargeV3Turbo,
+                WhisperModel::LargeV3TurboQ8,
             ],
         }
     }
@@ -364,6 +399,9 @@ pub struct Settings {
     pub auto_select_model: bool,
     /// Hotkey shortcut string (e.g. "Control+Shift+Space")
     pub hotkey: String,
+    /// Optional initial prompt that primes the decoder with domain vocabulary
+    /// (names, jargon, spellings) for more accurate transcription. Empty = none.
+    pub initial_prompt: String,
     /// Whether the user has completed the first-launch onboarding
     pub has_completed_onboarding: bool,
 }
@@ -378,6 +416,7 @@ impl Default for Settings {
             auto_paste: true,
             auto_select_model: true,
             hotkey: "Control+Shift+Space".to_string(),
+            initial_prompt: String::new(),
             has_completed_onboarding: false,
         }
     }
@@ -491,6 +530,16 @@ mod tests {
             WhisperModel::LargeV3Turbo.coreml_encoder_dirname().as_deref(),
             Some("ggml-large-v3-turbo-encoder.mlmodelc")
         );
+        // Quantised turbo strips the `-q8_0` suffix and reuses the SAME FP16
+        // CoreML encoder as the f16 turbo (matches whisper.cpp's derivation).
+        assert_eq!(
+            WhisperModel::LargeV3TurboQ8.coreml_encoder_dirname().as_deref(),
+            Some("ggml-large-v3-turbo-encoder.mlmodelc")
+        );
+        assert_eq!(
+            WhisperModel::LargeV3TurboQ8.coreml_encoder_url().as_deref(),
+            Some("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-encoder.mlmodelc.zip")
+        );
         // KB/NB fine-tunes live in other repos and have no CoreML encoder.
         assert_eq!(WhisperModel::KbWhisperBase.coreml_encoder_url(), None);
         assert_eq!(WhisperModel::NbWhisperSmall.coreml_encoder_dirname(), None);
@@ -540,6 +589,7 @@ mod tests {
             WhisperModel::MediumEn,
             WhisperModel::Medium,
             WhisperModel::LargeV3Turbo,
+            WhisperModel::LargeV3TurboQ8,
         ];
         for m in models {
             let filename = m.ggml_filename();
@@ -570,6 +620,7 @@ mod tests {
             WhisperModel::MediumEn,
             WhisperModel::Medium,
             WhisperModel::LargeV3Turbo,
+            WhisperModel::LargeV3TurboQ8,
         ];
         for m in models {
             let url = m.download_url();
@@ -600,6 +651,7 @@ mod tests {
             WhisperModel::MediumEn,
             WhisperModel::Medium,
             WhisperModel::LargeV3Turbo,
+            WhisperModel::LargeV3TurboQ8,
         ];
         for m in models {
             assert!(m.size_mb() > 0, "{:?} has 0 size", m);
@@ -640,12 +692,13 @@ mod tests {
         assert!(no.contains(&WhisperModel::NbWhisperLarge));
 
         let auto = WhisperModel::models_for_language(Language::Auto);
-        assert_eq!(auto.len(), 5);
+        assert_eq!(auto.len(), 6);
         assert!(auto.contains(&WhisperModel::Tiny));
         assert!(auto.contains(&WhisperModel::Base));
         assert!(auto.contains(&WhisperModel::Small));
         assert!(auto.contains(&WhisperModel::Medium));
         assert!(auto.contains(&WhisperModel::LargeV3Turbo));
+        assert!(auto.contains(&WhisperModel::LargeV3TurboQ8));
     }
 
     #[test]
@@ -679,6 +732,7 @@ mod tests {
             (WhisperModel::MediumEn, "\"medium.en\""),
             (WhisperModel::Medium, "\"medium\""),
             (WhisperModel::LargeV3Turbo, "\"large-v3-turbo\""),
+            (WhisperModel::LargeV3TurboQ8, "\"large-v3-turbo-q8_0\""),
         ];
         for (model, expected) in pairs {
             let json = serde_json::to_string(&model).unwrap();
@@ -721,6 +775,7 @@ mod tests {
         assert!(s.auto_paste);
         assert!(s.auto_select_model);
         assert_eq!(s.hotkey, "Control+Shift+Space");
+        assert_eq!(s.initial_prompt, "");
     }
 
     #[test]
@@ -763,6 +818,7 @@ mod tests {
         assert_eq!(deserialized.auto_paste, original.auto_paste);
         assert_eq!(deserialized.auto_select_model, original.auto_select_model);
         assert_eq!(deserialized.hotkey, original.hotkey);
+        assert_eq!(deserialized.initial_prompt, original.initial_prompt);
     }
 
     #[test]
@@ -805,6 +861,7 @@ mod tests {
             WhisperModel::MediumEn,
             WhisperModel::Medium,
             WhisperModel::LargeV3Turbo,
+            WhisperModel::LargeV3TurboQ8,
         ];
         for m in models {
             assert_eq!(

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -402,6 +402,15 @@ pub struct Settings {
     /// Optional initial prompt that primes the decoder with domain vocabulary
     /// (names, jargon, spellings) for more accurate transcription. Empty = none.
     pub initial_prompt: String,
+    /// Beam search width. 0 = greedy decoding (fastest); >=2 enables beam search
+    /// (more accurate on hard audio, several times slower).
+    pub beam_size: u32,
+    /// Allow whisper's temperature fallback (re-decode hard segments at higher
+    /// temperature). true preserves robustness; false caps worst-case latency.
+    pub temperature_fallback: bool,
+    /// Skip non-speech regions with Silero VAD (reduces silence hallucination
+    /// and speeds up clips with leading/trailing silence). Needs the VAD model.
+    pub vad_enabled: bool,
     /// Whether the user has completed the first-launch onboarding
     pub has_completed_onboarding: bool,
 }
@@ -417,6 +426,9 @@ impl Default for Settings {
             auto_select_model: true,
             hotkey: "Control+Shift+Space".to_string(),
             initial_prompt: String::new(),
+            beam_size: 0,
+            temperature_fallback: true,
+            vad_enabled: false,
             has_completed_onboarding: false,
         }
     }
@@ -776,6 +788,9 @@ mod tests {
         assert!(s.auto_select_model);
         assert_eq!(s.hotkey, "Control+Shift+Space");
         assert_eq!(s.initial_prompt, "");
+        assert_eq!(s.beam_size, 0);
+        assert!(s.temperature_fallback);
+        assert!(!s.vad_enabled);
     }
 
     #[test]
@@ -819,6 +834,9 @@ mod tests {
         assert_eq!(deserialized.auto_select_model, original.auto_select_model);
         assert_eq!(deserialized.hotkey, original.hotkey);
         assert_eq!(deserialized.initial_prompt, original.initial_prompt);
+        assert_eq!(deserialized.beam_size, original.beam_size);
+        assert_eq!(deserialized.temperature_fallback, original.temperature_fallback);
+        assert_eq!(deserialized.vad_enabled, original.vad_enabled);
     }
 
     #[test]

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -674,8 +674,7 @@ mod tests {
 
     #[test]
     fn settings_effective_model_with_auto_select() {
-        let mut s = Settings::default();
-        s.auto_select_model = true;
+        let mut s = Settings { auto_select_model: true, ..Default::default() };
 
         s.language = Language::English;
         assert_eq!(s.effective_model(), WhisperModel::BaseEn);
@@ -692,10 +691,7 @@ mod tests {
 
     #[test]
     fn settings_effective_model_without_auto_select() {
-        let mut s = Settings::default();
-        s.auto_select_model = false;
-        s.whisper_model = WhisperModel::KbWhisperSmall;
-        s.language = Language::English; // shouldn't matter
+        let s = Settings { auto_select_model: false, whisper_model: WhisperModel::KbWhisperSmall, language: Language::English, ..Default::default() }; // language shouldn't matter
 
         assert_eq!(s.effective_model(), WhisperModel::KbWhisperSmall);
     }

--- a/src-tauri/src/settings/manager.rs
+++ b/src-tauri/src/settings/manager.rs
@@ -239,6 +239,29 @@ impl WhisperModel {
         }
     }
 
+    /// HuggingFace URL of the CoreML encoder bundle (`*-encoder.mlmodelc.zip`),
+    /// or `None` if this model has no CoreML encoder. CoreML encoders are
+    /// published alongside the GGML weights in the ggerganov/whisper.cpp repo;
+    /// the KB/NB fine-tunes live in their own repos and ship none.
+    #[cfg(target_os = "macos")]
+    pub fn coreml_encoder_url(&self) -> Option<String> {
+        let url = self.download_url();
+        let base = url
+            .strip_prefix("https://huggingface.co/ggerganov/whisper.cpp/")
+            .and(url.strip_suffix(".bin"))?;
+        Some(format!("{base}-encoder.mlmodelc.zip"))
+    }
+
+    /// Directory name whisper.cpp expects the CoreML encoder to have next to the
+    /// GGML file (`ggml-<name>-encoder.mlmodelc`). Mirrors whisper.cpp's own
+    /// `.bin` → `-encoder.mlmodelc` derivation. `None` if no CoreML encoder.
+    #[cfg(target_os = "macos")]
+    pub fn coreml_encoder_dirname(&self) -> Option<String> {
+        self.coreml_encoder_url()?;
+        let stem = self.ggml_filename().strip_suffix(".bin")?;
+        Some(format!("{stem}-encoder.mlmodelc"))
+    }
+
     /// Approximate download size in MB
     pub fn size_mb(&self) -> u32 {
         match self {
@@ -443,6 +466,34 @@ mod tests {
         assert!(!WhisperModel::LargeV3Turbo.is_english_only());
         assert!(!WhisperModel::KbWhisperTiny.is_english_only());
         assert!(!WhisperModel::NbWhisperBase.is_english_only());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn coreml_encoder_derivation() {
+        // OpenAI models: URL + on-disk dir name must match whisper.cpp's
+        // `.bin` → `-encoder.mlmodelc` derivation (verified against the
+        // ggerganov/whisper.cpp HF repo).
+        assert_eq!(
+            WhisperModel::Base.coreml_encoder_url().as_deref(),
+            Some("https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-encoder.mlmodelc.zip")
+        );
+        assert_eq!(
+            WhisperModel::Base.coreml_encoder_dirname().as_deref(),
+            Some("ggml-base-encoder.mlmodelc")
+        );
+        // `.en` is part of the name, not a quant suffix — must be preserved.
+        assert_eq!(
+            WhisperModel::BaseEn.coreml_encoder_dirname().as_deref(),
+            Some("ggml-base.en-encoder.mlmodelc")
+        );
+        assert_eq!(
+            WhisperModel::LargeV3Turbo.coreml_encoder_dirname().as_deref(),
+            Some("ggml-large-v3-turbo-encoder.mlmodelc")
+        );
+        // KB/NB fine-tunes live in other repos and have no CoreML encoder.
+        assert_eq!(WhisperModel::KbWhisperBase.coreml_encoder_url(), None);
+        assert_eq!(WhisperModel::NbWhisperSmall.coreml_encoder_dirname(), None);
     }
 
     #[test]

--- a/src-tauri/src/settings/store.rs
+++ b/src-tauri/src/settings/store.rs
@@ -111,9 +111,7 @@ mod tests {
     fn save_and_load_roundtrip() {
         with_temp_settings(|path| {
             let dir = path.parent().unwrap();
-            let mut settings = Settings::default();
-            settings.language = Language::Swedish;
-            settings.hotkey = "Alt+Space".to_string();
+            let settings = Settings { language: Language::Swedish, hotkey: "Alt+Space".to_string(), ..Default::default() };
 
             // Write directly to temp path (bypassing app_data_dir)
             fs::create_dir_all(dir).unwrap();
@@ -143,8 +141,7 @@ mod tests {
             fs::write(&path, serde_json::to_string_pretty(&initial).unwrap()).unwrap();
 
             // Save settings via merge
-            let mut settings = Settings::default();
-            settings.language = Language::Norwegian;
+            let settings = Settings { language: Language::Norwegian, ..Default::default() };
 
             // Simulate save's merge logic directly on this path
             let mut map: serde_json::Map<String, serde_json::Value> =

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -1,4 +1,4 @@
 pub mod model;
 pub mod whisper_backend;
 
-pub use whisper_backend::WhisperBackend;
+pub use whisper_backend::{TranscribeOptions, WhisperBackend};

--- a/src-tauri/src/transcription/model.rs
+++ b/src-tauri/src/transcription/model.rs
@@ -46,15 +46,20 @@ pub async fn download_model(
     model: WhisperModel,
     progress_callback: impl Fn(u64, u64) + Send + 'static,
 ) -> Result<PathBuf, DictationError> {
-    let path = model_path(model);
+    let dir = models_dir();
+    let path = dir.join(model.ggml_filename());
 
     if path.exists() {
         info!("Model {} already exists at {}", model.display_name(), path.display());
+        // Backfill the CoreML encoder for models downloaded before it was added.
+        #[cfg(target_os = "macos")]
+        if let Err(e) = ensure_coreml_encoder(model, &dir).await {
+            tracing::warn!("CoreML encoder not installed for {}: {e}", model.display_name());
+        }
         return Ok(path);
     }
 
     // Ensure directory exists
-    let dir = models_dir();
     std::fs::create_dir_all(&dir).map_err(|e| {
         DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
     })?;
@@ -115,5 +120,132 @@ pub async fn download_model(
     })?;
 
     info!("Model downloaded: {}", path.display());
+
+    // Best-effort: fetch the CoreML encoder so whisper.cpp runs the encoder on
+    // the Neural Engine instead of falling back to the Metal encoder. Non-fatal
+    // — transcription still works (just slower) if this fails.
+    #[cfg(target_os = "macos")]
+    if let Err(e) = ensure_coreml_encoder(model, &dir).await {
+        tracing::warn!("CoreML encoder not installed for {}: {e}", model.display_name());
+    }
+
     Ok(path)
+}
+
+/// Download and install the CoreML encoder (`ggml-<name>-encoder.mlmodelc`) next
+/// to the GGML file so whisper.cpp uses the Neural Engine for the encoder. The
+/// archive is streamed to a temp file, extracted with macOS' `ditto`, and the
+/// resulting `.mlmodelc` directory is moved into place atomically. Idempotent:
+/// returns early if the model has no CoreML encoder or it is already installed.
+#[cfg(target_os = "macos")]
+async fn ensure_coreml_encoder(
+    model: WhisperModel,
+    dir: &std::path::Path,
+) -> Result<(), DictationError> {
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let (Some(url), Some(dirname)) =
+        (model.coreml_encoder_url(), model.coreml_encoder_dirname())
+    else {
+        return Ok(()); // this model has no CoreML encoder
+    };
+
+    let dest = dir.join(&dirname);
+    if dest.exists() {
+        return Ok(()); // already installed
+    }
+
+    info!(
+        "Downloading CoreML encoder for {} from {url}",
+        model.display_name()
+    );
+
+    let client = reqwest::Client::new();
+    let response = client.get(&url).send().await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("CoreML download failed: {e}"))
+    })?;
+    if !response.status().is_success() {
+        return Err(DictationError::ModelDownloadFailed(format!(
+            "CoreML HTTP {}: {url}",
+            response.status()
+        )));
+    }
+
+    // Stream the zip to a temp file (encoders can be hundreds of MB).
+    let zip_path = dir.join(format!("{dirname}.zip.tmp"));
+    {
+        let mut file = tokio::fs::File::create(&zip_path).await.map_err(|e| {
+            DictationError::ModelDownloadFailed(format!("CoreML temp create failed: {e}"))
+        })?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| {
+                DictationError::ModelDownloadFailed(format!("CoreML download error: {e}"))
+            })?;
+            file.write_all(&chunk).await.map_err(|e| {
+                DictationError::ModelDownloadFailed(format!("CoreML write error: {e}"))
+            })?;
+        }
+        file.flush().await.map_err(|e| {
+            DictationError::ModelDownloadFailed(format!("CoreML flush error: {e}"))
+        })?;
+    }
+
+    // Extract into a temp dir with ditto (macOS' canonical zip tool); the
+    // archive contains the `.mlmodelc` directory at its root.
+    let extract_dir = dir.join(format!(".{dirname}.extract"));
+    let _ = tokio::fs::remove_dir_all(&extract_dir).await; // clear any stale temp
+    tokio::fs::create_dir_all(&extract_dir).await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("CoreML temp dir failed: {e}"))
+    })?;
+
+    // Extract, then move the `.mlmodelc` into place.
+    let install = match run_ditto(&zip_path, &extract_dir).await {
+        Ok(()) => {
+            let extracted = extract_dir.join(&dirname);
+            if extracted.exists() {
+                tokio::fs::rename(&extracted, &dest).await.map_err(|e| {
+                    DictationError::ModelDownloadFailed(format!(
+                        "CoreML move into place failed: {e}"
+                    ))
+                })
+            } else {
+                Err(DictationError::ModelDownloadFailed(format!(
+                    "CoreML archive did not contain {dirname}"
+                )))
+            }
+        }
+        Err(e) => Err(e),
+    };
+
+    // Clean up the temp zip and extraction dir regardless of outcome.
+    let _ = tokio::fs::remove_file(&zip_path).await;
+    let _ = tokio::fs::remove_dir_all(&extract_dir).await;
+
+    install?;
+    info!("CoreML encoder installed: {}", dest.display());
+    Ok(())
+}
+
+/// Run `ditto -x -k <zip> <dest_dir>` to expand a PKZip archive.
+#[cfg(target_os = "macos")]
+async fn run_ditto(
+    zip: &std::path::Path,
+    dest_dir: &std::path::Path,
+) -> Result<(), DictationError> {
+    let status = tokio::process::Command::new("/usr/bin/ditto")
+        .arg("-x")
+        .arg("-k")
+        .arg(zip)
+        .arg(dest_dir)
+        .status()
+        .await
+        .map_err(|e| DictationError::ModelDownloadFailed(format!("ditto failed to run: {e}")))?;
+    if !status.success() {
+        return Err(DictationError::ModelDownloadFailed(format!(
+            "ditto exited unsuccessfully ({status})"
+        )));
+    }
+    Ok(())
 }

--- a/src-tauri/src/transcription/model.rs
+++ b/src-tauri/src/transcription/model.rs
@@ -117,6 +117,21 @@ pub async fn download_vad_model(
     Ok(path)
 }
 
+/// Best-effort install of the CoreML encoder for an already-downloaded model —
+/// backfills models obtained before CoreML support existed, so their encoder
+/// runs on the Neural Engine. No-op off macOS, for models without a CoreML
+/// encoder, or if the encoder is already installed.
+#[cfg(target_os = "macos")]
+pub async fn backfill_coreml_encoder(model: WhisperModel) -> Result<(), DictationError> {
+    ensure_coreml_encoder(model, &models_dir()).await
+}
+
+/// Non-macOS stub (no CoreML).
+#[cfg(not(target_os = "macos"))]
+pub async fn backfill_coreml_encoder(_model: WhisperModel) -> Result<(), DictationError> {
+    Ok(())
+}
+
 /// Download a model from HuggingFace
 pub async fn download_model(
     model: WhisperModel,

--- a/src-tauri/src/transcription/model.rs
+++ b/src-tauri/src/transcription/model.rs
@@ -41,6 +41,82 @@ pub fn is_model_downloaded(model: WhisperModel) -> bool {
     model_path(model).exists()
 }
 
+/// Silero VAD model filename (used by whisper.cpp's built-in VAD).
+pub const VAD_MODEL_FILENAME: &str = "ggml-silero-v5.1.2.bin";
+
+/// Full path to the Silero VAD model in the models directory.
+pub fn vad_model_path() -> PathBuf {
+    models_dir().join(VAD_MODEL_FILENAME)
+}
+
+/// Whether the Silero VAD model has been downloaded.
+pub fn is_vad_model_downloaded() -> bool {
+    vad_model_path().exists()
+}
+
+/// Download the Silero VAD model used by whisper.cpp's built-in VAD (~0.9 MB).
+pub async fn download_vad_model(
+    progress_callback: impl Fn(u64, u64) + Send + 'static,
+) -> Result<PathBuf, DictationError> {
+    const VAD_MODEL_URL: &str =
+        "https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin";
+
+    let path = vad_model_path();
+    if path.exists() {
+        return Ok(path);
+    }
+
+    let dir = models_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
+    })?;
+
+    info!("Downloading Silero VAD model from {VAD_MODEL_URL}");
+
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(VAD_MODEL_URL)
+        .send()
+        .await
+        .map_err(|e| DictationError::ModelDownloadFailed(format!("VAD download failed: {e}")))?;
+    if !response.status().is_success() {
+        return Err(DictationError::ModelDownloadFailed(format!(
+            "VAD HTTP {}: {VAD_MODEL_URL}",
+            response.status()
+        )));
+    }
+
+    let total_size = response.content_length().unwrap_or(0);
+    let mut downloaded: u64 = 0;
+    let tmp_path = path.with_extension("bin.tmp");
+    let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to create temp file: {e}"))
+    })?;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .map_err(|e| DictationError::ModelDownloadFailed(format!("VAD download error: {e}")))?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| DictationError::ModelDownloadFailed(format!("Write error: {e}")))?;
+        downloaded += chunk.len() as u64;
+        progress_callback(downloaded, total_size);
+    }
+    file.flush()
+        .await
+        .map_err(|e| DictationError::ModelDownloadFailed(format!("Flush error: {e}")))?;
+    drop(file);
+    tokio::fs::rename(&tmp_path, &path).await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to rename temp file: {e}"))
+    })?;
+
+    info!("VAD model downloaded: {}", path.display());
+    Ok(path)
+}
+
 /// Download a model from HuggingFace
 pub async fn download_model(
     model: WhisperModel,

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -2,7 +2,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tracing::{info, warn};
-use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+use whisper_rs::{
+    FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
+};
 #[cfg(feature = "diarization")]
 use whisper_rs::{DtwMode, DtwParameters};
 
@@ -19,6 +21,10 @@ use crate::transcription::model;
 pub struct WhisperBackend {
     /// Loaded whisper context (model weights). None until load_model() is called.
     context: Mutex<Option<WhisperContext>>,
+    /// Reusable inference state, kept warm across utterances so we don't pay
+    /// whisper/Metal state-init (kernel compile + GPU buffer alloc) on every
+    /// call. Created lazily on first transcription; reset to None on model reload.
+    state: Mutex<Option<WhisperState>>,
     /// Currently loaded model
     loaded_model: Mutex<Option<WhisperModel>>,
     /// Abort flag — set to true to cancel in-progress transcription
@@ -34,6 +40,7 @@ impl WhisperBackend {
     pub fn new() -> Self {
         Self {
             context: Mutex::new(None),
+            state: Mutex::new(None),
             loaded_model: Mutex::new(None),
             abort_flag: Arc::new(AtomicBool::new(false)),
         }
@@ -67,11 +74,16 @@ impl WhisperBackend {
             model_path.display()
         );
 
-        // Enable DTW for attention-based token timestamps (used by --diarize).
-        // DTW is incompatible with flash_attn; flash_attn defaults to false so this is safe.
+        // Flash attention is an exact (not approximate) attention kernel that is
+        // accelerated on Metal — a free speedup with identical output. It is
+        // incompatible with DTW: whisper.cpp silently disables DTW token
+        // timestamps when flash_attn is on. So the default (dictation) build
+        // turns it ON, and the diarization build leaves it off and uses DTW for
+        // attention-based token timestamps (used by --diarize) instead.
         let ctx_params = {
-            #[allow(unused_mut)]
             let mut p = WhisperContextParameters::default();
+            #[cfg(not(feature = "diarization"))]
+            p.flash_attn(true);
             #[cfg(feature = "diarization")]
             p.dtw_parameters(DtwParameters {
                 mode: DtwMode::ModelPreset {
@@ -94,6 +106,9 @@ impl WhisperBackend {
 
         *self.context.lock().unwrap() = Some(ctx);
         *self.loaded_model.lock().unwrap() = Some(whisper_model);
+        // Drop any state bound to the previous model; the next transcription
+        // lazily creates a fresh state for the new context.
+        *self.state.lock().unwrap() = None;
 
         info!("Model loaded: {}", whisper_model.display_name());
         Ok(())
@@ -116,6 +131,41 @@ impl WhisperBackend {
             self.load_model(desired_model)?;
         }
         Ok(())
+    }
+
+    /// Pre-compile inference kernels and warm the reusable state by running a
+    /// short silent inference. Call once after the model is loaded so the first
+    /// real dictation doesn't pay the Metal/CoreML kernel-compile + state-init
+    /// cost. Best-effort — a failure here is non-fatal.
+    pub fn warmup(&self, language: Language) -> Result<(), DictationError> {
+        // 0.1s of silence is enough to build the compute graph and compile the
+        // kernels (whisper pads to its 30s window internally regardless).
+        let silence = vec![0.0f32; 1600];
+        self.transcribe_sync(&silence, language)?;
+        info!("Whisper warmup complete");
+        Ok(())
+    }
+
+    /// Run a closure with the reusable warm state, creating it lazily and
+    /// locking the context only briefly to do so. The context mutex is NOT held
+    /// across the closure, so a long-running inference no longer blocks model
+    /// (re)load. The state lock serializes concurrent transcriptions, which is
+    /// required anyway — a single whisper state cannot run two `full()` calls at
+    /// once.
+    fn with_warm_state<R>(
+        &self,
+        f: impl FnOnce(&mut WhisperState) -> Result<R, DictationError>,
+    ) -> Result<R, DictationError> {
+        let mut state_guard = self.state.lock().unwrap();
+        if state_guard.is_none() {
+            let ctx_guard = self.context.lock().unwrap();
+            let ctx = ctx_guard.as_ref().ok_or(DictationError::ModelNotLoaded)?;
+            let st = ctx.create_state().map_err(|e| {
+                DictationError::TranscriptionFailed(format!("Failed to create whisper state: {e}"))
+            })?;
+            *state_guard = Some(st);
+        }
+        f(state_guard.as_mut().unwrap())
     }
 
     /// Run transcription on loaded model (blocking — call from spawn_blocking)
@@ -151,16 +201,11 @@ impl WhisperBackend {
             return Err(DictationError::NoAudioCaptured);
         }
 
-        let ctx_guard = self.context.lock().unwrap();
-        let ctx = ctx_guard
-            .as_ref()
-            .ok_or(DictationError::ModelNotLoaded)?;
-
         let model = self
             .loaded_model()
             .ok_or(DictationError::ModelNotLoaded)?;
 
-        let n_threads = (num_cpus::get() / 2).max(1) as i32;
+        let n_threads = whisper_threads();
         let no_speech_thold = model.no_speech_threshold();
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
@@ -180,15 +225,11 @@ impl WhisperBackend {
         params.set_progress_callback_safe(on_progress);
 
         // Abort callback: DISABLED — whisper-rs 0.15.1 set_abort_callback_safe()
-        // causes error -6 on all models. Without this callback, request_abort() sets
-        // the flag but nothing reads it during inference. If whisper hangs, the context
-        // mutex remains held until inference completes naturally. The tokio timeout in
-        // commands.rs / main.rs will return an error to the caller, but the blocking
-        // task continues running in the background.
+        // causes error -6 on all models. request_abort() sets the flag but nothing
+        // reads it during inference; the tokio timeout in commands.rs / main.rs
+        // returns an error while the blocking task runs to completion.
         // TODO: Restore when whisper-rs fixes the FFI callback lifetime issue.
         self.abort_flag.store(false, Ordering::SeqCst);
-        // let abort = Arc::clone(&self.abort_flag);
-        // params.set_abort_callback_safe(move || abort.load(Ordering::SeqCst));
 
         info!(
             "Starting local transcription: {} samples, {} threads, lang={:?}, no_speech_thold={}",
@@ -198,28 +239,25 @@ impl WhisperBackend {
             no_speech_thold
         );
 
-        let mut state = ctx.create_state().map_err(|e| {
-            DictationError::TranscriptionFailed(format!("Failed to create whisper state: {e}"))
-        })?;
+        self.with_warm_state(|state| {
+            state.full(params, audio).map_err(|e| {
+                DictationError::TranscriptionFailed(format!("Whisper inference failed: {e}"))
+            })?;
 
-        state.full(params, audio).map_err(|e| {
-            DictationError::TranscriptionFailed(format!("Whisper inference failed: {e}"))
-        })?;
-
-        let n_segments = state.full_n_segments();
-
-        let mut transcript = String::new();
-        for i in 0..n_segments {
-            if let Some(segment) = state.get_segment(i) {
-                if let Ok(text) = segment.to_str() {
-                    transcript.push_str(text);
+            let n_segments = state.full_n_segments();
+            let mut transcript = String::new();
+            for i in 0..n_segments {
+                if let Some(segment) = state.get_segment(i) {
+                    if let Ok(text) = segment.to_str() {
+                        transcript.push_str(text);
+                    }
                 }
             }
-        }
 
-        let result = transcript.trim().to_string();
-        info!("Local transcription complete: {} chars", result.len());
-        Ok(result)
+            let result = transcript.trim().to_string();
+            info!("Local transcription complete: {} chars", result.len());
+            Ok(result)
+        })
     }
 
     /// Transcribe audio and return per-segment timestamps.
@@ -256,16 +294,11 @@ impl WhisperBackend {
         t_offset: f64,
         prompt: Option<&str>,
     ) -> Result<Vec<(f64, f64, String)>, DictationError> {
-        let ctx_guard = self.context.lock().unwrap();
-        let ctx = ctx_guard
-            .as_ref()
-            .ok_or(DictationError::ModelNotLoaded)?;
-
         let model = self
             .loaded_model()
             .ok_or(DictationError::ModelNotLoaded)?;
 
-        let n_threads = (num_cpus::get() / 2).max(1) as i32;
+        let n_threads = whisper_threads();
         let no_speech_thold = model.no_speech_threshold();
 
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
@@ -284,39 +317,70 @@ impl WhisperBackend {
             params.set_initial_prompt(p);
         }
 
-        let mut state = ctx.create_state().map_err(|e| {
-            DictationError::TranscriptionFailed(format!("Failed to create whisper state: {e}"))
-        })?;
+        self.with_warm_state(|state| {
+            state.full(params, audio).map_err(|e| {
+                DictationError::TranscriptionFailed(format!("Whisper inference failed: {e}"))
+            })?;
 
-        state.full(params, audio).map_err(|e| {
-            DictationError::TranscriptionFailed(format!("Whisper inference failed: {e}"))
-        })?;
+            let n_segments = state.full_n_segments();
+            let mut results = Vec::with_capacity(n_segments as usize);
 
-        let n_segments = state.full_n_segments();
-        let mut results = Vec::with_capacity(n_segments as usize);
+            for i in 0..n_segments {
+                let Some(segment) = state.get_segment(i) else { continue };
 
-        for i in 0..n_segments {
-            let Some(segment) = state.get_segment(i) else { continue };
+                let text = segment.to_str().unwrap_or("").trim().to_string();
+                if text.is_empty() {
+                    continue;
+                }
 
-            let text = segment.to_str().unwrap_or("").trim().to_string();
-            if text.is_empty() {
-                continue;
+                // Derive segment timing from DTW timestamps on first/last non-special
+                // token. DTW timestamps are in centiseconds; -1 means not computed.
+                // Fall back to segment-level timestamps if DTW was not available.
+                let (t0, t1) = dtw_segment_timestamps(&segment, t_offset).unwrap_or_else(|| {
+                    let t0 = segment.start_timestamp() as f64 / 100.0 + t_offset;
+                    let t1 = segment.end_timestamp() as f64 / 100.0 + t_offset;
+                    (t0, t1)
+                });
+
+                results.push((t0, t1, text));
             }
 
-            // Derive segment timing from DTW timestamps on first/last non-special token.
-            // DTW timestamps are in centiseconds; -1 means not computed.
-            // Fall back to segment-level timestamps if DTW was not available.
-            let (t0, t1) = dtw_segment_timestamps(&segment, t_offset).unwrap_or_else(|| {
-                let t0 = segment.start_timestamp() as f64 / 100.0 + t_offset;
-                let t1 = segment.end_timestamp() as f64 / 100.0 + t_offset;
-                (t0, t1)
-            });
-
-            results.push((t0, t1, text));
-        }
-
-        Ok(results)
+            Ok(results)
+        })
     }
+}
+
+/// Choose a whisper CPU thread count. `num_cpus` counts all cores; on Apple
+/// Silicon that includes the slower efficiency cores, and scheduling whisper's
+/// CPU work onto them hurts latency. Target the performance-core count
+/// (`hw.perflevel0.logicalcpu`) on macOS, falling back to `num_cpus / 2`
+/// elsewhere or if the sysctl is unavailable. Computed once and cached.
+fn whisper_threads() -> i32 {
+    use std::sync::OnceLock;
+    static THREADS: OnceLock<i32> = OnceLock::new();
+    *THREADS.get_or_init(|| {
+        #[cfg(target_os = "macos")]
+        if let Some(n) = macos_perf_cores() {
+            return n;
+        }
+        (num_cpus::get() / 2).max(1) as i32
+    })
+}
+
+/// Number of performance (P) cores on Apple Silicon via sysctl. Returns `None`
+/// on Intel Macs (key absent) or if the query fails.
+#[cfg(target_os = "macos")]
+fn macos_perf_cores() -> Option<i32> {
+    let out = std::process::Command::new("sysctl")
+        .args(["-n", "hw.perflevel0.logicalcpu"])
+        .output()
+        .ok()?;
+    String::from_utf8(out.stdout)
+        .ok()?
+        .trim()
+        .parse::<i32>()
+        .ok()
+        .filter(|&n| n > 0)
 }
 
 /// Extract segment timing from per-token DTW timestamps.

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -177,6 +177,17 @@ impl WhisperBackend {
         self.transcribe_sync_with_progress(audio, language, |_| {})
     }
 
+    /// Like `transcribe_sync` but with an optional initial prompt to prime the
+    /// decoder with domain vocabulary (names, jargon) for better accuracy.
+    pub fn transcribe_sync_with_prompt(
+        &self,
+        audio: &[f32],
+        language: Language,
+        prompt: Option<&str>,
+    ) -> Result<String, DictationError> {
+        self.transcribe_sync_with_progress_and_prompt(audio, language, prompt, |_| {})
+    }
+
     /// Run transcription with a progress callback that receives percentage (0–100).
     /// The callback is invoked from the whisper.cpp inference thread.
     pub fn transcribe_sync_with_progress(

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use tracing::{info, warn};
 use whisper_rs::{
     FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
+    WhisperVadParams,
 };
 #[cfg(feature = "diarization")]
 use whisper_rs::{DtwMode, DtwParameters};
@@ -11,6 +12,36 @@ use whisper_rs::{DtwMode, DtwParameters};
 use crate::error::DictationError;
 use crate::settings::{Language, WhisperModel};
 use crate::transcription::model;
+
+/// Per-transcription tuning knobs (opt-in modes). `Default` reproduces the
+/// fast, robust dictation defaults: greedy decoding, temperature fallback on,
+/// no VAD, no prompt.
+#[derive(Clone)]
+pub struct TranscribeOptions {
+    /// Optional decoder priming prompt (domain vocabulary).
+    pub prompt: Option<String>,
+    /// Beam width: 0/1 = greedy (fastest); >=2 enables beam search (more
+    /// accurate on hard audio, ~3-5x slower).
+    pub beam_size: u32,
+    /// Allow whisper's temperature fallback (re-decode harder segments at
+    /// higher temperature). `true` preserves robustness; `false` caps
+    /// worst-case latency.
+    pub temperature_fallback: bool,
+    /// Path to a Silero VAD ggml model to skip non-speech regions, or `None`
+    /// to disable VAD. The caller must ensure the file exists.
+    pub vad_model_path: Option<String>,
+}
+
+impl Default for TranscribeOptions {
+    fn default() -> Self {
+        Self {
+            prompt: None,
+            beam_size: 0,
+            temperature_fallback: true,
+            vad_model_path: None,
+        }
+    }
+}
 
 /// Local transcription backend using whisper-rs (whisper.cpp bindings)
 /// Uses GGML model files with optional CoreML acceleration on macOS.
@@ -177,17 +208,6 @@ impl WhisperBackend {
         self.transcribe_sync_with_progress(audio, language, |_| {})
     }
 
-    /// Like `transcribe_sync` but with an optional initial prompt to prime the
-    /// decoder with domain vocabulary (names, jargon) for better accuracy.
-    pub fn transcribe_sync_with_prompt(
-        &self,
-        audio: &[f32],
-        language: Language,
-        prompt: Option<&str>,
-    ) -> Result<String, DictationError> {
-        self.transcribe_sync_with_progress_and_prompt(audio, language, prompt, |_| {})
-    }
-
     /// Run transcription with a progress callback that receives percentage (0–100).
     /// The callback is invoked from the whisper.cpp inference thread.
     pub fn transcribe_sync_with_progress(
@@ -208,6 +228,23 @@ impl WhisperBackend {
         prompt: Option<&str>,
         on_progress: impl FnMut(i32) + 'static,
     ) -> Result<String, DictationError> {
+        let opts = TranscribeOptions {
+            prompt: prompt.map(str::to_string),
+            ..Default::default()
+        };
+        self.transcribe_sync_with_options(audio, language, &opts, on_progress)
+    }
+
+    /// Core transcription entry point. Honors the opt-in [`TranscribeOptions`]
+    /// (prompt, beam search, temperature fallback, VAD). Blocking — call from
+    /// spawn_blocking.
+    pub fn transcribe_sync_with_options(
+        &self,
+        audio: &[f32],
+        language: Language,
+        opts: &TranscribeOptions,
+        on_progress: impl FnMut(i32) + 'static,
+    ) -> Result<String, DictationError> {
         if audio.is_empty() {
             return Err(DictationError::NoAudioCaptured);
         }
@@ -219,20 +256,49 @@ impl WhisperBackend {
         let n_threads = whisper_threads();
         let no_speech_thold = model.no_speech_threshold();
 
-        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        // Beam search (opt-in) is more accurate on hard audio but several times
+        // slower; greedy best_of=1 is the fast default.
+        let strategy = if opts.beam_size >= 2 {
+            SamplingStrategy::BeamSearch {
+                beam_size: opts.beam_size as i32,
+                patience: -1.0, // whisper default
+            }
+        } else {
+            SamplingStrategy::Greedy { best_of: 1 }
+        };
+
+        let mut params = FullParams::new(strategy);
         params.set_language(language.whisper_code());
         params.set_n_threads(n_threads);
         params.set_temperature(0.0);
-        params.set_temperature_inc(0.2);
+        // Temperature fallback re-decodes hard segments at higher temperature.
+        // Disabling it caps worst-case latency at the cost of some robustness.
+        params.set_temperature_inc(if opts.temperature_fallback { 0.2 } else { 0.0 });
         params.set_translate(false);
         params.set_no_timestamps(true);
         params.set_print_progress(false);
         params.set_print_realtime(false);
         params.set_no_speech_thold(no_speech_thold);
         params.set_suppress_blank(true);
-        if let Some(p) = prompt {
-            params.set_initial_prompt(p);
+        if let Some(p) = &opts.prompt {
+            if !p.is_empty() {
+                params.set_initial_prompt(p);
+            }
         }
+
+        // VAD (opt-in): skip non-speech regions. The model path MUST be set
+        // before enable_vad — whisper-rs panics otherwise. The caller guarantees
+        // the file exists.
+        if let Some(vad_path) = &opts.vad_model_path {
+            params.set_vad_model_path(Some(vad_path.as_str()));
+            let mut vad = WhisperVadParams::new();
+            vad.set_threshold(0.5);
+            vad.set_min_silence_duration(200); // ms — slightly longer for dictation
+            vad.set_speech_pad(50); // ms — avoid clipping word edges
+            params.set_vad_params(vad);
+            params.enable_vad(true);
+        }
+
         params.set_progress_callback_safe(on_progress);
 
         // Abort callback: DISABLED — whisper-rs 0.15.1 set_abort_callback_safe()
@@ -243,11 +309,13 @@ impl WhisperBackend {
         self.abort_flag.store(false, Ordering::SeqCst);
 
         info!(
-            "Starting local transcription: {} samples, {} threads, lang={:?}, no_speech_thold={}",
+            "Starting local transcription: {} samples, {} threads, lang={:?}, beam={}, temp_fallback={}, vad={}",
             audio.len(),
             n_threads,
             language,
-            no_speech_thold
+            opts.beam_size,
+            opts.temperature_fallback,
+            opts.vad_model_path.is_some()
         );
 
         self.with_warm_state(|state| {

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -60,6 +60,10 @@ pub struct WhisperBackend {
     loaded_model: Mutex<Option<WhisperModel>>,
     /// Abort flag — set to true to cancel in-progress transcription
     abort_flag: Arc<AtomicBool>,
+    /// Serializes model (re)loads so concurrent `ensure_model()` callers — e.g.
+    /// the startup warmup thread and the first dictation — don't load the same
+    /// model twice or race the warm-state reset.
+    load_lock: Mutex<()>,
 }
 
 // WhisperContext is Send+Sync (it wraps a C pointer that's thread-safe)
@@ -74,6 +78,7 @@ impl WhisperBackend {
             state: Mutex::new(None),
             loaded_model: Mutex::new(None),
             abort_flag: Arc::new(AtomicBool::new(false)),
+            load_lock: Mutex::new(()),
         }
     }
 
@@ -135,11 +140,17 @@ impl WhisperBackend {
             DictationError::TranscriptionFailed(format!("Failed to load model: {e}"))
         })?;
 
-        *self.context.lock().unwrap() = Some(ctx);
-        *self.loaded_model.lock().unwrap() = Some(whisper_model);
-        // Drop any state bound to the previous model; the next transcription
-        // lazily creates a fresh state for the new context.
-        *self.state.lock().unwrap() = None;
+        // Publish the new context atomically with respect to warm-state users:
+        // hold the state lock across the swap so no in-flight transcription can
+        // observe the new context (via loaded_model) while still holding the old
+        // warm state. The next transcription lazily recreates the state. Lock
+        // order is state -> context, matching with_warm_state().
+        {
+            let mut state = self.state.lock().unwrap();
+            *self.context.lock().unwrap() = Some(ctx);
+            *self.loaded_model.lock().unwrap() = Some(whisper_model);
+            *state = None;
+        }
 
         info!("Model loaded: {}", whisper_model.display_name());
         Ok(())
@@ -155,8 +166,11 @@ impl WhisperBackend {
         self.loaded_model() != Some(desired_model)
     }
 
-    /// Ensure the correct model is loaded
+    /// Ensure the correct model is loaded. Serialized via `load_lock` so two
+    /// concurrent callers don't both load the same model; the loser re-checks
+    /// after acquiring the lock and finds the model already loaded.
     pub fn ensure_model(&self, desired_model: WhisperModel) -> Result<(), DictationError> {
+        let _load = self.load_lock.lock().unwrap();
         if self.needs_reload(desired_model) {
             info!("Loading model: {:?}", desired_model);
             self.load_model(desired_model)?;
@@ -257,10 +271,13 @@ impl WhisperBackend {
         let no_speech_thold = model.no_speech_threshold();
 
         // Beam search (opt-in) is more accurate on hard audio but several times
-        // slower; greedy best_of=1 is the fast default.
-        let strategy = if opts.beam_size >= 2 {
+        // slower; greedy best_of=1 is the fast default. Clamp to a sane range —
+        // an unbounded beam_size from config would overflow the i32 cast or make
+        // whisper.cpp unusably slow.
+        let beam_size = opts.beam_size.clamp(0, 8);
+        let strategy = if beam_size >= 2 {
             SamplingStrategy::BeamSearch {
-                beam_size: opts.beam_size as i32,
+                beam_size: beam_size as i32,
                 patience: -1.0, // whisper default
             }
         } else {

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -9,6 +9,9 @@
     setInitialPrompt,
     setShowOverlay,
     setWhisperModel,
+    setBeamSize,
+    setTemperatureFallback,
+    setVadEnabled,
     getBuildInfo,
     getModelInfo,
     getLoadedModel,
@@ -166,6 +169,24 @@
     if (!settings) return;
     const value = (e.target as HTMLTextAreaElement).value;
     await setInitialPrompt(value);
+    settings = await getSettings();
+  }
+
+  async function onBeamSizeChange(e: Event) {
+    const value = Number((e.target as HTMLSelectElement).value);
+    await setBeamSize(value);
+    settings = await getSettings();
+  }
+
+  async function onTemperatureFallbackToggle() {
+    if (!settings) return;
+    await setTemperatureFallback(!settings.temperature_fallback);
+    settings = await getSettings();
+  }
+
+  async function onVadToggle() {
+    if (!settings) return;
+    await setVadEnabled(!settings.vad_enabled);
     settings = await getSettings();
   }
 
@@ -597,6 +618,40 @@
           ></textarea>
           <div class="hotkey-hint">Prime the transcriber with names, jargon, or preferred spellings.</div>
         </div>
+
+        <div class="field">
+          <label for="beam-size">Decoding mode</label>
+          <select id="beam-size" value={settings.beam_size} onchange={onBeamSizeChange}>
+            <option value={0}>Greedy (fast)</option>
+            <option value={5}>Beam search (accurate)</option>
+          </select>
+        </div>
+
+        <div class="field-row">
+          <label>Temperature fallback</label>
+          <div
+            class="toggle"
+            class:active={settings.temperature_fallback}
+            onclick={onTemperatureFallbackToggle}
+            role="switch"
+            tabindex="0"
+            aria-checked={settings.temperature_fallback}
+          ></div>
+        </div>
+        <div class="hotkey-hint">Re-decode hard segments; off = faster, less robust.</div>
+
+        <div class="field-row">
+          <label>Voice activity detection</label>
+          <div
+            class="toggle"
+            class:active={settings.vad_enabled}
+            onclick={onVadToggle}
+            role="switch"
+            tabindex="0"
+            aria-checked={settings.vad_enabled}
+          ></div>
+        </div>
+        <div class="hotkey-hint">Skip silence; downloads a small model on first enable.</div>
 
         <div class="field">
           <label>Version</label>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -6,6 +6,7 @@
     setHotkeyMode,
     setHotkey,
     setAutoPaste,
+    setInitialPrompt,
     setShowOverlay,
     setWhisperModel,
     getBuildInfo,
@@ -158,6 +159,13 @@
   async function onShowOverlayToggle() {
     if (!settings) return;
     await setShowOverlay(!settings.show_overlay);
+    settings = await getSettings();
+  }
+
+  async function onInitialPromptBlur(e: Event) {
+    if (!settings) return;
+    const value = (e.target as HTMLTextAreaElement).value;
+    await setInitialPrompt(value);
     settings = await getSettings();
   }
 
@@ -578,6 +586,19 @@
         </div>
 
         <div class="field">
+          <label for="initial-prompt">Initial prompt</label>
+          <textarea
+            id="initial-prompt"
+            class="initial-prompt-input"
+            rows="3"
+            value={settings.initial_prompt}
+            onblur={onInitialPromptBlur}
+            placeholder="Prime the transcriber with names, jargon, or preferred spellings."
+          ></textarea>
+          <div class="hotkey-hint">Prime the transcriber with names, jargon, or preferred spellings.</div>
+        </div>
+
+        <div class="field">
           <label>Version</label>
           <div class="version-text">
             {#if buildInfo}
@@ -908,6 +929,24 @@
   .version-text {
     color: var(--text-muted);
     font-size: 12px;
+  }
+
+  .initial-prompt-input {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+  }
+
+  .initial-prompt-input:focus {
+    border-color: var(--accent);
   }
 
   .loading {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,6 +21,9 @@ export interface Settings {
   auto_select_model: boolean;
   hotkey: string;
   initial_prompt: string;
+  beam_size: number;
+  temperature_fallback: boolean;
+  vad_enabled: boolean;
 }
 
 export interface BuildInfo {
@@ -81,6 +84,18 @@ export async function setInitialPrompt(prompt: string): Promise<void> {
 
 export async function setShowOverlay(enabled: boolean): Promise<void> {
   return invoke("set_show_overlay", { enabled });
+}
+
+export async function setBeamSize(beamSize: number): Promise<void> {
+  return invoke("set_beam_size", { beamSize });
+}
+
+export async function setTemperatureFallback(enabled: boolean): Promise<void> {
+  return invoke("set_temperature_fallback", { enabled });
+}
+
+export async function setVadEnabled(enabled: boolean): Promise<void> {
+  return invoke("set_vad_enabled", { enabled });
 }
 
 export async function getModelInfo(): Promise<WhisperModel[]> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,7 @@ export interface Settings {
   auto_paste: boolean;
   auto_select_model: boolean;
   hotkey: string;
+  initial_prompt: string;
 }
 
 export interface BuildInfo {
@@ -72,6 +73,10 @@ export async function setHotkey(shortcut: string): Promise<void> {
 
 export async function setAutoPaste(enabled: boolean): Promise<void> {
   return invoke("set_auto_paste", { enabled });
+}
+
+export async function setInitialPrompt(prompt: string): Promise<void> {
+  return invoke("set_initial_prompt", { prompt });
 }
 
 export async function setShowOverlay(enabled: boolean): Promise<void> {


### PR DESCRIPTION
Consolidated transcription performance + accuracy overhaul. This single PR is rebased on current `main` (incl. #59) and supersedes #60, #62, and #61 (closed) so CI can gate it under the strict ruleset. Cross-model reviewed by Codex (gpt-5.5, xhigh); all findings fixed.

**Verified locally on the integrated tree:** `cargo clippy --all-targets -D warnings` clean, **183 tests pass**, compiles under default and `--features diarization`, no conflicts with #59.

## Tier 1 — hot-path latency
Flash attention on the dictation context; warm `WhisperState` reuse (context mutex no longer held across inference); thread count from the Apple-Silicon P-core count; background model preload + warmup; single-pass resampling (resampler moved out of the realtime cpal callback → raw device-rate mono buffered, resampled once on stop; alloc-free downmix incl. i16); `[profile.release]` (opt-level 3, thin LTO, codegen-units 1).

## Tier 2 — CoreML encoder
Download + `ditto`-extract the `*-encoder.mlmodelc` next to the `.bin` so the encoder runs on the ANE; backfilled for already-downloaded models (CLI + startup).

## Tier 3 — lossless accuracy
`initial_prompt` setting (CLI + Settings UI) wired into both live dictation paths; new `large-v3-turbo-q8_0` model that reuses the f16 turbo's CoreML encoder.

## Tier 4 — opt-in modes (default-OFF)
Beam search (`beam_size`, clamped 0..=8), temperature-fallback toggle, and built-in Silero VAD (`set_vad_model_path` before `enable_vad`; model auto-fetched; gracefully skipped if absent) — via a `TranscribeOptions` struct.

## Codex review fixes
Atomic model-reload + `load_lock` (no double-load / stale-state race); CoreML backfill gap closed; `beam_size` overflow clamp; alloc-free i16 capture path + 6 tests.

## Also folds in
- The pre-existing clippy-cleanup (was #61) → `clippy --all-targets -D warnings` now clean.

**On-device follow-ups** (can't be verified headless): benchmark with `cargo tauri build --debug`; confirm `loading Core ML model from …` in the log; spot-check the opt-in modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
