### PR TITLE
feat(linux): experimental Tauri GUI build (#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,76 @@ jobs:
           echo "JSON: $RESULT"
           echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['text']; assert d['language']=='no'; assert d['duration_seconds']>0"
 
+  check-linux:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libasound2-dev \
+            build-essential \
+            file \
+            xdotool
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Cargo registry and target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: linux-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            linux-cargo-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      # GUI build: compiles the cfg(target_os = "linux") Tauri path so it can't
+      # silently break on a future PR (the macOS/Windows runners never see it).
+      - name: Cargo check (GUI)
+        working-directory: src-tauri
+        run: cargo check --features gui
+
+      - name: Cargo clippy (GUI)
+        working-directory: src-tauri
+        run: cargo clippy --features gui -- -D warnings
+
+      # Headless CLI/batch build (no Tauri) — the other Linux target.
+      - name: Cargo check (headless)
+        working-directory: src-tauri
+        run: cargo check --no-default-features
+
+      - name: Cargo clippy (headless)
+        working-directory: src-tauri
+        run: cargo clippy --no-default-features -- -D warnings
+
+      - name: Cargo test (headless)
+        working-directory: src-tauri
+        run: cargo test --no-default-features
+
   check-windows:
     runs-on: windows-latest
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dictate anywhere. Privately. A lightweight menu bar app for macOS and Windows. P
 
 - **macOS**: macOS 13.0+ (Apple Silicon or Intel)
 - **Windows**: Windows 10+
+- **Linux** (experimental): X11 session; GTK/WebKit dev libraries + `xdotool` — see [Linux notes](docs/linux-notes.md)
 - Rust 1.75+ (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`)
 - Node.js 20+ (`brew install node` on macOS, or download from [nodejs.org](https://nodejs.org) on Windows)
 - Tauri CLI (`cargo install tauri-cli`)
@@ -43,7 +44,7 @@ cargo tauri dev
 cargo tauri build
 ```
 
-On macOS the `.app` bundle will be in `src-tauri/target/release/bundle/macos/`. On Windows the installer will be in `src-tauri/target/release/bundle/msi/` or `src-tauri/target/release/bundle/nsis/`.
+On macOS the `.app` bundle will be in `src-tauri/target/release/bundle/macos/`. On Windows the installer will be in `src-tauri/target/release/bundle/msi/` or `src-tauri/target/release/bundle/nsis/`. On Linux the `.deb`/`.rpm`/`.AppImage` will be in `src-tauri/target/release/bundle/` (see [Linux notes](docs/linux-notes.md)).
 
 ## CLI usage
 
@@ -93,6 +94,7 @@ Sagascript needs the following permissions (macOS will prompt you on first use):
 ## Documentation
 
 - [Installation guide](docs/installation.md) -- detailed install instructions for macOS and Windows
+- [Linux notes](docs/linux-notes.md) -- experimental Linux build, prerequisites, and known limitations
 - [Windows-specific notes](docs/windows-notes.md) -- feature comparison, known limitations, and troubleshooting
 
 ## Contributing

--- a/docs/linux-notes.md
+++ b/docs/linux-notes.md
@@ -1,0 +1,83 @@
+# Linux-Specific Notes
+
+> **Status: experimental.** The Linux GUI build is community-contributed (issue
+> #44) and verified on Ubuntu / X11 / GNOME. Other distros, desktop
+> environments, and Wayland have not been tested. The headless CLI build
+> (`--no-default-features`) is the well-trodden path on Linux; the GUI build is
+> newer.
+
+## Differences from macOS
+
+| Feature | macOS | Linux |
+|---|---|---|
+| Transcription backend | Metal + Core ML (GPU) | CPU only (Vulkan is a broken upstream opt-in) |
+| Permissions required | Microphone, Accessibility, Input Monitoring | None (no TCC-style gate) |
+| Tray behavior | Menu bar icon | System tray via libayatana-appindicator |
+| Default hotkey | Ctrl+Shift+Space | Ctrl+Shift+Space |
+| Paste shortcut | Cmd+V (enigo) | Ctrl+V (via `xdotool`) |
+| Recording overlay | Shown | **Disabled** (see limitations) |
+| Settings path | `~/Library/Application Support/com.sagascript.app/` | `~/.config/com.sagascript.app/` |
+| Model path | `~/.sagascript/models/` | `~/.sagascript/models/` |
+| Installer format | `.dmg` | `.deb` / `.rpm` / `.AppImage` |
+
+## Prerequisites
+
+System libraries for the Tauri GUI (Debian/Ubuntu names):
+
+```bash
+sudo apt-get install libwebkit2gtk-4.1-dev build-essential curl wget file \
+  libssl-dev libayatana-appindicator3-dev librsvg2-dev
+```
+
+Auto-paste shells out to `xdotool` (X11):
+
+```bash
+sudo apt-get install xdotool
+```
+
+Then the usual Rust + Node toolchain (see the main README) and:
+
+```bash
+npm install
+cargo tauri build      # GUI app (.deb/.rpm/.AppImage in src-tauri/target/release/bundle/)
+```
+
+For a **headless CLI / batch-transcription** build with no GUI or audio-capture
+system libraries beyond ALSA:
+
+```bash
+cargo build --release --no-default-features                 # transcribe / record
+cargo build --release --no-default-features --features diarization   # + speaker diarization
+```
+
+## Known limitations
+
+- **CPU-only transcription.** No Metal/Core ML. Prefer `base` or `small` models;
+  `large` will be slow. (whisper-rs's `vulkan` feature is currently broken
+  upstream.)
+- **Recording overlay disabled.** Creating the transparent, always-on-top
+  overlay window triggers an X11 window-lifecycle crash that terminates the app
+  on several compositors, so the visual recording indicator is suppressed.
+  Transcription and auto-paste are unaffected — watch the tray tooltip/title for
+  state instead.
+- **Auto-paste requires `xdotool` and X11.** enigo's X11 backend leaves the
+  Control modifier unmapped, so paste is simulated via `xdotool key ctrl+v`.
+  **Wayland is not supported** for auto-paste yet (it would need `ydotool` and
+  `wl-clipboard`). On Wayland you can still disable auto-paste and paste manually
+  from the clipboard.
+- **No auto-updater.** Check the [Releases page](https://github.com/Magnus-Gille/sagascript/releases).
+
+## Troubleshooting
+
+### Auto-paste does nothing
+
+Confirm `xdotool` is installed and you're on an X11 session
+(`echo $XDG_SESSION_TYPE` should print `x11`). On Wayland, disable auto-paste in
+settings and paste manually — the transcription is always copied to the
+clipboard.
+
+### Tray icon missing
+
+Install `libayatana-appindicator3-dev` (build) / the matching runtime package,
+and ensure your desktop environment has an app-indicator/system-tray extension
+enabled (GNOME needs the AppIndicator extension).

--- a/docs/linux-notes.md
+++ b/docs/linux-notes.md
@@ -16,8 +16,8 @@
 | Default hotkey | Ctrl+Shift+Space | Ctrl+Shift+Space |
 | Paste shortcut | Cmd+V (enigo) | Ctrl+V (via `xdotool`) |
 | Recording overlay | Shown | **Disabled** (see limitations) |
-| Settings path | `~/Library/Application Support/com.sagascript.app/` | `~/.config/com.sagascript.app/` |
-| Model path | `~/.sagascript/models/` | `~/.sagascript/models/` |
+| Settings path | `~/Library/Application Support/com.sagascript.app/` | `~/.local/share/com.sagascript.app/` (`$XDG_DATA_HOME`) |
+| Model path | `~/Library/Application Support/Sagascript/Models/` | `~/.local/share/Sagascript/Models/` (`$XDG_DATA_HOME`) |
 | Installer format | `.dmg` | `.deb` / `.rpm` / `.AppImage` |
 
 ## Prerequisites

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sagascript"
 version = "0.0.1"
 edition = "2021"
-description = "Low-latency macOS/Windows dictation app"
+description = "Low-latency macOS/Linux/Windows dictation app"
 license = "MIT"
 build = "build.rs"
 
@@ -67,11 +67,16 @@ whisper-rs = { version = "0.15" }
 notify = { version = "7" }
 enigo = { version = "0.6", features = ["serde"] }
 
-# Linux: headless CLI / batch transcription only (no GUI, no auto-paste).
+# Linux: supports both the headless CLI/batch build (`--no-default-features`)
+# and an experimental Tauri GUI build (`--features gui`, the default).
 # whisper-rs is declared per-target because macOS/Windows enable Metal/CoreML;
 # Linux uses the CPU backend (Vulkan is a separate, currently-broken opt-in).
+# No `enigo` here: its X11 backend leaves the Control modifier unmapped, so the
+# GUI auto-paste shells out to `xdotool` instead (see paste/service.rs).
+# `notify` gets its default (inotify) backend on Linux for the settings watcher.
 [target.'cfg(target_os = "linux")'.dependencies]
 whisper-rs = { version = "0.15" }
+notify = { version = "7" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -987,7 +987,11 @@ pub async fn get_platform() -> Result<String, String> {
     {
         Ok("windows".to_string())
     }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
+    {
+        Ok("linux".to_string())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         Ok("unknown".to_string())
     }

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1,19 +1,34 @@
 use tauri::Manager;
-use tracing::{error, info};
+use tracing::info;
+#[cfg(not(target_os = "linux"))]
+use tracing::error;
 
 const OVERLAY_LABEL: &str = "overlay";
 
-/// Show the recording overlay window (create lazily on first call)
+/// Show the recording overlay window (create lazily on first call).
+///
+/// Disabled on Linux: creating the transparent, always-on-top overlay window
+/// triggers an X11 window-lifecycle crash that terminates the app on several
+/// compositors. Transcription and auto-paste still work — only the visual
+/// recording indicator is suppressed. See issue #44.
 pub fn show(app: &tauri::AppHandle) {
-    if let Some(window) = app.get_webview_window(OVERLAY_LABEL) {
-        let _ = window.show();
-        #[cfg(target_os = "macos")]
-        macos_order_front(&window);
-        info!("Overlay shown (existing window)");
-    } else {
-        match create_overlay(app) {
-            Ok(_) => info!("Overlay created and shown"),
-            Err(e) => error!("Failed to create overlay: {e}"),
+    #[cfg(target_os = "linux")]
+    {
+        let _ = app;
+        info!("Overlay disabled on Linux (avoids X11 window-lifecycle crash)");
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        if let Some(window) = app.get_webview_window(OVERLAY_LABEL) {
+            let _ = window.show();
+            #[cfg(target_os = "macos")]
+            macos_order_front(&window);
+            info!("Overlay shown (existing window)");
+        } else {
+            match create_overlay(app) {
+                Ok(_) => info!("Overlay created and shown"),
+                Err(e) => error!("Failed to create overlay: {e}"),
+            }
         }
     }
 }
@@ -26,6 +41,7 @@ pub fn hide(app: &tauri::AppHandle) {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
 fn create_overlay(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     // Calculate horizontal center position
     let (x, _screen_width) = if let Some(monitor) = app.primary_monitor()? {

--- a/src-tauri/src/paste/service.rs
+++ b/src-tauri/src/paste/service.rs
@@ -1,4 +1,8 @@
 use arboard::Clipboard;
+// enigo is the input simulator on macOS/Windows. On Linux its X11 backend leaves
+// the Control modifier unmapped (paste silently fails), so we shell out to
+// xdotool instead and don't depend on enigo there.
+#[cfg(not(target_os = "linux"))]
 use enigo::{Enigo, Keyboard, Settings as EnigoSettings, Key, Direction};
 use tracing::info;
 #[cfg(target_os = "macos")]
@@ -7,7 +11,7 @@ use tracing::warn;
 use crate::error::DictationError;
 
 /// Service for pasting transcribed text into the active application
-/// Uses clipboard + simulated Cmd+V (macOS) or Ctrl+V (Windows)
+/// Uses clipboard + simulated Cmd+V (macOS) or Ctrl+V (Windows/Linux)
 pub struct PasteService;
 
 impl PasteService {
@@ -71,6 +75,7 @@ impl PasteService {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
 fn simulate_paste() -> Result<(), DictationError> {
     let mut enigo = Enigo::new(&EnigoSettings::default())
         .map_err(|e| DictationError::PasteError(format!("Failed to create input simulator: {e}")))?;
@@ -78,10 +83,7 @@ fn simulate_paste() -> Result<(), DictationError> {
     #[cfg(target_os = "macos")]
     let modifier = Key::Meta; // Cmd
 
-    #[cfg(target_os = "windows")]
-    let modifier = Key::Control;
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(not(target_os = "macos"))]
     let modifier = Key::Control;
 
     enigo
@@ -95,5 +97,31 @@ fn simulate_paste() -> Result<(), DictationError> {
         .map_err(|e| DictationError::PasteError(format!("Key release failed: {e}")))?;
 
     info!("Paste keystroke simulated");
+    Ok(())
+}
+
+/// Linux: simulate Ctrl+V via the `xdotool` CLI. enigo's X11 backend leaves the
+/// Control modifier unmapped, so we shell out instead. Requires `xdotool` and an
+/// X11 session (Wayland needs `ydotool`, which is not yet wired up).
+#[cfg(target_os = "linux")]
+fn simulate_paste() -> Result<(), DictationError> {
+    use std::process::Command;
+
+    let status = Command::new("xdotool")
+        .args(["key", "--clearmodifiers", "ctrl+v"])
+        .status()
+        .map_err(|e| {
+            DictationError::PasteError(format!(
+                "Failed to launch xdotool (install it with `apt install xdotool`): {e}"
+            ))
+        })?;
+
+    if !status.success() {
+        return Err(DictationError::PasteError(format!(
+            "xdotool exited unsuccessfully ({status})"
+        )));
+    }
+
+    info!("Paste keystroke simulated (xdotool)");
     Ok(())
 }

--- a/src-tauri/src/platform/linux.rs
+++ b/src-tauri/src/platform/linux.rs
@@ -1,0 +1,26 @@
+// Linux-specific platform code
+//
+// These stubs exist for API parity with the macOS platform module. Linux has
+// no macOS-style accessibility (TCC) permission gate or dock activation policy:
+// global input simulation works without an explicit per-app grant. They are not
+// currently called (commands.rs short-circuits the permission queries on
+// non-macOS targets) but are kept for parity and future use.
+
+/// Linux doesn't gate keyboard simulation behind an accessibility permission.
+#[allow(dead_code)]
+pub fn is_accessibility_trusted() -> bool {
+    true
+}
+
+/// No-op on Linux — there is no accessibility permission to request.
+#[allow(dead_code)]
+pub fn request_accessibility_permission() {
+    // Nothing to do
+}
+
+/// No-op on Linux — there is no dock activation policy to set (the app lives in
+/// the system tray via libayatana-appindicator).
+#[allow(dead_code)]
+pub fn set_activation_policy_accessory() {
+    // Nothing to do
+}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -3,3 +3,6 @@ pub mod macos;
 
 #[cfg(target_os = "windows")]
 pub mod windows;
+
+#[cfg(target_os = "linux")]
+pub mod linux;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,11 @@
         "type": "downloadBootstrapper"
       },
       "allowDowngrades": false
+    },
+    "linux": {
+      "deb": {
+        "depends": ["xdotool"]
+      }
     }
   },
   "plugins": {}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,9 @@
     "linux": {
       "deb": {
         "depends": ["xdotool"]
+      },
+      "rpm": {
+        "depends": ["xdotool"]
       }
     }
   },


### PR DESCRIPTION
Enables an **experimental Tauri GUI build on Linux** (X11), building on #66's headless feature-gating. Addresses #44, where @apnea contributed a working Ubuntu/X11/GNOME port. Their original patch predates #66, so this re-implements the same approach against the current architecture (Tauri behind the `gui` feature, `whisper-rs` CPU already wired for Linux).

## What changed
- **Cargo.toml** — Linux target block gains `notify` (inotify backend for the settings watcher). No `enigo` on Linux: its X11 backend leaves the Control modifier unmapped, so auto-paste uses `xdotool` instead.
- **paste/service.rs** — Linux auto-paste shells out to `xdotool key --clearmodifiers ctrl+v`; the enigo import and enigo path are gated to `not(target_os = "linux")`.
- **overlay.rs** — recording overlay **disabled on Linux**. Creating the transparent, always-on-top overlay window triggers an X11 window-lifecycle crash that terminates the app on several compositors. Transcription + auto-paste are unaffected (state shows in the tray tooltip/title instead).
- **platform/linux.rs** — stub module mirroring `windows.rs` (no accessibility gate / dock policy on Linux).
- **commands.rs** — `get_platform()` returns `"linux"`. The frontend already gates macOS-only permission UI behind `platform === "macos"`, so onboarding/permission steps are skipped automatically.
- **tauri.conf.json** — Linux `.deb` depends on `xdotool`; `macOSPrivateApi` retained (it's macOS-only and harmless on Linux — the contributor's original removal would have broken the macOS overlay).
- **docs/linux-notes.md + README** — prerequisites, build steps (GUI + headless), and known limitations.

## Verification
- ✅ macOS default/GUI: `cargo clippy --all-targets -- -D warnings` clean
- ✅ 183 unit tests pass
- ✅ CI gate is `cargo clippy -- -D warnings` (default features) on macOS + Windows — unaffected

## ⚠️ Pending
All Linux-specific code is `cfg(target_os = "linux")`-gated, so **it cannot be compiled from macOS** — final compile + runtime verification on a Linux machine is still required before this is non-experimental. @apnea, if you're able to build this branch on your Ubuntu setup, that would confirm the reconciliation against the new architecture.

## Out of scope (noted, not fixed here)
`cargo clippy --no-default-features --features diarization --all-targets -- -D warnings` surfaces ~4 pre-existing lints in `src/diarization/segmentation.rs` (`needless_range_loop`, `manual_range_contains`) — unrelated to this PR, only triggered by `--all-targets` (which CI doesn't run). Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
