### PR TITLE
feat(cli): headless Linux CLI build via `gui` feature gate (#66)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,10 +11,13 @@ tauri-build = { version = "2", features = [] }
 chrono = "0.4"
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
-tauri-plugin-global-shortcut = "2"
-tauri-plugin-autostart = "2"
-tauri-plugin-store = "2"
+# Tauri (GUI) deps are optional behind the default `gui` feature so the CLI
+# (`transcribe`, `record`, diarization) can build headless on Linux.
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"], optional = true }
+tauri-plugin-global-shortcut = { version = "2", optional = true }
+tauri-plugin-autostart = { version = "2", optional = true }
+tauri-plugin-store = { version = "2", optional = true }
+tauri-plugin-dialog = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -27,7 +30,6 @@ tracing-appender = "0.2"
 cpal = "0.15"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 arboard = "3"
-enigo = { version = "0.6", features = ["serde"] }
 dirs = "6"
 futures-util = "0.3"
 num_cpus = "1"
@@ -37,7 +39,6 @@ clap_mangen = "0.2"
 ctrlc = "3"
 indicatif = "0.17"
 notify = { version = "7", default-features = false }
-tauri-plugin-dialog = "2"
 symphonia = { version = "0.5", features = ["aac", "alac", "flac", "mp3", "pcm", "vorbis", "isomp4", "mkv", "ogg"] }
 rubato = "0.14"
 
@@ -50,6 +51,8 @@ ndarray = { version = "0.17", optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.15", features = ["coreml", "metal"] }
 notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+# enigo (auto-paste) only builds/needs the GUI on desktop targets.
+enigo = { version = "0.6", features = ["serde"] }
 
 core-graphics = "0.24"
 core-foundation = "0.10"
@@ -60,12 +63,28 @@ block = "0.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 whisper-rs = { version = "0.15" }
 notify = { version = "7" }
+enigo = { version = "0.6", features = ["serde"] }
+
+# Linux: headless CLI / batch transcription only (no GUI, no auto-paste).
+# whisper-rs is declared per-target because macOS/Windows enable Metal/CoreML;
+# Linux uses the CPU backend (Vulkan is a separate, currently-broken opt-in).
+[target.'cfg(target_os = "linux")'.dependencies]
+whisper-rs = { version = "0.15" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
 
 [features]
-default = ["custom-protocol"]
+default = ["gui", "custom-protocol"]
+# `gui` pulls in Tauri and the desktop app entry point. Disable it
+# (`--no-default-features`) for a headless CLI build (e.g. on Linux).
+gui = [
+    "dep:tauri",
+    "dep:tauri-plugin-global-shortcut",
+    "dep:tauri-plugin-autostart",
+    "dep:tauri-plugin-store",
+    "dep:tauri-plugin-dialog",
+]
 custom-protocol = ["tauri/custom-protocol"]
 diarization = ["dep:ort", "dep:rustfft", "dep:kodama", "dep:ndarray"]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,9 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+# Optional + gated under `gui` so the headless build doesn't compile Tauri
+# tooling. build.rs only calls tauri_build::build() under `feature = "gui"`.
+tauri-build = { version = "2", features = [], optional = true }
 chrono = "0.4"
 
 [dependencies]
@@ -79,13 +81,17 @@ default = ["gui", "custom-protocol"]
 # `gui` pulls in Tauri and the desktop app entry point. Disable it
 # (`--no-default-features`) for a headless CLI build (e.g. on Linux).
 gui = [
+    "dep:tauri-build",
     "dep:tauri",
     "dep:tauri-plugin-global-shortcut",
     "dep:tauri-plugin-autostart",
     "dep:tauri-plugin-store",
     "dep:tauri-plugin-dialog",
 ]
-custom-protocol = ["tauri/custom-protocol"]
+# Weak dep: only enables tauri's custom-protocol when tauri is already pulled in
+# (via `gui`). Keeps a headless `--no-default-features` build Tauri-free even if
+# `custom-protocol` is enabled on its own.
+custom-protocol = ["tauri?/custom-protocol"]
 diarization = ["dep:ort", "dep:rustfft", "dep:kodama", "dep:ndarray"]
 
 # Optimize the Rust DSP/glue (rubato resampler, symphonia decode, audio mixing)

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -15,5 +15,8 @@ fn main() {
         chrono::Utc::now().format("%Y-%m-%d")
     );
 
-    tauri_build::build()
+    // Only run the Tauri build script for the GUI build. A headless CLI build
+    // (`--no-default-features`, e.g. on Linux) has no Tauri context to generate.
+    #[cfg(feature = "gui")]
+    tauri_build::build();
 }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -19,8 +19,9 @@ Sagascript is a privacy-first dictation app that transcribes speech to text \
 using local Whisper models. It runs as a macOS menu bar app (GUI) or as a \
 standalone CLI tool.
 
-When invoked without a subcommand, Sagascript launches the GUI. \
-Use any subcommand below to operate in CLI mode instead.
+When invoked without a subcommand, the desktop build launches the GUI; \
+the headless CLI build prints this help. Use any subcommand below to \
+operate in CLI mode.
 
 Workflow:
   1. Download a model:   sagascript download-model base.en

--- a/src-tauri/src/cli/transcribe.rs
+++ b/src-tauri/src/cli/transcribe.rs
@@ -229,7 +229,7 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         beam_size: args.beam_size.unwrap_or(if stored.beam_size >= 2 {
             stored.beam_size
         } else {
-            crate::commands::FILE_TRANSCRIBE_BEAM
+            crate::transcription::FILE_TRANSCRIBE_BEAM
         }),
         temperature_fallback: stored.temperature_fallback,
         vad_model_path,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 use crate::app_controller::{AppController, AppState};
 use crate::audio::decoder;
 use crate::settings::{HotkeyMode, Language, Settings, WhisperModel};
-use crate::transcription::{model, TranscribeOptions, WhisperBackend};
+use crate::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
 
 /// Build the per-transcription options from the current settings. Resolves the
 /// VAD model path only when VAD is enabled and the model is present (otherwise
@@ -39,11 +39,6 @@ pub(crate) fn build_transcribe_options(settings: &Settings) -> TranscribeOptions
         vad_model_path,
     }
 }
-
-/// Default beam-search width for file transcription. Unlike live dictation,
-/// file transcription is not latency-sensitive, and beam search markedly
-/// reduces greedy-decoder repetition loops — so files default to beam search.
-pub(crate) const FILE_TRANSCRIBE_BEAM: u32 = 5;
 
 /// Like [`build_transcribe_options`] but for file transcription: defaults to
 /// beam search for quality (unless the user explicitly set a beam width), and

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,51 +1,111 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+// In the headless (CLI-only) build, the desktop/GUI integrations are gated out,
+// so a number of GUI-only helpers (whisper warmup/abort, model reload checks,
+// settings helpers) are legitimately unused. Allow that rather than scattering
+// per-item cfgs through the core modules the GUI still needs.
+#![cfg_attr(not(feature = "gui"), allow(dead_code))]
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "gui"))]
 #[macro_use]
 extern crate objc;
 
-mod app_controller;
+// CLI + core modules — always compiled (the headless Linux CLI build relies on
+// these being Tauri-free).
 mod audio;
 mod cli;
-mod commands;
 #[cfg(feature = "diarization")]
 pub mod diarization;
 mod error;
-mod events;
-mod hotkey;
-mod logging;
-mod overlay;
-mod paste;
-mod platform;
 mod settings;
 mod transcription;
 
+// File-logging service used by the desktop app only (the CLI logs via
+// tracing_subscriber to stderr).
+#[cfg(feature = "gui")]
+mod logging;
+
+// GUI-only modules — these reference Tauri (directly or transitively) and the
+// desktop integrations (auto-paste, tray, hotkey, overlay), so they are gated
+// behind the `gui` feature and excluded from the headless build.
+#[cfg(feature = "gui")]
+mod app_controller;
+#[cfg(feature = "gui")]
+mod commands;
+#[cfg(feature = "gui")]
+mod events;
+#[cfg(feature = "gui")]
+mod hotkey;
+#[cfg(feature = "gui")]
+mod overlay;
+#[cfg(feature = "gui")]
+mod paste;
+#[cfg(feature = "gui")]
+mod platform;
+
+use tracing_subscriber::EnvFilter;
+
+#[cfg(feature = "gui")]
 use std::sync::{Arc, Mutex};
+#[cfg(feature = "gui")]
 use std::time::Duration;
 
 /// Maximum time to wait for whisper inference before aborting (seconds)
+#[cfg(feature = "gui")]
 const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 
+#[cfg(feature = "gui")]
 use tauri::{
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
     Emitter, Manager,
 };
+#[cfg(feature = "gui")]
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+#[cfg(feature = "gui")]
 use tracing::{error, info, warn};
-use tracing_subscriber::EnvFilter;
 
+#[cfg(feature = "gui")]
 use app_controller::{AppController, HotkeyDownResult};
+#[cfg(feature = "gui")]
 use commands::{SharedController, SharedWhisper};
+#[cfg(feature = "gui")]
 use transcription::WhisperBackend;
 
 /// Minimum recording duration before we allow stop (300ms)
+#[cfg(feature = "gui")]
 const MIN_RECORDING_MS: u64 = 300;
 
 /// Shared tray status menu item for updating from anywhere
+#[cfg(feature = "gui")]
 type SharedStatusItem = Mutex<Option<MenuItem<tauri::Wry>>>;
 
+/// Headless entry point: CLI-only build (no Tauri / GUI). Used for the Linux
+/// batch-transcription build. A bare invocation (no subcommand) prints help,
+/// since there is no GUI to launch.
+#[cfg(not(feature = "gui"))]
+fn main() {
+    use clap::CommandFactory;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    match cli::try_parse() {
+        Some(parsed) => cli::run(parsed),
+        None => {
+            // No subcommand and no GUI to fall back to — show help and exit non-zero.
+            let _ = cli::Cli::command().print_help();
+            println!();
+            std::process::exit(2);
+        }
+    }
+}
+
+#[cfg(feature = "gui")]
 fn main() {
     // CLI mode: if a subcommand is given, run CLI and exit
     if let Some(parsed) = cli::try_parse() {
@@ -330,6 +390,7 @@ fn main() {
 }
 
 /// Update the tray tooltip, title, and status menu item to reflect current state
+#[cfg(feature = "gui")]
 fn update_tray_status(app: &tauri::AppHandle, state: &str) {
     let (tooltip, title, menu_text) = match state {
         "recording" => ("Sagascript - Recording...", "Rec", "Recording..."),
@@ -347,6 +408,7 @@ fn update_tray_status(app: &tauri::AppHandle, state: &str) {
 }
 
 /// Update the tray status menu item and tooltip to show the last transcription
+#[cfg(feature = "gui")]
 fn update_tray_last_result(app: &tauri::AppHandle, text: &str) {
     let display = if text.len() > 60 {
         format!("{}...", &text[..57])
@@ -362,6 +424,7 @@ fn update_tray_last_result(app: &tauri::AppHandle, text: &str) {
 }
 
 /// Helper to update the status menu item text
+#[cfg(feature = "gui")]
 fn set_status_menu_text(app: &tauri::AppHandle, text: &str) {
     let guard = app.state::<SharedStatusItem>().lock().unwrap().clone();
     if let Some(item) = guard {
@@ -370,6 +433,7 @@ fn set_status_menu_text(app: &tauri::AppHandle, text: &str) {
 }
 
 /// Open or focus the main window, optionally navigating to a specific tab
+#[cfg(feature = "gui")]
 fn open_settings_window(app: &tauri::AppHandle, tab: Option<&str>) {
     info!("Opening main window (tab: {:?})", tab);
 
@@ -412,6 +476,7 @@ fn open_settings_window(app: &tauri::AppHandle, tab: Option<&str>) {
 }
 
 /// Handle hotkey release: stop recording for push-to-talk mode
+#[cfg(feature = "gui")]
 fn handle_hotkey_release(
     app: &tauri::AppHandle,
     ctrl: &tauri::State<'_, SharedController>,
@@ -430,6 +495,7 @@ fn handle_hotkey_release(
 
 /// Stop recording, enforce minimum duration, and spawn transcription.
 /// Shared by both push-to-talk (on key-up) and toggle (on second key-down).
+#[cfg(feature = "gui")]
 fn stop_recording_and_transcribe(
     app: &tauri::AppHandle,
     ctrl: &tauri::State<'_, SharedController>,
@@ -578,6 +644,7 @@ fn stop_recording_and_transcribe(
 
 /// Watch the settings file for external changes and hot-reload into the running app.
 /// Handles hotkey re-registration and emits a settings-changed event to the frontend.
+#[cfg(feature = "gui")]
 fn start_settings_watcher(app: tauri::AppHandle) {
     use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
     use std::sync::mpsc;

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -1,4 +1,4 @@
 pub mod model;
 pub mod whisper_backend;
 
-pub use whisper_backend::{TranscribeOptions, WhisperBackend};
+pub use whisper_backend::{FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};

--- a/src-tauri/src/transcription/whisper_backend.rs
+++ b/src-tauri/src/transcription/whisper_backend.rs
@@ -13,6 +13,11 @@ use crate::error::DictationError;
 use crate::settings::{Language, WhisperModel};
 use crate::transcription::model;
 
+/// Default beam width for file (non-live) transcription. File transcription
+/// isn't latency-sensitive, so a wider beam trades speed for fewer repetition
+/// loops. Shared by the GUI file-transcribe command and the `transcribe` CLI.
+pub const FILE_TRANSCRIBE_BEAM: u32 = 5;
+
 /// Per-transcription tuning knobs (opt-in modes). `Default` reproduces the
 /// fast, robust dictation defaults: greedy decoding, temperature fallback on,
 /// no VAD, no prompt.


### PR DESCRIPTION
Closes #66.

Makes the `transcribe` / `record` / diarization CLI buildable **headless (no Tauri)** so it can run as a batch transcription + diarization-benchmark farm on Linux (the "M5" box / AMD Strix Halo). Today the CLI is linked into the Tauri/macOS binary and won't build off macOS/Windows.

## Approach — feature-gate, macOS GUI build stays byte-identical

- **`Cargo.toml`**: all `tauri*` deps become `optional` behind a new **default `gui`** feature; `enigo` (auto-paste) moves into the macOS/Windows target blocks (off Linux); a `cfg(target_os = "linux")` block provides `whisper-rs` (CPU backend).
- **`build.rs`**: `tauri_build::build()` only runs under `feature = "gui"`.
- **`main.rs`**: GUI modules, imports, helpers and the Tauri `main()` are gated behind `gui`; a headless `#[cfg(not(feature = "gui"))] fn main()` runs the CLI (a bare invocation prints help, since there's no GUI to launch). A crate-level `allow(dead_code)` scoped to the headless build covers GUI-only helpers without scattering cfgs through core modules.
- **`FILE_TRANSCRIBE_BEAM`** moves from the (GUI-gated) `commands` module to the Tauri-free `transcription` module — the CLI `transcribe` path uses it.

The core (`cli/ transcription/ audio/ settings/ diarization/`) was already Tauri-free; this just draws the build boundary.

## Headless build

```
cargo build --no-default-features --features diarization   # Linux batch farm
cargo build --no-default-features                          # bare transcribe/record
```

## Verification (on macOS)

| Config | Compiles | clippy `-D warnings` | tests |
|---|---|---|---|
| Default (GUI) | ✓ | ✓ | 183 pass |
| `--no-default-features` | ✓ | — | — |
| `--no-default-features --features diarization` | ✓ | ✓ | 218 pass |

The "headless on macOS" build exercises the same feature-gating the Linux build uses; the Linux build itself was proven by the original M5 spike in the issue.

## Out of scope / follow-ups
- whisper-rs `vulkan` feature (large-model GPU speed on Linux) is broken upstream on renamed ggml symbols — separable; CPU works today.
- Formalizing as a `sagascript-core` lib + `sagascript-cli` bin workspace split (issue step 3) and making `cpal`/`record` optional (step 4) — deferred; this PR is the MVP that unblocks the batch farm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)