### PR TITLE
Hardening sprint: crash safety, durability, observability (46 audit findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,38 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
 
+      # `diarization` feature coverage (#68): gates ~1,771 lines of speaker
+      # diarization code (crates/sagascript-core/src/diarization/) and its
+      # CLI wiring (--diarize / --diarize-threshold in sagascript-cli) that
+      # otherwise never compile in CI. All diarization unit tests are pure
+      # (math/serialization/clustering logic) — none load an ONNX model file
+      # at runtime — so no continue-on-error/skip gating is needed here,
+      # unlike the Tier 2 transcription smoke tests below which do need a
+      # downloaded whisper model.
+      - name: Cargo check (sagascript-core, diarization)
+        working-directory: src-tauri
+        run: cargo check -p sagascript-core --features diarization
+
+      - name: Cargo check (sagascript-cli, diarization)
+        working-directory: src-tauri
+        run: cargo check -p sagascript-cli --features diarization
+
+      - name: Cargo test (sagascript-core, diarization)
+        working-directory: src-tauri
+        run: cargo test -p sagascript-core --features diarization
+
+      - name: Cargo test (sagascript-cli, diarization)
+        working-directory: src-tauri
+        run: cargo test -p sagascript-cli --features diarization
+
+      - name: Cargo clippy (sagascript-core, diarization)
+        working-directory: src-tauri
+        run: cargo clippy -p sagascript-core --features diarization --all-targets -- -D warnings
+
+      - name: Cargo clippy (sagascript-cli, diarization)
+        working-directory: src-tauri
+        run: cargo clippy -p sagascript-cli --features diarization --all-targets -- -D warnings
+
       - name: Svelte check
         run: npx svelte-check --tsconfig ./tsconfig.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4081,7 +4081,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "uuid",
 ]

--- a/src-tauri/crates/sagascript-cli/Cargo.toml
+++ b/src-tauri/crates/sagascript-cli/Cargo.toml
@@ -24,7 +24,6 @@ uuid = { version = "1", features = ["v4"] }
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Live-recording support (the `record` subcommand). Optional so a pure

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -98,7 +98,7 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         }
     }
 
-    let audio = capture.stop_capture();
+    let audio = capture.stop_capture()?;
     let duration = audio.len() as f64 / TARGET_SAMPLE_RATE as f64;
     eprintln!("Captured {:.1}s of audio ({} samples)", duration, audio.len());
 

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -10,9 +10,9 @@ use sagascript_core::error::DictationError;
 use sagascript_core::transcription::model;
 use sagascript_core::transcription::WhisperBackend;
 
-use sagascript_core::settings::WhisperModel;
-
-use super::transcribe::{copy_to_clipboard, model_id_string, parse_language, parse_model};
+use super::transcribe::{
+    copy_to_clipboard, model_id_string, parse_language, resolve_effective_model,
+};
 
 #[derive(Args)]
 pub struct RecordArgs {
@@ -51,16 +51,12 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
 
     // Only validate model if we're going to transcribe
     let model = if !save_only {
-        let m = match &args.model {
-            Some(s) => parse_model(s)?,
-            None => {
-                if stored.auto_select_model {
-                    WhisperModel::recommended(language)
-                } else {
-                    stored.whisper_model
-                }
-            }
-        };
+        let m = resolve_effective_model(
+            args.model.as_deref(),
+            language,
+            stored.auto_select_model,
+            stored.whisper_model,
+        )?;
         if !model::is_model_downloaded(m) {
             return Err(DictationError::TranscriptionFailed(format!(
                 "Model '{}' is not downloaded. Run: sagascript download-model {}",

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -39,6 +39,7 @@ pub struct TranscribeArgs {
     /// Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.
     #[cfg(feature = "diarization")]
     #[arg(long, value_name = "THRESHOLD", default_value = "0.85",
+          value_parser = parse_diarize_threshold,
           help = "Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.")]
     pub diarize_threshold: f32,
 
@@ -72,16 +73,12 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         Some(l) => parse_language(l)?,
         None => stored.language,
     };
-    let model = match &args.model {
-        Some(m) => parse_model(m)?,
-        None => {
-            if stored.auto_select_model {
-                WhisperModel::recommended(language)
-            } else {
-                stored.whisper_model
-            }
-        }
-    };
+    let model = resolve_effective_model(
+        args.model.as_deref(),
+        language,
+        stored.auto_select_model,
+        stored.whisper_model,
+    )?;
 
     // Check model is downloaded
     if !model::is_model_downloaded(model) {
@@ -280,6 +277,28 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     Ok(())
 }
 
+/// Validates a `--diarize-threshold` value: must parse as a finite f32 in the
+/// documented 0.0-2.0 range. NaN/infinite or out-of-range values silently
+/// produce degenerate agglomerative clustering downstream, so reject them at
+/// the CLI boundary rather than at the clustering call site.
+#[cfg(feature = "diarization")]
+fn parse_diarize_threshold(s: &str) -> Result<f32, String> {
+    let value: f32 = s
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+    if !value.is_finite() {
+        return Err(format!(
+            "diarize-threshold must be a finite number, got '{s}'"
+        ));
+    }
+    if !(0.0..=2.0).contains(&value) {
+        return Err(format!(
+            "diarize-threshold must be between 0.0 and 2.0, got {value}"
+        ));
+    }
+    Ok(value)
+}
+
 pub fn parse_language(s: &str) -> Result<Language, DictationError> {
     match s {
         "en" | "english" => Ok(Language::English),
@@ -292,14 +311,34 @@ pub fn parse_language(s: &str) -> Result<Language, DictationError> {
     }
 }
 
-#[allow(dead_code)]
-pub fn resolve_model(
-    model_str: Option<&str>,
+/// Resolves the whisper model to use for a run: an explicit `--model` argument
+/// always wins; otherwise, if `auto_select_model` is set, the model
+/// recommended for `language` is used; otherwise `fallback` (the stored
+/// `whisper_model` setting) is used, ignoring `language`.
+///
+/// This is the single source of truth for the branch shared by
+/// `transcribe::run()` and `record::run()` — keep their call sites in sync
+/// with this function rather than re-deriving the logic inline.
+///
+/// Note: this intentionally does not delegate to
+/// `Settings::effective_model()` (core/settings/manager.rs), because that
+/// method always uses the *stored* `Settings::language`, while callers here
+/// need to honor a `--language` override that differs from the stored value
+/// (e.g. `--language sv` with auto-select on should recommend the Swedish
+/// model even if the stored language is English).
+pub fn resolve_effective_model(
+    model_arg: Option<&str>,
     language: Language,
+    auto_select_model: bool,
+    fallback: WhisperModel,
 ) -> Result<WhisperModel, DictationError> {
-    match model_str {
-        None => Ok(WhisperModel::recommended(language)),
+    match model_arg {
         Some(s) => parse_model(s),
+        None => Ok(if auto_select_model {
+            WhisperModel::recommended(language)
+        } else {
+            fallback
+        }),
     }
 }
 
@@ -502,25 +541,108 @@ mod tests {
         }
     }
 
-    // -- resolve_model --
+    // -- resolve_effective_model --
+    //
+    // These exercise the exact branch used by both transcribe::run() and
+    // record::run(): explicit arg wins -> auto_select_model recommends by
+    // language -> otherwise the stored fallback model (language ignored).
 
     #[test]
-    fn resolve_model_none_uses_recommended() {
-        let result = resolve_model(None, Language::English).unwrap();
-        assert_eq!(result, WhisperModel::BaseEn);
-
-        let result = resolve_model(None, Language::Swedish).unwrap();
+    fn resolve_effective_model_none_auto_recommends_by_language() {
+        let result =
+            resolve_effective_model(None, Language::Swedish, true, WhisperModel::Base).unwrap();
         assert_eq!(result, WhisperModel::KbWhisperBase);
     }
 
     #[test]
-    fn resolve_model_explicit_overrides() {
-        let result = resolve_model(Some("tiny.en"), Language::Swedish).unwrap();
+    fn resolve_effective_model_none_no_auto_uses_fallback_ignoring_language() {
+        let result = resolve_effective_model(
+            None,
+            Language::Swedish,
+            false,
+            WhisperModel::LargeV3Turbo,
+        )
+        .unwrap();
+        assert_eq!(result, WhisperModel::LargeV3Turbo);
+    }
+
+    #[test]
+    fn resolve_effective_model_explicit_arg_wins_over_auto_select() {
+        let result = resolve_effective_model(
+            Some("tiny.en"),
+            Language::Swedish,
+            true,
+            WhisperModel::Base,
+        )
+        .unwrap();
         assert_eq!(result, WhisperModel::TinyEn);
     }
 
     #[test]
-    fn resolve_model_invalid_string() {
-        assert!(resolve_model(Some("invalid"), Language::Auto).is_err());
+    fn resolve_effective_model_invalid_arg_errors() {
+        assert!(
+            resolve_effective_model(Some("bogus"), Language::Auto, true, WhisperModel::Base)
+                .is_err()
+        );
+    }
+}
+
+// -- diarize_threshold validation --
+//
+// Exercised via clap's try_parse_from against a small wrapper so the
+// value_parser attribute itself (not just the bare parsing function) is
+// under test.
+#[cfg(all(test, feature = "diarization"))]
+mod diarize_threshold_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: TranscribeArgs,
+    }
+
+    fn parse_threshold(value: &str) -> Result<f32, String> {
+        TestCli::try_parse_from(["sagascript", "file.wav", "--diarize-threshold", value])
+            .map(|cli| cli.args.diarize_threshold)
+            .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn rejects_nan() {
+        assert!(parse_threshold("nan").is_err());
+    }
+
+    #[test]
+    fn rejects_negative() {
+        assert!(parse_threshold("-1.0").is_err());
+    }
+
+    #[test]
+    fn rejects_above_range() {
+        assert!(parse_threshold("3.0").is_err());
+    }
+
+    #[test]
+    fn accepts_default_value() {
+        assert_eq!(parse_threshold("0.85").unwrap(), 0.85);
+    }
+
+    #[test]
+    fn accepts_in_range_value() {
+        assert_eq!(parse_threshold("1.5").unwrap(), 1.5);
+    }
+
+    #[test]
+    fn default_applies_when_flag_omitted() {
+        let cli = TestCli::try_parse_from(["sagascript", "file.wav"]).unwrap();
+        assert_eq!(cli.args.diarize_threshold, 0.85);
+    }
+
+    #[test]
+    fn accepts_boundary_values() {
+        assert_eq!(parse_threshold("0.0").unwrap(), 0.0);
+        assert_eq!(parse_threshold("2.0").unwrap(), 2.0);
     }
 }

--- a/src-tauri/crates/sagascript-core/src/audio/capture.rs
+++ b/src-tauri/crates/sagascript-core/src/audio/capture.rs
@@ -83,8 +83,13 @@ impl AudioCaptureService {
         Ok(())
     }
 
-    /// Stop capturing and return the audio samples
-    pub fn stop_capture(&mut self) -> Vec<f32> {
+    /// Stop capturing and return the captured 16 kHz samples.
+    ///
+    /// On resample failure this returns `Err` (finding 4) rather than an empty
+    /// `Vec` — an empty buffer means genuine silence, so masking a device/format
+    /// error as empty made a real failure indistinguishable from silence (and
+    /// surfaced the misleading "No audio captured" to the user).
+    pub fn stop_capture(&mut self) -> Result<Vec<f32>, DictationError> {
         // Signal the capture thread to stop
         {
             let mut stop = self.stop_signal.lock().unwrap();
@@ -104,18 +109,17 @@ impl AudioCaptureService {
         // Resample the entire recording to 16 kHz in a single pass. Doing it
         // here (rather than per-callback) keeps the realtime audio thread cheap
         // and avoids the filter-restart transient that a per-callback resampler
-        // injects at every chunk boundary.
+        // injects at every chunk boundary. An empty buffer or unknown device
+        // rate is genuine silence — Ok(empty); a resample failure is a real
+        // error and is propagated.
         let device_rate = self.device_sample_rate.load(Ordering::SeqCst);
         let samples = if raw.is_empty() || device_rate == 0 {
             raw
         } else {
-            match resample_to_16khz(raw, device_rate) {
-                Ok(s) => s,
-                Err(e) => {
-                    error!("Resample failed, dropping recording: {e}");
-                    Vec::new()
-                }
-            }
+            resample_to_16khz(raw, device_rate).map_err(|e| {
+                error!("Resample failed: {e}");
+                DictationError::AudioCaptureError(format!("Resample failed: {e}"))
+            })?
         };
 
         let duration = samples.len() as f64 / TARGET_SAMPLE_RATE as f64;
@@ -129,7 +133,7 @@ impl AudioCaptureService {
         // Retain for retry
         self.last_captured = Some(samples.clone());
 
-        samples
+        Ok(samples)
     }
 
     /// Get the last captured audio for retry
@@ -365,5 +369,18 @@ mod tests {
         let cap = MAX_BUFFER_SECONDS;
         process_samples_i16(&vec![0i16; cap + 100], 1, 1, &b);
         assert_eq!(b.lock().unwrap().len(), cap);
+    }
+
+    // Finding 4: stop_capture returns a Result so a real device/resample failure
+    // is distinguishable from silence. With no capture ever started the buffer is
+    // empty and the device rate unknown (0), so genuine silence must be
+    // Ok(empty) — NOT an error and NOT indistinguishable from a failure.
+    #[test]
+    fn stop_capture_silence_is_ok_empty() {
+        let mut svc = AudioCaptureService::new();
+        let out = svc
+            .stop_capture()
+            .expect("silence should be Ok(empty), not Err");
+        assert!(out.is_empty());
     }
 }

--- a/src-tauri/crates/sagascript-core/src/audio/decoder.rs
+++ b/src-tauri/crates/sagascript-core/src/audio/decoder.rs
@@ -16,6 +16,48 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "wav", "mp3", "m4a", "aac", "mp4", "mov", "ogg", "webm", "flac", "qta",
 ];
 
+/// Hard ceiling on decoded audio length, expressed in samples of a 16kHz mono
+/// clip of equivalent duration (~4 hours: `4 * 3600 * 16_000`). Without a
+/// cap, `decode_audio_file` accumulates the ENTIRE decoded PCM stream into a
+/// single `Vec<f32>` before resampling — a multi-hour, high-sample-rate
+/// multichannel file (or an adversarial/corrupt one that decodes to far more
+/// "audio" than its file size implies) can require tens of GB and OOM the
+/// process.
+///
+/// The check is done against a *duration-normalized* sample count (raw
+/// accumulated samples, divided by channel count and source sample rate, then
+/// scaled to 16kHz) rather than the literal raw interleaved sample count, so
+/// the cap applies consistently regardless of the source format — a 4-hour
+/// clip is rejected the same whether it's mono 16kHz or stereo 48kHz. This is
+/// deliberately generous: no legitimate multi-hour podcast batch-
+/// transcription job should ever hit it.
+pub const MAX_DECODE_SAMPLES: usize = 4 * 3600 * 16_000; // ~230M, ~4h @ 16kHz mono equivalent
+
+/// Check whether the accumulated decode so far has exceeded
+/// [`MAX_DECODE_SAMPLES`], normalized to a 16kHz-mono-equivalent duration.
+/// Factored out of the decode loop so it can be unit tested without
+/// allocating gigabytes of PCM data.
+fn check_decode_size_cap(
+    raw_sample_count: usize,
+    channels: usize,
+    sample_rate: u32,
+) -> Result<(), DictationError> {
+    let channels = (channels.max(1)) as f64;
+    let sample_rate = if sample_rate == 0 { 44_100.0 } else { sample_rate as f64 };
+
+    let duration_secs = raw_sample_count as f64 / channels / sample_rate;
+    let equivalent_16k_mono_samples = duration_secs * 16_000.0;
+
+    if equivalent_16k_mono_samples > MAX_DECODE_SAMPLES as f64 {
+        return Err(DictationError::FileDecodeError(format!(
+            "Audio file is too long to decode (exceeds the ~4 hour / {MAX_DECODE_SAMPLES}-sample \
+             16kHz-mono-equivalent limit); aborting to avoid unbounded memory use"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Decode an audio or video file to `Vec<f32>` at 16 kHz mono (Whisper input format).
 ///
 /// Uses symphonia to probe the file format, find the first audio track,
@@ -131,6 +173,11 @@ pub fn decode_audio_file(path: &Path) -> Result<Vec<f32>, DictationError> {
         sample_buf.copy_interleaved_ref(decoded);
 
         all_samples.extend_from_slice(sample_buf.samples());
+
+        // Abort early (before accumulating further) if this file would decode
+        // to an unreasonably long clip. Checked every packet so we bail out
+        // during decode rather than after the huge buffer already exists.
+        check_decode_size_cap(all_samples.len(), actual_channels, sample_rate)?;
     }
 
     if all_samples.is_empty() {
@@ -278,5 +325,82 @@ mod tests {
             }
             other => panic!("unexpected error: {:?}", other),
         }
+    }
+
+    // -- decode size cap --
+    // These test the extracted check_decode_size_cap function directly
+    // (constructing the accumulated-count condition rather than actually
+    // decoding tens of GB of audio).
+
+    #[test]
+    fn decode_size_cap_rejects_over_limit() {
+        // 5 hours of mono 16kHz raw samples — over the ~4h cap.
+        let raw_samples = 5 * 3600 * 16_000;
+        let result = check_decode_size_cap(raw_samples, 1, 16_000);
+        assert!(result.is_err(), "5h mono 16kHz should exceed the cap");
+        match result.unwrap_err() {
+            DictationError::FileDecodeError(msg) => {
+                assert!(
+                    msg.contains("4 hour") || msg.contains(&MAX_DECODE_SAMPLES.to_string()),
+                    "error should name the limit: {msg}"
+                );
+            }
+            other => panic!("expected FileDecodeError, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decode_size_cap_allows_under_limit() {
+        // 3 hours of stereo 48kHz raw samples — well under the cap once
+        // normalized to a 16kHz-mono-equivalent duration.
+        let raw_samples = 3 * 3600 * 48_000 * 2;
+        let result = check_decode_size_cap(raw_samples, 2, 48_000);
+        assert!(result.is_ok(), "3h stereo 48kHz should not be rejected: {:?}", result);
+    }
+
+    #[test]
+    fn decode_size_cap_does_not_reject_legitimate_multi_hour_podcasts() {
+        // A ~3h55m clip in several common real-world source formats should
+        // all pass — this is the "generous enough" requirement: the cap must
+        // not reject realistic multi-hour batch-transcription jobs.
+        let almost_four_hours_secs = 3.917 * 3600.0; // ~3h 55m
+        for (channels, sample_rate) in [
+            (1u32, 16_000u32), // mono 16kHz (Whisper-native)
+            (1, 8_000),        // mono 8kHz (phone-quality)
+            (2, 44_100),       // stereo CD-quality
+            (2, 48_000),       // stereo studio/podcast standard
+        ] {
+            let raw = (almost_four_hours_secs * channels as f64 * sample_rate as f64) as usize;
+            let result = check_decode_size_cap(raw, channels as usize, sample_rate);
+            assert!(
+                result.is_ok(),
+                "channels={channels} sample_rate={sample_rate} (~3h55m) should not be rejected: {:?}",
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn decode_size_cap_treats_zero_channels_as_one() {
+        // channels=0 is a defensive/malformed-metadata case; must not divide
+        // by zero (NaN/inf) or panic.
+        let raw_samples = 3600 * 16_000; // 1h mono-equivalent
+        let result = check_decode_size_cap(raw_samples, 0, 16_000);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn decode_size_cap_treats_zero_sample_rate_as_default() {
+        // sample_rate=0 would otherwise divide by zero; must not panic.
+        let result = check_decode_size_cap(1_000_000, 1, 0);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn existing_decode_calls_pass_the_cap_check() {
+        // Sanity: the ~1s clip used by decode_wav_from_encode is nowhere
+        // near the cap.
+        let result = check_decode_size_cap(16_000, 1, 16_000);
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/crates/sagascript-core/src/diarization/clustering.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/clustering.rs
@@ -37,14 +37,17 @@ pub fn cluster_speakers(
     for i in 0..n {
         for j in (i + 1)..n {
             let sim = cosine_similarity(&embeddings[i].1, &embeddings[j].1);
-            // Clamp to [0, 2] — cosine distance range for L2-normalized vectors
-            condensed.push((1.0 - sim).clamp(0.0, 2.0));
+            // Clamp to [0, 2] — cosine distance range for L2-normalized vectors.
+            // Non-finite distances (NaN embeddings) map to max distance so they
+            // never merge and cannot panic kodama::linkage.
+            let dist = (1.0 - sim).clamp(0.0, 2.0);
+            condensed.push(if dist.is_finite() { dist } else { 2.0 });
         }
     }
 
     if !condensed.is_empty() {
         let mut sorted = condensed.clone();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let n_dist = sorted.len();
         tracing::debug!(
             "Embedding distances: n={}, p25={:.3}, p50={:.3}, p75={:.3}, p90={:.3}",
@@ -282,5 +285,16 @@ mod tests {
         // Should not panic or produce NaN
         let sim = cosine_similarity(&zero, &v);
         assert!(!sim.is_nan());
+    }
+
+    #[test]
+    fn cluster_speakers_survives_nan_in_distance_matrix() {
+        // A NaN component (e.g. a non-finite ONNX embedding output that bypassed
+        // l2_normalize's sanitization) must not panic the distance sort.
+        let mut nan_emb = [0.0f32; EMBEDDING_DIM];
+        nan_emb[0] = f32::NAN;
+        let input = vec![(0, nan_emb), (1, unit_embedding(1)), (2, unit_embedding(2))];
+        let result = cluster_speakers(&input, 0.8);
+        assert_eq!(result.len(), 3);
     }
 }

--- a/src-tauri/crates/sagascript-core/src/diarization/embedding.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/embedding.rs
@@ -107,7 +107,14 @@ impl Embedder {
 }
 
 /// L2-normalize a fixed-size embedding vector.
+/// Non-finite components (NaN/Inf from the ONNX model) are replaced with 0.0
+/// so they cannot propagate into the clustering distance matrix.
 pub fn l2_normalize(mut v: [f32; EMBEDDING_DIM]) -> [f32; EMBEDDING_DIM] {
+    for x in &mut v {
+        if !x.is_finite() {
+            *x = 0.0;
+        }
+    }
     let norm: f32 = v.iter().map(|&x| x * x).sum::<f32>().sqrt();
     if norm > 1e-12 {
         for x in &mut v {
@@ -145,6 +152,21 @@ mod tests {
         // Should not panic or produce NaN
         for x in &normalized {
             assert!(!x.is_nan(), "NaN in zero-vector normalization");
+        }
+    }
+
+    #[test]
+    fn l2_normalize_sanitizes_non_finite_components() {
+        // The ONNX model can emit NaN/Inf components; these must not survive
+        // normalization and reach the clustering distance matrix.
+        let mut v = [0.0f32; EMBEDDING_DIM];
+        v[0] = f32::NAN;
+        v[1] = f32::INFINITY;
+        v[2] = f32::NEG_INFINITY;
+        v[3] = 1.0;
+        let normalized = l2_normalize(v);
+        for x in &normalized {
+            assert!(x.is_finite(), "non-finite component survived l2_normalize: {x}");
         }
     }
 

--- a/src-tauri/crates/sagascript-core/src/diarization/model.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/model.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use tracing::info;
 
+use crate::download::download_to_path;
 use crate::error::DictationError;
 
 /// ONNX models used for speaker diarization.
@@ -112,12 +113,6 @@ pub async fn download_model(
         return Ok(path);
     }
 
-    // Ensure directory exists
-    let dir = crate::transcription::model::models_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
-    })?;
-
     info!(
         "Downloading {} from {} (~{}MB)",
         model.display_name(),
@@ -125,53 +120,12 @@ pub async fn download_model(
         model.size_mb()
     );
 
-    let client = reqwest::Client::new();
-    let response = client
-        .get(model.download_url())
-        .send()
-        .await
-        .map_err(|e| DictationError::ModelDownloadFailed(format!("Download failed: {e}")))?;
-
-    if !response.status().is_success() {
-        return Err(DictationError::ModelDownloadFailed(format!(
-            "HTTP {}: {}",
-            response.status(),
-            model.download_url()
-        )));
-    }
-
-    let total_size = response.content_length().unwrap_or(0);
-    let mut downloaded: u64 = 0;
-
-    // Download to a temp file then rename (atomic)
-    let tmp_path = path.with_extension("onnx.tmp");
-    let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to create temp file: {e}"))
-    })?;
-
-    use futures_util::StreamExt;
-    use tokio::io::AsyncWriteExt;
-    let mut stream = response.bytes_stream();
-
-    while let Some(chunk) = stream.next().await {
-        let chunk =
-            chunk.map_err(|e| DictationError::ModelDownloadFailed(format!("Download error: {e}")))?;
-        file.write_all(&chunk).await.map_err(|e| {
-            DictationError::ModelDownloadFailed(format!("Write error: {e}"))
-        })?;
-        downloaded += chunk.len() as u64;
-        progress_callback(downloaded, total_size);
-    }
-
-    file.flush().await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Flush error: {e}"))
-    })?;
-    drop(file);
-
-    // Rename temp to final
-    tokio::fs::rename(&tmp_path, &path).await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to rename temp file: {e}"))
-    })?;
+    // ONNX files are bare protobuf with no fixed leading bytes (the first
+    // bytes vary with ir_version and the producer-name string length), so no
+    // magic check is applied here — only the Content-Length check. A magic
+    // check risks false-rejecting a valid model, which the hardening this is
+    // part of explicitly must never do.
+    download_to_path(model.download_url(), &path, "onnx", None, progress_callback).await?;
 
     info!("Diarization model downloaded: {}", path.display());
     Ok(path)

--- a/src-tauri/crates/sagascript-core/src/download.rs
+++ b/src-tauri/crates/sagascript-core/src/download.rs
@@ -1,0 +1,363 @@
+//! Shared model-download pipeline: stream a URL to a uniquely-named temp
+//! file, validate the result, then atomically rename it into place. Used by
+//! every model downloader in the crate (whisper GGML models, the Silero VAD
+//! model, and the diarization ONNX models) so this hardening lives in one
+//! place instead of three near-identical, independently-drifting copies.
+//!
+//! What this closes relative to the original triplicated code:
+//! - every error path removes the temp file (no more orphaned multi-hundred-
+//!   MB `.bin.tmp` left behind by a dropped connection or a full disk);
+//! - the response body is validated (length + optional magic bytes) before
+//!   the rename, so an HTML rate-limit page or a git-LFS pointer stub can
+//!   never be renamed into a `ggml-*.bin` and silently make
+//!   `is_model_downloaded()` report success forever;
+//! - the temp filename is unique per invocation (previously a fixed
+//!   `<name>.bin.tmp`), so two concurrent downloads of the same model can no
+//!   longer interleave bytes into one corrupt file. Losing the fixed name
+//!   also loses its incidental self-cleaning property (a retried download
+//!   used to just overwrite its own leftover), so `download_to_path`
+//!   opportunistically sweeps stale `.tmp` files from the destination
+//!   directory before it starts.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use futures_util::StreamExt;
+use tokio::io::AsyncWriteExt;
+
+use crate::error::DictationError;
+
+/// whisper.cpp's `GGML_FILE_MAGIC` (`0x67676d6c`, mnemonic "ggml") as it
+/// actually appears on disk: the constant is written out as a little-endian
+/// `u32`, so the file's first 4 bytes are `6c 6d 67 67` — not the ASCII
+/// string "ggml". Verified directly against real downloaded models (both
+/// stock ggerganov/whisper.cpp files and the KBLab/NbAiLab q5_0 quantized
+/// fine-tunes — quantization only changes tensor payloads, never the
+/// header) and against the Silero VAD model, which whisper.cpp has shipped
+/// in ggml format since v1.7.4.
+pub const GGML_MAGIC: [u8; 4] = [0x6c, 0x6d, 0x67, 0x67];
+
+/// Number of leading response bytes buffered for the magic check. Only ever
+/// need to compare against `GGML_MAGIC` (4 bytes) today; a little slack
+/// keeps this working if a longer magic is added later without holding the
+/// whole file in memory.
+const MAGIC_PREFIX_LEN: usize = 8;
+
+/// A stale temp file older than this is treated as an orphan from a
+/// crashed/killed download rather than a concurrent, in-progress download of
+/// a *different* model sharing the same directory (temp names are unique
+/// per invocation, so a live download's own temp file is never the one a
+/// given call is about to create — but another call's could still be
+/// sitting alongside it). No real model download takes anywhere near this
+/// long, so this is generous on purpose.
+const ORPHAN_TMP_MAX_AGE: Duration = Duration::from_secs(60 * 60);
+
+/// Stream `url` to `dest`, via a uniquely-named temp file in the same
+/// directory so the final rename is atomic and same-filesystem.
+///
+/// - `tmp_ext` is a short marker folded into the temp filename purely for
+///   readability when a leftover file is being debugged (e.g. `"bin"` or
+///   `"onnx"`) — it plays no role in making the name unique.
+/// - `expected_magic`, when `Some`, is checked against the first bytes of
+///   the downloaded file before the rename. Pass `None` to skip the check
+///   (e.g. ONNX files are bare protobuf with no fixed leading bytes, so a
+///   magic check there risks false-rejecting a valid model).
+/// - `progress_callback` is invoked after every chunk with
+///   `(bytes_downloaded_so_far, total_size_or_0_if_unknown)`.
+///
+/// On any failure the temp file is removed best-effort before the error is
+/// returned; `dest` itself is only ever touched by the final rename, so a
+/// failed download can never leave a partial or invalid file in its place.
+pub async fn download_to_path(
+    url: &str,
+    dest: &Path,
+    tmp_ext: &str,
+    expected_magic: Option<&[u8]>,
+    progress_callback: impl Fn(u64, u64) + Send + 'static,
+) -> Result<(), DictationError> {
+    if let Some(dir) = dest.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| {
+            DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
+        })?;
+        sweep_orphaned_tmp_files(dir);
+    }
+
+    let tmp_path = unique_tmp_path(dest, tmp_ext);
+
+    if let Err(e) = fetch_to_tmp(url, &tmp_path, expected_magic, progress_callback).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
+
+    if let Err(e) = tokio::fs::rename(&tmp_path, dest).await {
+        // The download itself succeeded and was already validated — only the
+        // final move failed (e.g. a cross-device rename). Clean up rather
+        // than leave a uniquely-named temp file that nothing will ever look
+        // for again.
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(DictationError::ModelDownloadFailed(format!(
+            "Failed to rename temp file: {e}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Do the actual network fetch + stream-to-file + validate, in one `Result`
+/// so `download_to_path` can clean up the temp file with a single arm
+/// instead of repeating `let _ = remove_file(...).await;` after every `?`.
+async fn fetch_to_tmp(
+    url: &str,
+    tmp_path: &Path,
+    expected_magic: Option<&[u8]>,
+    progress_callback: impl Fn(u64, u64) + Send + 'static,
+) -> Result<(), DictationError> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| DictationError::ModelDownloadFailed(format!("Download failed: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(DictationError::ModelDownloadFailed(format!(
+            "HTTP {}: {url}",
+            response.status()
+        )));
+    }
+
+    let content_length = response.content_length();
+    let total_size = content_length.unwrap_or(0);
+    let mut downloaded: u64 = 0;
+    let mut prefix: Vec<u8> = Vec::with_capacity(MAGIC_PREFIX_LEN);
+
+    let mut file = tokio::fs::File::create(tmp_path).await.map_err(|e| {
+        DictationError::ModelDownloadFailed(format!("Failed to create temp file: {e}"))
+    })?;
+
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|e| DictationError::ModelDownloadFailed(format!("Download error: {e}")))?;
+        if prefix.len() < MAGIC_PREFIX_LEN {
+            let take = (MAGIC_PREFIX_LEN - prefix.len()).min(chunk.len());
+            prefix.extend_from_slice(&chunk[..take]);
+        }
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| DictationError::ModelDownloadFailed(format!("Write error: {e}")))?;
+        downloaded += chunk.len() as u64;
+        progress_callback(downloaded, total_size);
+    }
+
+    file.flush()
+        .await
+        .map_err(|e| DictationError::ModelDownloadFailed(format!("Flush error: {e}")))?;
+    drop(file);
+
+    validate_download(&prefix, downloaded, content_length, expected_magic)
+        .map_err(DictationError::ModelDownloadFailed)?;
+
+    Ok(())
+}
+
+/// Pure validation of a completed-but-not-yet-renamed download. Kept free of
+/// I/O so it is trivially unit-testable.
+///
+/// - When the server reported a non-zero `Content-Length`, the bytes
+///   actually written must match it exactly — catches a truncated download
+///   from a dropped connection or an early stream close.
+/// - When `expected_magic` is `Some`, the file's leading bytes must match it
+///   — catches an HTTP-200 body that isn't actually the model: a
+///   HuggingFace git-LFS pointer stub, an HTML rate-limit/error page, or an
+///   S3 XML error document would otherwise be renamed straight into
+///   `ggml-*.bin` and `is_model_downloaded()` would report success forever.
+pub fn validate_download(
+    prefix_bytes: &[u8],
+    bytes_written: u64,
+    content_length: Option<u64>,
+    expected_magic: Option<&[u8]>,
+) -> Result<(), String> {
+    if let Some(expected_len) = content_length {
+        if expected_len != 0 && bytes_written != expected_len {
+            return Err(format!(
+                "downloaded {bytes_written} bytes but server reported Content-Length \
+                 {expected_len} (truncated or interrupted download)"
+            ));
+        }
+    }
+
+    if let Some(magic) = expected_magic {
+        if !prefix_bytes.starts_with(magic) {
+            let got_len = magic.len().min(prefix_bytes.len());
+            return Err(format!(
+                "downloaded file does not start with the expected magic bytes {magic:02x?} \
+                 (got {:02x?}) — this looks like an HTML page, a git-LFS pointer stub, or an \
+                 error document rather than a model file",
+                &prefix_bytes[..got_len]
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Build a temp-file path in the same directory as `dest`, unique per call
+/// so two concurrent downloads (e.g. the user queues two models back to
+/// back) never write into the same temp file and interleave bytes into a
+/// corrupt result. `tmp_ext` (e.g. `"bin"`/`"onnx"`) is folded in purely so a
+/// human staring at the directory can tell what a leftover file was for.
+fn unique_tmp_path(dest: &Path, tmp_ext: &str) -> PathBuf {
+    let unique = uuid::Uuid::new_v4();
+    dest.with_extension(format!("{tmp_ext}.{unique}.tmp"))
+}
+
+/// Best-effort removal of `.tmp` files left behind by a crashed or killed
+/// download. Needed because unique-per-invocation temp names (above) lose
+/// the old fixed-name behavior where a retried download would just
+/// overwrite/truncate its own stale leftover — now nothing reclaims an
+/// orphan on its own. Only sweeps files older than `ORPHAN_TMP_MAX_AGE`, so
+/// a fresh temp file belonging to a *different*, concurrently-running
+/// download in the same models directory is never touched. Errors (missing
+/// dir, permissions) are swallowed: this is opportunistic housekeeping, not
+/// something a download should fail over.
+fn sweep_orphaned_tmp_files(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("tmp") {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(modified) else {
+            continue;
+        };
+        if age > ORPHAN_TMP_MAX_AGE {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_test_dir() -> PathBuf {
+        std::env::temp_dir().join(format!("sagascript-download-test-{}", uuid::Uuid::new_v4()))
+    }
+
+    // -- validate_download --
+
+    #[test]
+    fn accepts_valid_ggml_prefix_with_matching_length() {
+        let prefix = [0x6c, 0x6d, 0x67, 0x67, 0x0a, 0x00, 0x00, 0x00];
+        assert!(
+            validate_download(&prefix, 142_000_000, Some(142_000_000), Some(&GGML_MAGIC)).is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_html_rate_limit_page() {
+        let prefix = b"<!DOCTYPE html><html><head><title>429</title>";
+        let err =
+            validate_download(prefix, prefix.len() as u64, Some(prefix.len() as u64), Some(&GGML_MAGIC))
+                .unwrap_err();
+        assert!(err.contains("magic"), "error should mention magic bytes: {err}");
+    }
+
+    #[test]
+    fn rejects_git_lfs_pointer_file() {
+        let prefix =
+            b"version https://git-lfs.github.com/spec/v1\noid sha256:deadbeef\nsize 142000000\n";
+        let err = validate_download(prefix, prefix.len() as u64, None, Some(&GGML_MAGIC)).unwrap_err();
+        assert!(err.contains("magic"), "error should mention magic bytes: {err}");
+    }
+
+    #[test]
+    fn rejects_length_mismatch_even_without_magic_check() {
+        // Simulates a dropped connection: server promised 1000 bytes, only 400 arrived.
+        let prefix = b"partial-body-bytes";
+        let err = validate_download(prefix, 400, Some(1000), None).unwrap_err();
+        assert!(
+            err.contains("400") && err.contains("1000"),
+            "error should name both byte counts: {err}"
+        );
+    }
+
+    #[test]
+    fn skips_length_check_when_content_length_unknown_or_zero() {
+        let prefix = GGML_MAGIC;
+        assert!(validate_download(&prefix, 999, None, Some(&GGML_MAGIC)).is_ok());
+        assert!(validate_download(&prefix, 999, Some(0), Some(&GGML_MAGIC)).is_ok());
+    }
+
+    #[test]
+    fn skips_magic_check_when_none_e_g_onnx() {
+        // ONNX files are protobuf-encoded with no fixed magic; only length is checked.
+        let onnx_like_prefix = [0x08, 0x07, 0x12, 0x07];
+        assert!(validate_download(&onnx_like_prefix, 27_000_000, Some(27_000_000), None).is_ok());
+    }
+
+    // -- unique_tmp_path --
+
+    #[test]
+    fn unique_tmp_path_is_unique_and_carries_marker() {
+        let dest = Path::new("/models/ggml-base.bin");
+        let a = unique_tmp_path(dest, "bin");
+        let b = unique_tmp_path(dest, "bin");
+        assert_ne!(a, b, "two calls must never collide");
+        for p in [&a, &b] {
+            assert_eq!(p.parent(), dest.parent());
+            let name = p.file_name().unwrap().to_str().unwrap();
+            assert!(name.starts_with("ggml-base.bin."), "name: {name}");
+            assert!(name.ends_with(".tmp"), "name: {name}");
+        }
+    }
+
+    // -- sweep_orphaned_tmp_files --
+
+    #[test]
+    fn sweep_removes_only_stale_tmp_files() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let stale = dir.join("stale.bin.tmp");
+        std::fs::write(&stale, b"leftover").unwrap();
+        // Backdate mtime well past the sweep threshold using std's stable
+        // `File::set_times` (no extra dependency needed).
+        let ancient = SystemTime::now() - (ORPHAN_TMP_MAX_AGE + Duration::from_secs(60));
+        let file = std::fs::OpenOptions::new().write(true).open(&stale).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(ancient)).unwrap();
+
+        let fresh = dir.join("fresh.bin.tmp");
+        std::fs::write(&fresh, b"in progress").unwrap();
+
+        let keep = dir.join("keep.bin"); // not a .tmp — must never be touched
+        std::fs::write(&keep, b"real model").unwrap();
+
+        sweep_orphaned_tmp_files(&dir);
+
+        assert!(!stale.exists(), "stale tmp file should be swept");
+        assert!(
+            fresh.exists(),
+            "fresh tmp file must survive — it might belong to a concurrent download"
+        );
+        assert!(keep.exists(), "non-tmp file must never be touched");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sweep_tolerates_missing_directory() {
+        // Must not panic if the models dir doesn't exist yet (fresh install).
+        sweep_orphaned_tmp_files(&temp_test_dir());
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/error.rs
+++ b/src-tauri/crates/sagascript-core/src/error.rs
@@ -29,9 +29,6 @@ pub enum DictationError {
     #[error("Settings error: {0}")]
     SettingsError(String),
 
-    #[error("Hotkey error: {0}")]
-    HotkeyError(String),
-
     #[error("Paste error: {0}")]
     PasteError(String),
 
@@ -128,9 +125,9 @@ mod tests {
 
     #[test]
     fn debug_format() {
-        let err = DictationError::HotkeyError("conflict".into());
+        let err = DictationError::PasteError("conflict".into());
         let debug = format!("{:?}", err);
-        assert!(debug.contains("HotkeyError"));
+        assert!(debug.contains("PasteError"));
         assert!(debug.contains("conflict"));
     }
 }

--- a/src-tauri/crates/sagascript-core/src/lib.rs
+++ b/src-tauri/crates/sagascript-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! entry points and integrations on top.
 
 pub mod audio;
+pub mod download;
 pub mod error;
 pub mod settings;
 pub mod transcription;

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -28,7 +28,20 @@ pub fn load() -> Settings {
 /// Load settings from a specific path. Returns defaults if missing or unreadable.
 pub fn load_from(path: &PathBuf) -> Settings {
     match std::fs::read_to_string(path) {
-        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Ok(contents) => match serde_json::from_str(&contents) {
+            Ok(settings) => settings,
+            Err(e) => {
+                // One wrong-typed field would otherwise silently reset ALL
+                // user settings to defaults with no diagnostic trail. We
+                // still fall back to defaults (self-healing contract), but
+                // now there's a log line to explain why.
+                tracing::warn!(
+                    "Failed to parse settings file at {}: {e} — falling back to defaults",
+                    path.display()
+                );
+                Settings::default()
+            }
+        },
         Err(_) => Settings::default(),
     }
 }
@@ -37,17 +50,47 @@ pub fn load_from(path: &PathBuf) -> Settings {
 /// (e.g. `hasCompletedOnboarding` from Tauri plugin store).
 /// Uses atomic write: write to .tmp then rename.
 pub fn save(settings: &Settings) -> Result<(), String> {
-    let path = settings_path();
-    let dir = app_data_dir();
+    save_to(&settings_path(), settings)
+}
+
+/// Persist settings to a specific path. Test seam for `save`, which always
+/// targets `settings_path()`.
+fn save_to(path: &PathBuf, settings: &Settings) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
 
     // Ensure directory exists
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {e}"))?;
 
     // Read existing file to preserve non-settings keys
     let mut map: serde_json::Map<String, serde_json::Value> = if let Ok(contents) =
-        std::fs::read_to_string(&path)
+        std::fs::read_to_string(path)
     {
-        serde_json::from_str(&contents).unwrap_or_default()
+        match serde_json::from_str(&contents) {
+            Ok(m) => m,
+            Err(e) => {
+                // A parse failure here used to silently drop every
+                // preserved non-Settings key (e.g. hasCompletedOnboarding)
+                // this read-merge-write exists to protect. Back up the
+                // corrupt bytes to a sidecar before starting fresh, rather
+                // than aborting the save (aborting would contradict the
+                // corrupt-to-defaults self-healing contract).
+                tracing::warn!(
+                    "Existing settings file at {} is corrupt ({e}) — backing up to .bak and starting fresh",
+                    path.display()
+                );
+                let bak_path = path.with_extension("json.bak");
+                if let Err(be) = std::fs::write(&bak_path, &contents) {
+                    tracing::warn!(
+                        "Failed to write corrupt settings backup to {}: {be}",
+                        bak_path.display()
+                    );
+                }
+                serde_json::Map::new()
+            }
+        }
     } else {
         serde_json::Map::new()
     };
@@ -67,7 +110,7 @@ pub fn save(settings: &Settings) -> Result<(), String> {
     let tmp_path = path.with_extension("json.tmp");
     std::fs::write(&tmp_path, &json)
         .map_err(|e| format!("Failed to write settings: {e}"))?;
-    std::fs::rename(&tmp_path, &path)
+    std::fs::rename(&tmp_path, path)
         .map_err(|e| format!("Failed to rename settings file: {e}"))?;
 
     Ok(())
@@ -247,6 +290,47 @@ mod tests {
             let d = Settings::default();
             // Should fall back to full defaults since deserialization fails
             assert_eq!(s.language, d.language);
+        });
+    }
+
+    // -- save_to backing up a corrupt existing file --
+
+    #[test]
+    fn save_backs_up_corrupt_existing_file() {
+        with_temp_settings(|path| {
+            let dir = path.parent().unwrap();
+            fs::create_dir_all(dir).unwrap();
+
+            let corrupt = "this is not json{{{";
+            fs::write(&path, corrupt).unwrap();
+
+            let settings = Settings { language: Language::Swedish, ..Default::default() };
+            let result = save_to(&path, &settings);
+            assert!(result.is_ok(), "save_to should still succeed over a corrupt existing file: {result:?}");
+
+            // The corrupt bytes must be preserved in a .bak sidecar rather
+            // than silently discarded.
+            let bak_path = path.with_extension("json.bak");
+            assert!(bak_path.exists(), "expected a .bak sidecar for the corrupt file");
+            let bak_contents = fs::read_to_string(&bak_path).unwrap();
+            assert_eq!(bak_contents, corrupt);
+
+            // And the save itself produced valid, fresh settings.
+            let raw: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+            assert_eq!(raw["language"], "sv");
+        });
+    }
+
+    #[test]
+    fn save_to_no_existing_file_does_not_create_bak() {
+        with_temp_settings(|path| {
+            let settings = Settings::default();
+            let result = save_to(&path, &settings);
+            assert!(result.is_ok());
+
+            let bak_path = path.with_extension("json.bak");
+            assert!(!bak_path.exists(), "no corrupt file existed, so no .bak should be created");
         });
     }
 }

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -10,7 +10,7 @@ const SETTINGS_FILENAME: &str = "sagascript-settings.json";
 /// Windows: %APPDATA%/com.sagascript.app/
 pub fn app_data_dir() -> PathBuf {
     dirs::data_dir()
-        .expect("could not determine application data directory")
+        .unwrap_or_else(|| PathBuf::from("."))
         .join(APP_IDENTIFIER)
 }
 

--- a/src-tauri/crates/sagascript-core/src/transcription/model.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/model.rs
@@ -1,13 +1,30 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tracing::info;
 
+use crate::download::{GGML_MAGIC, download_to_path};
 use crate::error::DictationError;
 use crate::settings::WhisperModel;
 
 /// Get the models directory for storing GGML files
 pub fn models_dir() -> PathBuf {
     let base = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
+    migrate_legacy_models_dir(&base)
+}
+
+/// Migrate the legacy FlowDictate models directory to Sagascript's, given a
+/// base app-data directory (`dirs::data_dir()` in production; a tempdir in
+/// tests). Pure with respect to the filesystem seam — no global state — so
+/// it's fully unit-testable without touching the real
+/// `~/Library/Application Support`.
+///
+/// - Fresh install (neither dir exists): no-op, just returns the new path.
+/// - Legacy dir only: renamed into place; the now-empty legacy parent
+///   (`<base>/FlowDictate`) is removed best-effort (`remove_dir` is a no-op
+///   if it's not actually empty, e.g. the old app left other files there).
+/// - Both dirs exist: the legacy dir is left untouched — never silently
+///   clobber a Models dir that's already populated at the new location.
+pub fn migrate_legacy_models_dir(base: &Path) -> PathBuf {
     let new_dir = base.join("Sagascript").join("Models");
 
     // Migrate from legacy FlowDictate models directory
@@ -66,52 +83,11 @@ pub async fn download_vad_model(
         return Ok(path);
     }
 
-    let dir = models_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
-    })?;
-
     info!("Downloading Silero VAD model from {VAD_MODEL_URL}");
 
-    use futures_util::StreamExt;
-    use tokio::io::AsyncWriteExt;
-
-    let client = reqwest::Client::new();
-    let response = client
-        .get(VAD_MODEL_URL)
-        .send()
-        .await
-        .map_err(|e| DictationError::ModelDownloadFailed(format!("VAD download failed: {e}")))?;
-    if !response.status().is_success() {
-        return Err(DictationError::ModelDownloadFailed(format!(
-            "VAD HTTP {}: {VAD_MODEL_URL}",
-            response.status()
-        )));
-    }
-
-    let total_size = response.content_length().unwrap_or(0);
-    let mut downloaded: u64 = 0;
-    let tmp_path = path.with_extension("bin.tmp");
-    let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to create temp file: {e}"))
-    })?;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk
-            .map_err(|e| DictationError::ModelDownloadFailed(format!("VAD download error: {e}")))?;
-        file.write_all(&chunk)
-            .await
-            .map_err(|e| DictationError::ModelDownloadFailed(format!("Write error: {e}")))?;
-        downloaded += chunk.len() as u64;
-        progress_callback(downloaded, total_size);
-    }
-    file.flush()
-        .await
-        .map_err(|e| DictationError::ModelDownloadFailed(format!("Flush error: {e}")))?;
-    drop(file);
-    tokio::fs::rename(&tmp_path, &path).await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to rename temp file: {e}"))
-    })?;
+    // The Silero VAD model has shipped in ggml format since whisper.cpp
+    // v1.7.4, so the same magic check as the whisper models applies.
+    download_to_path(VAD_MODEL_URL, &path, "bin", Some(&GGML_MAGIC), progress_callback).await?;
 
     info!("VAD model downloaded: {}", path.display());
     Ok(path)
@@ -150,11 +126,6 @@ pub async fn download_model(
         return Ok(path);
     }
 
-    // Ensure directory exists
-    std::fs::create_dir_all(&dir).map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to create models directory: {e}"))
-    })?;
-
     info!(
         "Downloading {} from {} (~{}MB)",
         model.display_name(),
@@ -162,53 +133,8 @@ pub async fn download_model(
         model.size_mb()
     );
 
-    let client = reqwest::Client::new();
-    let response = client
-        .get(model.download_url())
-        .send()
-        .await
-        .map_err(|e| DictationError::ModelDownloadFailed(format!("Download failed: {e}")))?;
-
-    if !response.status().is_success() {
-        return Err(DictationError::ModelDownloadFailed(format!(
-            "HTTP {}: {}",
-            response.status(),
-            model.download_url()
-        )));
-    }
-
-    let total_size = response.content_length().unwrap_or(0);
-    let mut downloaded: u64 = 0;
-
-    // Download to a temp file then rename (atomic)
-    let tmp_path = path.with_extension("bin.tmp");
-    let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to create temp file: {e}"))
-    })?;
-
-    use tokio::io::AsyncWriteExt;
-    let mut stream = response.bytes_stream();
-    use futures_util::StreamExt;
-
-    while let Some(chunk) = stream.next().await {
-        let chunk =
-            chunk.map_err(|e| DictationError::ModelDownloadFailed(format!("Download error: {e}")))?;
-        file.write_all(&chunk).await.map_err(|e| {
-            DictationError::ModelDownloadFailed(format!("Write error: {e}"))
-        })?;
-        downloaded += chunk.len() as u64;
-        progress_callback(downloaded, total_size);
-    }
-
-    file.flush().await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Flush error: {e}"))
-    })?;
-    drop(file);
-
-    // Rename temp to final
-    tokio::fs::rename(&tmp_path, &path).await.map_err(|e| {
-        DictationError::ModelDownloadFailed(format!("Failed to rename temp file: {e}"))
-    })?;
+    download_to_path(model.download_url(), &path, "bin", Some(&GGML_MAGIC), progress_callback)
+        .await?;
 
     info!("Model downloaded: {}", path.display());
 
@@ -339,4 +265,100 @@ async fn run_ditto(
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod migrate_legacy_models_dir_tests {
+    use super::*;
+
+    fn temp_base() -> PathBuf {
+        std::env::temp_dir().join(format!("sagascript-migrate-test-{}", uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn fresh_install_creates_nothing_and_returns_new_path() {
+        let base = temp_base();
+        // Deliberately don't create `base` itself — a fresh install has
+        // neither the legacy nor the new dir yet.
+
+        let result = migrate_legacy_models_dir(&base);
+
+        assert_eq!(result, base.join("Sagascript").join("Models"));
+        assert!(!base.join("FlowDictate").exists(), "must not create the legacy dir");
+        assert!(!result.exists(), "migration itself must not create the new dir either");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn legacy_dir_with_file_is_moved_and_old_dir_removed() {
+        let base = temp_base();
+        let legacy_models = base.join("FlowDictate").join("Models");
+        std::fs::create_dir_all(&legacy_models).unwrap();
+        std::fs::write(legacy_models.join("ggml-base.bin"), b"dummy").unwrap();
+
+        let result = migrate_legacy_models_dir(&base);
+
+        assert_eq!(result, base.join("Sagascript").join("Models"));
+        assert!(result.join("ggml-base.bin").exists(), "file must end up under Sagascript/Models");
+        assert!(
+            !base.join("FlowDictate").exists(),
+            "now-empty legacy parent should be cleaned up"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn both_dirs_present_leaves_legacy_untouched() {
+        let base = temp_base();
+
+        let new_models = base.join("Sagascript").join("Models");
+        std::fs::create_dir_all(&new_models).unwrap();
+        std::fs::write(new_models.join("ggml-base.bin"), b"current").unwrap();
+
+        let legacy_models = base.join("FlowDictate").join("Models");
+        std::fs::create_dir_all(&legacy_models).unwrap();
+        std::fs::write(legacy_models.join("ggml-tiny.bin"), b"legacy").unwrap();
+
+        let result = migrate_legacy_models_dir(&base);
+
+        assert_eq!(result, new_models);
+        assert!(
+            legacy_models.join("ggml-tiny.bin").exists(),
+            "legacy dir must survive untouched when the new dir already exists"
+        );
+        assert!(
+            new_models.join("ggml-base.bin").exists(),
+            "existing new-dir contents must be untouched"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sibling_file_in_legacy_parent_survives_migration() {
+        let base = temp_base();
+        let legacy_models = base.join("FlowDictate").join("Models");
+        std::fs::create_dir_all(&legacy_models).unwrap();
+        std::fs::write(legacy_models.join("ggml-base.bin"), b"dummy").unwrap();
+
+        // A sibling file directly under FlowDictate/ (not under Models/) —
+        // e.g. a leftover settings file from the old app. `remove_dir` only
+        // removes empty directories, so this must survive the migration.
+        let sibling = base.join("FlowDictate").join("settings.json");
+        std::fs::write(&sibling, b"{}").unwrap();
+
+        let result = migrate_legacy_models_dir(&base);
+
+        assert_eq!(result, base.join("Sagascript").join("Models"));
+        assert!(result.join("ggml-base.bin").exists());
+        assert!(sibling.exists(), "sibling file in legacy parent must survive");
+        assert!(
+            base.join("FlowDictate").exists(),
+            "legacy parent must survive since it's not empty"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -355,8 +355,11 @@ impl WhisperBackend {
             let mut transcript = String::new();
             for i in 0..n_segments {
                 if let Some(segment) = state.get_segment(i) {
-                    if let Ok(text) = segment.to_str() {
-                        transcript.push_str(text);
+                    match segment.to_str() {
+                        Ok(text) => transcript.push_str(text),
+                        Err(e) => warn!(
+                            "Segment {i} failed UTF-8 conversion, dropping from transcript: {e}"
+                        ),
                     }
                 }
             }
@@ -462,7 +465,16 @@ impl WhisperBackend {
                 Granularity::Segment => {
                     for i in 0..n_segments {
                         let Some(segment) = state.get_segment(i) else { continue };
-                        let text = segment.to_str().unwrap_or("").trim().to_string();
+                        let text = match segment.to_str() {
+                            Ok(s) => s,
+                            Err(e) => {
+                                warn!(
+                                    "Segment {i} failed UTF-8 conversion, dropping from transcript: {e}"
+                                );
+                                continue;
+                            }
+                        };
+                        let text = text.trim().to_string();
                         if text.is_empty() {
                             continue;
                         }

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -22,6 +22,23 @@ pub enum HotkeyDownResult {
     NoOp,
 }
 
+/// Outcome of a guarded stop-recording request (see
+/// [`AppController::stop_recording_guarded`]).
+#[derive(Debug)]
+pub enum StopRecordingOutcome {
+    /// Not currently recording — the stop was ignored (guards against a
+    /// duplicate/late stop racing an in-flight transcription). State and
+    /// `last_error` are left untouched.
+    NotRecording,
+    /// Recording stopped; carries the captured 16 kHz samples (may be empty if
+    /// the mic produced only silence).
+    Stopped(Vec<f32>),
+    /// The capture/resample failed. The controller has recorded the error and
+    /// returned to Idle; the message is returned so the caller can surface it
+    /// via the transcription-error event path.
+    Failed(String),
+}
+
 /// Application state machine
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -123,8 +140,15 @@ impl AppController {
 
         match self.settings.hotkey_mode {
             HotkeyMode::PushToTalk => {
-                self.start_recording()?;
-                Ok(HotkeyDownResult::StartedRecording)
+                // Only report StartedRecording if we actually started. Holding
+                // PTT while a prior utterance is still Transcribing must be a
+                // no-op — otherwise the overlay/tray shows a recording that
+                // never happened and never hides (finding 1).
+                if self.start_recording()? {
+                    Ok(HotkeyDownResult::StartedRecording)
+                } else {
+                    Ok(HotkeyDownResult::NoOp)
+                }
             }
             HotkeyMode::Toggle => {
                 if self.state.is_recording() {
@@ -144,11 +168,16 @@ impl AppController {
         self.settings.hotkey_mode == HotkeyMode::PushToTalk && self.state.is_recording()
     }
 
-    /// Start audio recording
-    pub fn start_recording(&mut self) -> Result<(), DictationError> {
+    /// Start audio recording.
+    ///
+    /// Returns `Ok(true)` if recording actually started, `Ok(false)` if it was
+    /// refused because the controller is not idle (e.g. a previous utterance is
+    /// still transcribing). Callers use this to avoid reporting a recording that
+    /// never happened (finding 1).
+    pub fn start_recording(&mut self) -> Result<bool, DictationError> {
         if self.state != AppState::Idle {
             warn!("Cannot start recording: state is {:?}", self.state);
-            return Ok(());
+            return Ok(false);
         }
 
         let session_id = self.logging.start_dictation_session();
@@ -165,12 +194,18 @@ impl AppController {
         self.last_error = None;
 
         info!("Recording started");
-        Ok(())
+        Ok(true)
     }
 
-    /// Stop recording and return the audio samples
-    pub fn stop_recording(&mut self) -> Vec<f32> {
-        let samples = self.audio.stop_capture();
+    /// Stop recording and return the captured 16 kHz samples.
+    ///
+    /// Propagates a capture/resample failure (finding 4) instead of masking it
+    /// as an empty buffer, so a real device/format error can reach the user
+    /// rather than being reported as "No audio captured". On error the state is
+    /// left as `Recording`; callers surface the error and return to Idle (see
+    /// [`Self::stop_recording_guarded`]).
+    pub fn stop_recording(&mut self) -> Result<Vec<f32>, DictationError> {
+        let samples = self.audio.stop_capture()?;
         let duration = self
             .recording_start
             .map(|s| s.elapsed().as_millis())
@@ -182,7 +217,28 @@ impl AppController {
         );
 
         self.state = AppState::Transcribing;
-        samples
+        Ok(samples)
+    }
+
+    /// Stop recording only if currently recording, mapping a capture/resample
+    /// failure onto the error state. Combines the finding-3 guard (a late or
+    /// duplicate stop racing an in-flight transcription must not clobber state)
+    /// and the finding-4 error surfacing (a real capture error is recorded and
+    /// the controller returns to Idle so it reaches the user).
+    pub fn stop_recording_guarded(&mut self) -> StopRecordingOutcome {
+        if !self.state.is_recording() {
+            return StopRecordingOutcome::NotRecording;
+        }
+        match self.stop_recording() {
+            Ok(samples) => StopRecordingOutcome::Stopped(samples),
+            Err(e) => {
+                warn!("Recording stop failed: {e}");
+                let msg = e.to_string();
+                // Records last_error and returns to Idle.
+                self.on_transcription_error(&msg);
+                StopRecordingOutcome::Failed(msg)
+            }
+        }
     }
 
     /// Called after transcription succeeds
@@ -415,6 +471,19 @@ mod tests {
         assert_eq!(result, HotkeyDownResult::NoOp);
     }
 
+    // Finding 1: in push-to-talk mode a hotkey-down while a prior utterance is
+    // still transcribing must NOT report StartedRecording (start_recording
+    // refuses when state != Idle) — otherwise the overlay/tray shows a recording
+    // that never happened and never hides.
+    #[test]
+    fn push_to_talk_down_when_transcribing_is_noop() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
+        ctrl.state = AppState::Transcribing;
+        let result = ctrl.handle_hotkey_down().unwrap();
+        assert_eq!(result, HotkeyDownResult::NoOp);
+    }
+
     // -- auto_paste --
 
     #[test]
@@ -440,8 +509,38 @@ mod tests {
     fn start_recording_when_transcribing_is_noop() {
         let mut ctrl = default_controller();
         ctrl.state = AppState::Transcribing;
-        let result = ctrl.start_recording();
-        assert!(result.is_ok());
+        // Finding 1: refused start reports `false` (did not actually start).
+        let started = ctrl.start_recording().unwrap();
+        assert!(!started);
         assert_eq!(ctrl.state(), AppState::Transcribing); // unchanged
+    }
+
+    // -- stop_recording_guarded --
+
+    // Finding 3: a stop that races an in-flight transcription (state !=
+    // Recording) must be a no-op — it must not transition state nor set
+    // last_error, so the running transcription is not clobbered.
+    #[test]
+    fn stop_recording_guarded_when_not_recording_is_noop() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Transcribing;
+        let outcome = ctrl.stop_recording_guarded();
+        assert!(matches!(outcome, StopRecordingOutcome::NotRecording));
+        assert_eq!(ctrl.state(), AppState::Transcribing); // unchanged
+        assert!(ctrl.last_error().is_none());
+    }
+
+    // Finding 4: a guarded stop from the Recording state returns the captured
+    // samples (here empty — no real capture in the test) and transitions to
+    // Transcribing. Exercises the Result plumbing added for finding 4.
+    #[test]
+    fn stop_recording_guarded_from_recording_returns_stopped() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Recording;
+        match ctrl.stop_recording_guarded() {
+            StopRecordingOutcome::Stopped(samples) => assert!(samples.is_empty()),
+            other => panic!("expected Stopped, got {other:?}"),
+        }
+        assert_eq!(ctrl.state(), AppState::Transcribing);
     }
 }

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -7,6 +7,7 @@ use sagascript_core::audio::AudioCaptureService;
 use sagascript_core::error::DictationError;
 use crate::hotkey::HotkeyService;
 use crate::logging::LoggingService;
+use crate::logging::log_events;
 use crate::paste::PasteService;
 use sagascript_core::settings::{HotkeyMode, Settings};
 
@@ -66,7 +67,7 @@ impl AppController {
         logging.log(
             "info",
             "App",
-            "app_started",
+            log_events::app::STARTED,
             serde_json::json!({ "appSessionId": logging.app_session_id }),
         );
 
@@ -154,7 +155,7 @@ impl AppController {
         self.logging.log(
             "info",
             "App",
-            "dictation_session_started",
+            log_events::session::DICTATION_STARTED,
             serde_json::json!({ "dictationSessionId": session_id }),
         );
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,6 +8,7 @@ use tracing::{error, info};
 const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 
 use crate::app_controller::{AppController, AppState, StopRecordingOutcome};
+use crate::hotkey::{HotkeyHealth, HotkeyStatus};
 use sagascript_core::audio::decoder;
 use sagascript_core::settings::{HotkeyMode, Language, Settings, WhisperModel};
 use sagascript_core::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
@@ -214,8 +215,10 @@ pub async fn set_hotkey_mode(
 pub async fn set_hotkey(
     app: tauri::AppHandle,
     controller: State<'_, SharedController>,
+    health: State<'_, HotkeyHealth>,
     shortcut: String,
 ) -> Result<(), String> {
+    use tauri::Emitter;
     use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
     let old_shortcut = {
@@ -232,9 +235,23 @@ pub async fn set_hotkey(
     // Register new shortcut
     if let Err(e) = app.global_shortcut().register(shortcut.as_str()) {
         error!("Failed to register new hotkey '{}': {}", shortcut, e);
-        // Try to re-register the old one
-        if let Err(e2) = app.global_shortcut().register(old_shortcut.as_str()) {
-            error!("Failed to re-register old hotkey '{}': {}", old_shortcut, e2);
+        // Try to re-register the old one so the app isn't left with no
+        // hotkey bound at all. If that succeeds, the app is still healthy
+        // (the *requested* change failed, which is already surfaced to the
+        // caller via the returned Err below) — only record a health failure
+        // if even the fallback re-registration fails.
+        let change = match app.global_shortcut().register(old_shortcut.as_str()) {
+            Ok(()) => {
+                info!("Re-registered old hotkey '{}' after failed change", old_shortcut);
+                health.record(&old_shortcut, None)
+            }
+            Err(e2) => {
+                error!("Failed to re-register old hotkey '{}': {}", old_shortcut, e2);
+                health.record(&old_shortcut, Some(e2.to_string()))
+            }
+        };
+        if change.changed {
+            let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
         }
         return Err(format!("Failed to register hotkey '{}': {}", shortcut, e));
     }
@@ -246,11 +263,27 @@ pub async fn set_hotkey(
         ctrl.hotkey_service_mut().set_shortcut(&shortcut);
     }
 
+    let change = health.record(&shortcut, None);
+    if change.changed {
+        let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+    }
+
     // Persist via shared store
     persist_settings(&controller)?;
 
     info!("Hotkey changed to: {shortcut}");
     Ok(())
+}
+
+/// Current hotkey registration health — whether the last registration
+/// attempt (at startup, from this command, or from the settings-file
+/// watcher's hot-reload) actually succeeded. Reads the process-wide flag
+/// rather than querying the global-shortcut plugin's `is_registered()`,
+/// which only tells you *a* shortcut is bound, not whether *our* most recent
+/// attempt to bind it succeeded.
+#[tauri::command]
+pub async fn hotkey_status(health: State<'_, HotkeyHealth>) -> Result<HotkeyStatus, String> {
+    Ok(health.status())
 }
 
 // -- Recording --

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use tracing::{error, info};
 /// Maximum time to wait for whisper inference before aborting (seconds)
 const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 
-use crate::app_controller::{AppController, AppState};
+use crate::app_controller::{AppController, AppState, StopRecordingOutcome};
 use sagascript_core::audio::decoder;
 use sagascript_core::settings::{HotkeyMode, Language, Settings, WhisperModel};
 use sagascript_core::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
@@ -258,7 +258,9 @@ pub async fn set_hotkey(
 #[tauri::command]
 pub async fn start_recording(controller: State<'_, SharedController>) -> Result<(), String> {
     let mut ctrl = controller.lock().unwrap();
-    ctrl.start_recording().map_err(|e| e.to_string())
+    // The bool (whether recording actually started) is only meaningful to the
+    // hotkey path; the GUI command just needs success/failure.
+    ctrl.start_recording().map(|_| ()).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -268,7 +270,17 @@ pub async fn stop_and_transcribe(
 ) -> Result<String, String> {
     let (audio, language, effective_model, opts) = {
         let mut ctrl = controller.lock().unwrap();
-        let audio = ctrl.stop_recording();
+        // Guard against a late/duplicate invoke racing the hotkey stop path
+        // (finding 3): if we're not recording, do nothing and return Ok-empty
+        // (NOT Err — an error would surface a misleading toast in the UI) so an
+        // in-flight transcription's state/last_error is not clobbered.
+        let audio = match ctrl.stop_recording_guarded() {
+            StopRecordingOutcome::NotRecording => return Ok(String::new()),
+            // Capture/resample failure (finding 4): the controller already
+            // recorded the error and returned to Idle; surface the real error.
+            StopRecordingOutcome::Failed(msg) => return Err(msg),
+            StopRecordingOutcome::Stopped(audio) => audio,
+        };
         let language = ctrl.language();
         let effective_model = ctrl.settings().effective_model();
         let opts = build_transcribe_options(ctrl.settings());

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -12,6 +12,9 @@ pub mod event {
     pub const MODEL_READY: &str = "model-ready";
     /// Transcription progress percentage (0–100)
     pub const TRANSCRIPTION_PROGRESS: &str = "transcription-progress";
+    /// Hotkey registration health changed (registered OK <-> failed to
+    /// register). Payload: `{ ok: bool, error: string | null, shortcut: string }`.
+    pub const HOTKEY_REGISTRATION_CHANGED: &str = "hotkey-registration-changed";
 }
 
 #[cfg(test)]
@@ -27,6 +30,7 @@ mod tests {
             MODEL_DOWNLOAD_PROGRESS,
             MODEL_READY,
             TRANSCRIPTION_PROGRESS,
+            HOTKEY_REGISTRATION_CHANGED,
         ];
         for name in events {
             assert!(!name.is_empty());
@@ -50,6 +54,7 @@ mod tests {
             MODEL_DOWNLOAD_PROGRESS,
             MODEL_READY,
             TRANSCRIPTION_PROGRESS,
+            HOTKEY_REGISTRATION_CHANGED,
         ];
         for (i, a) in events.iter().enumerate() {
             for (j, b) in events.iter().enumerate() {

--- a/src-tauri/src/hotkey/health.rs
+++ b/src-tauri/src/hotkey/health.rs
@@ -1,0 +1,158 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use serde::Serialize;
+
+/// Snapshot of hotkey registration health, exposed to the frontend via the
+/// `hotkey_status` command and the `hotkey-registration-changed` event.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct HotkeyStatus {
+    pub ok: bool,
+    pub error: Option<String>,
+    pub shortcut: String,
+}
+
+/// Result of recording a registration attempt: the resulting status, plus
+/// whether the ok/failed flag actually flipped. Callers use `changed` to
+/// decide whether to emit `hotkey-registration-changed` — a repeated failure
+/// of the same already-broken shortcut (e.g. the settings watcher firing
+/// again) must not spam listeners.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HotkeyStatusChange {
+    pub status: HotkeyStatus,
+    pub changed: bool,
+}
+
+/// Process-wide hotkey registration health.
+///
+/// Deliberately NOT folded into `AppController`/`HotkeyService`: routing
+/// registration outcomes through the controller mutex — which is already
+/// locked from the global-shortcut handler, the settings-watcher thread, and
+/// the `set_hotkey` command — would risk lock-ordering deadlocks for no real
+/// benefit. This is a small independent piece of shared state (an
+/// `AtomicBool` plus a couple of `Mutex<String>`s for the error/shortcut
+/// detail) instead. It is set on registration failure and cleared on
+/// registration success at all three registration sites: app startup,
+/// `commands::set_hotkey`, and the settings-file watcher's hot-reload path.
+pub struct HotkeyHealth {
+    failed: AtomicBool,
+    error: Mutex<Option<String>>,
+    shortcut: Mutex<String>,
+}
+
+impl HotkeyHealth {
+    pub fn new(initial_shortcut: &str) -> Self {
+        Self {
+            failed: AtomicBool::new(false),
+            error: Mutex::new(None),
+            shortcut: Mutex::new(initial_shortcut.to_string()),
+        }
+    }
+
+    /// True if the most recent registration attempt failed. Sticky until the
+    /// next successful registration clears it.
+    pub fn is_failed(&self) -> bool {
+        self.failed.load(Ordering::SeqCst)
+    }
+
+    pub fn status(&self) -> HotkeyStatus {
+        HotkeyStatus {
+            ok: !self.is_failed(),
+            error: self.error.lock().unwrap().clone(),
+            shortcut: self.shortcut.lock().unwrap().clone(),
+        }
+    }
+
+    /// Record the outcome of a registration attempt for `shortcut`.
+    /// `error = None` means the registration succeeded (clears the flag);
+    /// `Some(msg)` means it failed (sets the flag). Returns the resulting
+    /// status plus whether the ok/failed flag actually changed.
+    pub fn record(&self, shortcut: &str, error: Option<String>) -> HotkeyStatusChange {
+        let new_failed = error.is_some();
+        let prev_failed = self.failed.swap(new_failed, Ordering::SeqCst);
+        *self.error.lock().unwrap() = error.clone();
+        *self.shortcut.lock().unwrap() = shortcut.to_string();
+        HotkeyStatusChange {
+            changed: prev_failed != new_failed,
+            status: HotkeyStatus {
+                ok: !new_failed,
+                error,
+                shortcut: shortcut.to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_not_failed() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        assert!(!h.is_failed());
+        let s = h.status();
+        assert!(s.ok);
+        assert!(s.error.is_none());
+        assert_eq!(s.shortcut, "Control+Shift+Space");
+    }
+
+    #[test]
+    fn record_failure_sets_flag_and_reports_changed() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        let change = h.record("Control+Shift+Space", Some("already registered".to_string()));
+        assert!(change.changed);
+        assert!(!change.status.ok);
+        assert_eq!(change.status.error.as_deref(), Some("already registered"));
+        assert!(h.is_failed());
+    }
+
+    #[test]
+    fn record_same_failure_twice_is_not_changed_second_time() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
+        let second = h.record("Control+Shift+Space", Some("busy".to_string()));
+        assert!(!second.changed);
+        assert!(!second.status.ok);
+    }
+
+    #[test]
+    fn record_success_after_failure_clears_flag_and_reports_changed() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
+        assert!(h.is_failed());
+        let change = h.record("Control+Shift+Space", None);
+        assert!(change.changed);
+        assert!(change.status.ok);
+        assert!(change.status.error.is_none());
+        assert!(!h.is_failed());
+    }
+
+    #[test]
+    fn record_success_after_success_is_not_changed() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        let change = h.record("Control+Shift+Space", None);
+        assert!(!change.changed);
+        assert!(change.status.ok);
+    }
+
+    #[test]
+    fn status_reflects_latest_shortcut() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        h.record("Alt+D", None);
+        assert_eq!(h.status().shortcut, "Alt+D");
+    }
+
+    #[test]
+    fn failure_then_different_failure_is_not_changed_but_updates_detail() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
+        let second = h.record("Alt+D", Some("also busy".to_string()));
+        // The flag itself didn't flip (still failed), but the detail must
+        // still reflect the latest attempt.
+        assert!(!second.changed);
+        assert_eq!(second.status.shortcut, "Alt+D");
+        assert_eq!(second.status.error.as_deref(), Some("also busy"));
+        assert_eq!(h.status().shortcut, "Alt+D");
+    }
+}

--- a/src-tauri/src/hotkey/health.rs
+++ b/src-tauri/src/hotkey/health.rs
@@ -13,10 +13,11 @@ pub struct HotkeyStatus {
 }
 
 /// Result of recording a registration attempt: the resulting status, plus
-/// whether the ok/failed flag actually flipped. Callers use `changed` to
-/// decide whether to emit `hotkey-registration-changed` — a repeated failure
-/// of the same already-broken shortcut (e.g. the settings watcher firing
-/// again) must not spam listeners.
+/// whether the status actually changed (ok/failed flag, shortcut, or error
+/// detail). Callers use `changed` to decide whether to emit
+/// `hotkey-registration-changed` — a repeated identical failure (e.g. the
+/// settings watcher firing again on the same broken shortcut) must not spam
+/// listeners, but a different shortcut or error while still failed must.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HotkeyStatusChange {
     pub status: HotkeyStatus,
@@ -66,19 +67,21 @@ impl HotkeyHealth {
     /// Record the outcome of a registration attempt for `shortcut`.
     /// `error = None` means the registration succeeded (clears the flag);
     /// `Some(msg)` means it failed (sets the flag). Returns the resulting
-    /// status plus whether the ok/failed flag actually changed.
+    /// status plus whether any part of the status actually changed.
     pub fn record(&self, shortcut: &str, error: Option<String>) -> HotkeyStatusChange {
+        let prev = self.status();
         let new_failed = error.is_some();
-        let prev_failed = self.failed.swap(new_failed, Ordering::SeqCst);
+        self.failed.store(new_failed, Ordering::SeqCst);
         *self.error.lock().unwrap() = error.clone();
         *self.shortcut.lock().unwrap() = shortcut.to_string();
+        let status = HotkeyStatus {
+            ok: !new_failed,
+            error,
+            shortcut: shortcut.to_string(),
+        };
         HotkeyStatusChange {
-            changed: prev_failed != new_failed,
-            status: HotkeyStatus {
-                ok: !new_failed,
-                error,
-                shortcut: shortcut.to_string(),
-            },
+            changed: status != prev,
+            status,
         }
     }
 }
@@ -144,13 +147,13 @@ mod tests {
     }
 
     #[test]
-    fn failure_then_different_failure_is_not_changed_but_updates_detail() {
+    fn failure_then_different_failure_reports_changed() {
         let h = HotkeyHealth::new("Control+Shift+Space");
         let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
         let second = h.record("Alt+D", Some("also busy".to_string()));
-        // The flag itself didn't flip (still failed), but the detail must
-        // still reflect the latest attempt.
-        assert!(!second.changed);
+        // The ok/failed flag didn't flip, but the shortcut/error detail did —
+        // listeners must hear about it or the UI shows a stale failure.
+        assert!(second.changed);
         assert_eq!(second.status.shortcut, "Alt+D");
         assert_eq!(second.status.error.as_deref(), Some("also busy"));
         assert_eq!(h.status().shortcut, "Alt+D");

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -1,3 +1,5 @@
+pub mod health;
 pub mod service;
 
+pub use health::{HotkeyHealth, HotkeyStatus};
 pub use service::HotkeyService;

--- a/src-tauri/src/logging/log_events.rs
+++ b/src-tauri/src/logging/log_events.rs
@@ -1,8 +1,16 @@
-/// Log event name constants matching the Swift app's LogEvent structure
-#[allow(dead_code)]
+/// Log event name constants matching the Swift app's LogEvent structure.
+///
+/// Not every constant here is wired up yet from the Rust side — some mirror
+/// events the Swift companion app emits but the Rust app_controller doesn't
+/// (yet) log. Those carry their own `#[allow(dead_code)]` rather than a
+/// blanket module-level one, so newly-wired constants (see `app::STARTED`,
+/// `session::DICTATION_STARTED`) surface a real dead-code warning if their
+/// call site is ever removed without removing the constant too.
 pub mod app {
     pub const STARTED: &str = "app_started";
+    #[allow(dead_code)]
     pub const READY: &str = "app_ready";
+    #[allow(dead_code)]
     pub const TERMINATED: &str = "app_terminated";
 }
 
@@ -38,9 +46,10 @@ pub mod paste {
     pub const FAILED: &str = "paste_failed";
 }
 
-#[allow(dead_code)]
 pub mod session {
     pub const DICTATION_STARTED: &str = "dictation_session_started";
+    #[allow(dead_code)]
     pub const DICTATION_COMPLETE: &str = "dictation_session_complete";
+    #[allow(dead_code)]
     pub const STATE_CHANGED: &str = "state_changed";
 }

--- a/src-tauri/src/logging/service.rs
+++ b/src-tauri/src/logging/service.rs
@@ -35,9 +35,20 @@ pub struct LogEntry {
 
 impl LoggingService {
     pub fn new() -> Self {
-        let app_session_id = format!("app-{}", &Uuid::new_v4().to_string()[..8]);
         let log_dir = Self::log_directory();
         let log_path = log_dir.join("sagascript.log");
+        Self::new_with_path(log_path)
+    }
+
+    /// Construct against an explicit log file path. Test seam for
+    /// `new()` — production code always goes through `new()`, which derives
+    /// the path from `log_directory()`.
+    fn new_with_path(log_path: PathBuf) -> Self {
+        let app_session_id = format!("app-{}", &Uuid::new_v4().to_string()[..8]);
+        let log_dir = log_path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."));
 
         // Create log directory with restrictive permissions
         if let Err(e) = fs::create_dir_all(&log_dir) {
@@ -138,7 +149,7 @@ impl LoggingService {
         }
     }
 
-    fn rotate_if_needed(&self, _file: &mut File) {
+    fn rotate_if_needed(&self, file: &mut File) {
         let size = fs::metadata(&self.log_path)
             .map(|m| m.len())
             .unwrap_or(0);
@@ -147,7 +158,12 @@ impl LoggingService {
             return;
         }
 
-        let dir = Self::log_directory();
+        // Directory of the (possibly test-injected) log path, not the
+        // hardcoded platform log_directory() — matters for `new_with_path`.
+        let dir = match self.log_path.parent() {
+            Some(d) => d.to_path_buf(),
+            None => Self::log_directory(),
+        };
 
         // Delete oldest
         let oldest = dir.join(format!("sagascript.{MAX_FILES}.log"));
@@ -162,10 +178,48 @@ impl LoggingService {
 
         // Current -> .1
         let rotated = dir.join("sagascript.1.log");
-        let _ = fs::rename(&self.log_path, rotated);
-
-        // Reopen
-        // (The caller will need to handle this - for simplicity we just create a new file)
+        match fs::rename(&self.log_path, &rotated) {
+            Ok(()) => {
+                // Reopen a fresh file at the original path and swap it into
+                // the already-held &mut File — do NOT re-lock self.log_file,
+                // write_entry already holds that lock (re-locking a
+                // non-reentrant std Mutex would deadlock). Only swap on Ok
+                // so a failed reopen doesn't silently kill logging (the
+                // caller keeps writing to the renamed .1.log instead of
+                // losing entries).
+                match OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&self.log_path)
+                {
+                    Ok(new_file) => {
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            let _ = fs::set_permissions(
+                                &self.log_path,
+                                fs::Permissions::from_mode(0o600),
+                            );
+                        }
+                        *file = new_file;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Log rotation: failed to reopen fresh log file at {}: {e} — \
+                             continuing to write to the rotated file",
+                            self.log_path.display()
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Log rotation: failed to rename {} to {}: {e}",
+                    self.log_path.display(),
+                    rotated.display()
+                );
+            }
+        }
     }
 }
 
@@ -271,5 +325,73 @@ mod tests {
     fn constants() {
         assert_eq!(MAX_FILE_SIZE, 5_000_000);
         assert_eq!(MAX_FILES, 5);
+    }
+
+    /// Regression test for the rotation-reopen bug: after the first 5MB
+    /// rotation, the live File handle used to keep writing to the renamed
+    /// `.1.log` inode forever (since fs::metadata on the now-missing
+    /// `sagascript.log` path always failed -> unwrap_or(0) -> rotation never
+    /// fired again). A subsequent write must land in a FRESH sagascript.log,
+    /// not the renamed .1.log, and the fresh file must have 0o600 perms.
+    #[test]
+    fn rotate_reopens_file_so_writes_continue_in_fresh_log() {
+        let dir = std::env::temp_dir().join(format!("sagascript-log-test-{}", Uuid::new_v4()));
+        let log_path = dir.join("sagascript.log");
+        let svc = LoggingService::new_with_path(log_path.clone());
+
+        // Inflate the log file past MAX_FILE_SIZE directly (avoids tens of
+        // thousands of svc.log() calls just to cross the threshold).
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(&log_path)
+                .expect("log file should exist after construction");
+            let filler = vec![b'a'; MAX_FILE_SIZE as usize + 1000];
+            f.write_all(&filler).unwrap();
+            f.flush().unwrap();
+        }
+
+        // This write should trigger rotation.
+        svc.log("info", "Test", "trigger_rotation", serde_json::json!({}));
+
+        // Old content should have been moved to sagascript.1.log
+        let rotated = dir.join("sagascript.1.log");
+        assert!(rotated.exists(), "expected rotated file sagascript.1.log to exist");
+        let rotated_size = fs::metadata(&rotated).unwrap().len();
+        assert!(
+            rotated_size >= MAX_FILE_SIZE,
+            "rotated file should hold the old (large) content, got {rotated_size} bytes"
+        );
+
+        // The live path must exist again and be small (just the one JSON
+        // line we wrote after rotation) — NOT the multi-megabyte renamed
+        // content. Against the pre-fix code this fails: either the metadata
+        // call errors (path missing) or the file is still huge.
+        let new_size = fs::metadata(&log_path)
+            .unwrap_or_else(|e| panic!("fresh sagascript.log should exist after rotation: {e}"))
+            .len();
+        assert!(
+            new_size < MAX_FILE_SIZE,
+            "expected a small fresh log file after rotation, got {new_size} bytes (rotation reopen is broken)"
+        );
+
+        // Fresh file must carry the same restrictive permissions as new().
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&log_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "fresh log file should have 0o600 perms");
+        }
+
+        // A second write should append to the fresh file, not error out.
+        let size_before_second_write = new_size;
+        svc.log("info", "Test", "after_rotation", serde_json::json!({}));
+        let size_after_second_write = fs::metadata(&log_path).unwrap().len();
+        assert!(
+            size_after_second_write > size_before_second_write,
+            "second write after rotation should grow the fresh log file"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -199,10 +199,7 @@ fn main() {
                 if let Some(dir) = app_dir {
                     let legacy = dir.join("flowdictate-settings.json");
                     let new_path = dir.join("sagascript-settings.json");
-                    if legacy.exists() && !new_path.exists() {
-                        info!("Migrating settings store from FlowDictate");
-                        let _ = std::fs::rename(&legacy, &new_path);
-                    }
+                    migrate_legacy_settings(&legacy, &new_path);
                 }
             }
 
@@ -348,6 +345,31 @@ fn update_tray_status(app: &tauri::AppHandle, state: &str) {
     }
 
     set_status_menu_text(app, &format!("Sagascript - {menu_text}"));
+}
+
+/// Migrate the legacy FlowDictate settings file to the new Sagascript path, if
+/// present and no Sagascript settings file already exists. Rename failure used
+/// to be silently swallowed (`let _ = std::fs::rename(...)`), which would
+/// silently reset an upgrading user to defaults with no diagnostic trail.
+fn migrate_legacy_settings(legacy: &std::path::Path, new_path: &std::path::Path) {
+    if !legacy.exists() || new_path.exists() {
+        return;
+    }
+
+    info!("Migrating settings store from FlowDictate");
+    match std::fs::rename(legacy, new_path) {
+        Ok(()) => info!(
+            "Migrated settings store from FlowDictate ({}) to Sagascript ({})",
+            legacy.display(),
+            new_path.display()
+        ),
+        Err(e) => warn!(
+            "Failed to migrate FlowDictate settings from {} to {}: {e} — \
+             the upgrading user will fall back to default settings",
+            legacy.display(),
+            new_path.display()
+        ),
+    }
 }
 
 /// Truncate transcription text for tray display, cutting on a char boundary.
@@ -740,5 +762,83 @@ mod tests {
         let text = "🎉".repeat(16);
         let display = truncate_for_tray(&text);
         assert!(std::str::from_utf8(display.as_bytes()).is_ok());
+    }
+
+    fn migrate_test_dir() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("sagascript-migrate-test-{}", uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn migrate_legacy_settings_renames_when_new_absent() {
+        let dir = migrate_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let legacy = dir.join("flowdictate-settings.json");
+        let new_path = dir.join("sagascript-settings.json");
+        std::fs::write(&legacy, r#"{"language":"sv"}"#).unwrap();
+
+        migrate_legacy_settings(&legacy, &new_path);
+
+        assert!(!legacy.exists(), "legacy file should be renamed away");
+        assert!(new_path.exists(), "new path should now hold the migrated settings");
+        assert_eq!(std::fs::read_to_string(&new_path).unwrap(), r#"{"language":"sv"}"#);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn migrate_legacy_settings_noop_when_new_already_exists() {
+        let dir = migrate_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let legacy = dir.join("flowdictate-settings.json");
+        let new_path = dir.join("sagascript-settings.json");
+        std::fs::write(&legacy, "legacy-content").unwrap();
+        std::fs::write(&new_path, "already-migrated-content").unwrap();
+
+        migrate_legacy_settings(&legacy, &new_path);
+
+        // Neither file should be touched — a Sagascript settings file already exists.
+        assert!(legacy.exists());
+        assert_eq!(std::fs::read_to_string(&legacy).unwrap(), "legacy-content");
+        assert_eq!(std::fs::read_to_string(&new_path).unwrap(), "already-migrated-content");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn migrate_legacy_settings_noop_when_legacy_absent() {
+        let dir = migrate_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let legacy = dir.join("flowdictate-settings.json");
+        let new_path = dir.join("sagascript-settings.json");
+
+        // Should not panic when there's nothing to migrate.
+        migrate_legacy_settings(&legacy, &new_path);
+
+        assert!(!new_path.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression test for the swallowed-rename bug: a failed rename (here,
+    /// forced by a destination whose parent directory doesn't exist) must not
+    /// panic, and the legacy file must be left in place rather than lost —
+    /// the old `let _ = std::fs::rename(...)` code silently discarded the
+    /// error either way, but this at least confirms the failure path doesn't
+    /// destroy data.
+    #[test]
+    fn migrate_legacy_settings_does_not_panic_on_rename_failure() {
+        let dir = migrate_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let legacy = dir.join("flowdictate-settings.json");
+        std::fs::write(&legacy, "legacy-content").unwrap();
+        // Destination's parent directory doesn't exist -> rename fails.
+        let new_path = dir.join("nonexistent-subdir").join("sagascript-settings.json");
+
+        migrate_legacy_settings(&legacy, &new_path);
+
+        assert!(legacy.exists(), "legacy file must survive a failed rename");
+        assert!(!new_path.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -75,8 +75,15 @@ fn main() {
 
     let settings = sagascript_core::settings::store::load();
     info!("Loaded settings: language={:?}, model={:?}, hotkey={}", settings.language, settings.whisper_model, settings.hotkey);
+    let initial_hotkey = settings.hotkey.clone();
     let controller = Mutex::new(AppController::new(settings));
     let whisper: SharedWhisper = Arc::new(WhisperBackend::new());
+    // Process-wide hotkey registration health (see hotkey::health for why this
+    // is deliberately independent of the AppController mutex). Assumed healthy
+    // until the first real registration attempt in `.setup()` below proves
+    // otherwise — there's no observable window in between since that attempt
+    // runs synchronously before the event loop starts.
+    let hotkey_health = hotkey::HotkeyHealth::new(&initial_hotkey);
 
     tauri::Builder::default()
         .plugin(
@@ -131,6 +138,7 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .manage(controller)
         .manage(whisper)
+        .manage(hotkey_health)
         .manage(Mutex::new(None::<MenuItem<tauri::Wry>>) as SharedStatusItem)
         .setup(|app| {
             // Hide from dock on macOS (tray-only app)
@@ -146,10 +154,27 @@ fn main() {
                 shortcut
             };
 
-            // Register global shortcut
+            // Register global shortcut. Failure here (combo already claimed by
+            // Spotlight/Raycast/etc.) used to be log-only: the app would look
+            // fine (tray shows "Idle") while being completely unable to
+            // dictate. Recorded in the process-wide health flag so the tray
+            // and Settings UI can surface it.
+            let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
             match app.global_shortcut().register(shortcut.as_str()) {
-                Ok(()) => info!("Hotkey registered: {shortcut}"),
-                Err(e) => error!("Failed to register hotkey: {e}"),
+                Ok(()) => {
+                    info!("Hotkey registered: {shortcut}");
+                    let change = health.record(&shortcut, None);
+                    if change.changed {
+                        let _ = app.emit(events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to register hotkey: {e}");
+                    let change = health.record(&shortcut, Some(e.to_string()));
+                    if change.changed {
+                        let _ = app.emit(events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+                    }
+                }
             }
 
             // Build tray menu
@@ -294,6 +319,7 @@ fn main() {
             commands::set_auto_select_model,
             commands::set_hotkey_mode,
             commands::set_hotkey,
+            commands::hotkey_status,
             commands::start_recording,
             commands::stop_and_transcribe,
             commands::cancel_recording,
@@ -330,14 +356,37 @@ fn main() {
         });
 }
 
-/// Update the tray tooltip, title, and status menu item to reflect current state
-fn update_tray_status(app: &tauri::AppHandle, state: &str) {
-    let (tooltip, title, menu_text) = match state {
+/// Pure state -> (tooltip, title, menu_text) mapping for the tray, extracted
+/// so the "hotkey unavailable" sticky-warning behavior can be unit tested
+/// without a running Tauri app. `hotkey_failed` must win over every normal
+/// state (idle/recording/transcribing/loading_model): once the hotkey is
+/// known to be unregistered, no ordinary state transition is allowed to
+/// silently paper back over "Idle" — that's the whole point of making the
+/// warning sticky.
+fn tray_label(state: &str, hotkey_failed: bool) -> (&'static str, &'static str, &'static str) {
+    if hotkey_failed {
+        return (
+            "Sagascript - Hotkey unavailable",
+            "\u{26A0}",
+            "Hotkey unavailable",
+        );
+    }
+    match state {
         "recording" => ("Sagascript - Recording...", "Rec", "Recording..."),
         "loading_model" => ("Sagascript - Loading model...", "Loading...", "Loading model..."),
         "transcribing" => ("Sagascript - Transcribing...", "...", "Transcribing..."),
         _ => ("Sagascript", "", "Idle"),
-    };
+    }
+}
+
+/// Update the tray tooltip, title, and status menu item to reflect current
+/// state. Consults the process-wide hotkey health flag on every call so a
+/// broken hotkey registration renders as a sticky "Hotkey unavailable"
+/// warning that later state changes (recording -> idle, model-preload status,
+/// etc.) cannot silently overwrite.
+fn update_tray_status(app: &tauri::AppHandle, state: &str) {
+    let hotkey_failed = app.state::<hotkey::HotkeyHealth>().is_failed();
+    let (tooltip, title, menu_text) = tray_label(state, hotkey_failed);
 
     if let Some(tray) = app.tray_by_id("main") {
         let _ = tray.set_tooltip(Some(tooltip));
@@ -387,8 +436,20 @@ fn truncate_for_tray(text: &str) -> String {
     }
 }
 
-/// Update the tray status menu item and tooltip to show the last transcription
+/// Update the tray status menu item and tooltip to show the last transcription.
+///
+/// Guarded the same way as [`update_tray_status`]: if the hotkey is currently
+/// unregistered, showing "Last: <transcription>" would silently overwrite the
+/// sticky "Hotkey unavailable" warning (the exact trap called out in review —
+/// this call always follows an `update_tray_status(_, "idle")` in the success
+/// path). Delegate to `update_tray_status` in that case instead of duplicating
+/// the warning text here.
 fn update_tray_last_result(app: &tauri::AppHandle, text: &str) {
+    if app.state::<hotkey::HotkeyHealth>().is_failed() {
+        update_tray_status(app, "idle");
+        return;
+    }
+
     let display = truncate_for_tray(text);
 
     if let Some(tray) = app.tray_by_id("main") {
@@ -742,13 +803,30 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                     error!("Failed to unregister old hotkey: {e}");
                 }
 
-                match app.global_shortcut().register(new_settings.hotkey.as_str()) {
-                    Ok(()) => info!("Hotkey re-registered: {}", new_settings.hotkey),
+                let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
+                let change = match app.global_shortcut().register(new_settings.hotkey.as_str()) {
+                    Ok(()) => {
+                        info!("Hotkey re-registered: {}", new_settings.hotkey);
+                        health.record(&new_settings.hotkey, None)
+                    }
                     Err(e) => {
                         error!("Failed to register new hotkey '{}': {e}", new_settings.hotkey);
-                        // Re-register the old one as fallback
-                        let _ = app.global_shortcut().register(old_settings.hotkey.as_str());
+                        // Re-register the old one as fallback so the app doesn't
+                        // end up with no hotkey bound at all.
+                        match app.global_shortcut().register(old_settings.hotkey.as_str()) {
+                            Ok(()) => {
+                                info!("Re-registered old hotkey '{}' as fallback", old_settings.hotkey);
+                                health.record(&old_settings.hotkey, None)
+                            }
+                            Err(e2) => {
+                                error!("Failed to re-register old hotkey: {e2}");
+                                health.record(&old_settings.hotkey, Some(e2.to_string()))
+                            }
+                        }
                     }
+                };
+                if change.changed {
+                    let _ = app.emit(events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
                 }
             }
 
@@ -769,6 +847,46 @@ fn start_settings_watcher(app: tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- tray_label --
+
+    #[test]
+    fn tray_label_idle_not_failed() {
+        assert_eq!(tray_label("idle", false), ("Sagascript", "", "Idle"));
+    }
+
+    #[test]
+    fn tray_label_recording_not_failed() {
+        assert_eq!(
+            tray_label("recording", false),
+            ("Sagascript - Recording...", "Rec", "Recording...")
+        );
+    }
+
+    #[test]
+    fn tray_label_hotkey_failed_is_distinct_from_idle() {
+        let failed = tray_label("idle", true);
+        assert_ne!(failed, tray_label("idle", false));
+        assert_eq!(failed.2, "Hotkey unavailable");
+    }
+
+    #[test]
+    fn tray_label_hotkey_failed_wins_over_recording() {
+        // The sticky warning must win over a normal state transition into
+        // "recording" — a hotkey that isn't registered can't actually be
+        // driving a recording state the user trusts.
+        assert_eq!(tray_label("recording", true), tray_label("idle", true));
+    }
+
+    #[test]
+    fn tray_label_hotkey_failed_wins_over_transcribing() {
+        assert_eq!(tray_label("transcribing", true), tray_label("idle", true));
+    }
+
+    #[test]
+    fn tray_label_hotkey_failed_wins_over_loading_model() {
+        assert_eq!(tray_label("loading_model", true), tray_label("idle", true));
+    }
 
     #[test]
     fn truncate_for_tray_empty_string_unchanged() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -350,13 +350,24 @@ fn update_tray_status(app: &tauri::AppHandle, state: &str) {
     set_status_menu_text(app, &format!("Sagascript - {menu_text}"));
 }
 
-/// Update the tray status menu item and tooltip to show the last transcription
-fn update_tray_last_result(app: &tauri::AppHandle, text: &str) {
-    let display = if text.len() > 60 {
-        format!("{}...", &text[..57])
+/// Truncate transcription text for tray display, cutting on a char boundary.
+fn truncate_for_tray(text: &str) -> String {
+    if text.len() > 60 {
+        let cut = text
+            .char_indices()
+            .map(|(i, _)| i)
+            .take_while(|&i| i <= 57)
+            .last()
+            .unwrap_or(0);
+        format!("{}...", &text[..cut])
     } else {
         text.to_string()
-    };
+    }
+}
+
+/// Update the tray status menu item and tooltip to show the last transcription
+fn update_tray_last_result(app: &tauri::AppHandle, text: &str) {
+    let display = truncate_for_tray(text);
 
     if let Some(tray) = app.tray_by_id("main") {
         let _ = tray.set_tooltip(Some(&format!("Sagascript\nLast: {display}")));
@@ -560,6 +571,7 @@ fn stop_recording_and_transcribe(
 
                 let mut c = ctrl.lock().unwrap();
                 c.on_transcription_success(&text);
+                drop(c);
 
                 let _ = app_handle.emit(events::event::TRANSCRIPTION_RESULT, &text);
                 let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
@@ -688,4 +700,45 @@ fn start_settings_watcher(app: tauri::AppHandle) {
             info!("Settings hot-reloaded from disk");
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_for_tray_empty_string_unchanged() {
+        assert_eq!(truncate_for_tray(""), "");
+    }
+
+    #[test]
+    fn truncate_for_tray_ascii_at_threshold_unchanged() {
+        let text = "a".repeat(60);
+        assert_eq!(truncate_for_tray(&text), text);
+    }
+
+    #[test]
+    fn truncate_for_tray_ascii_over_threshold_truncated() {
+        let text = "a".repeat(61);
+        let display = truncate_for_tray(&text);
+        assert_eq!(display, format!("{}...", "a".repeat(57)));
+    }
+
+    #[test]
+    fn truncate_for_tray_multibyte_straddle_does_not_panic() {
+        // "å" is 2 bytes in UTF-8; placed so its second byte falls exactly at
+        // byte offset 57 — the fixed byte-slice cutoff used before the fix.
+        let text = format!("{}å{}", "a".repeat(56), "b".repeat(10));
+        let display = truncate_for_tray(&text);
+        assert!(std::str::from_utf8(display.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncate_for_tray_all_multibyte_does_not_panic() {
+        // "🎉" is 4 bytes in UTF-8; 16 repeats = 64 bytes, so byte offset 57
+        // never lands on a char boundary.
+        let text = "🎉".repeat(16);
+        let display = truncate_for_tray(&text);
+        assert!(std::str::from_utf8(display.as_bytes()).is_ok());
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -218,6 +218,12 @@ fn main() {
 
             info!("Tray icon created");
 
+            // Render the initial tray state through the same path as later
+            // updates — the hotkey-health flag was recorded above, before the
+            // tray existed, and no state transition may ever come to refresh
+            // a static "Idle" label if the hotkey is dead.
+            update_tray_status(app.handle(), "idle");
+
             // Migrate settings store from FlowDictate
             {
                 let app_dir = app.path().app_data_dir().ok();
@@ -636,7 +642,7 @@ fn stop_recording_and_transcribe(
         // Show model loading status in tray
         if whisper.needs_reload(effective_model) {
             let _ = app_handle.emit(events::event::STATE_CHANGED, "loading_model");
-            update_tray_status(&app_handle, "loading_model");
+            dispatch_to_main(&app_handle, |app| update_tray_status(app, "loading_model"));
         }
 
         // Ensure model is loaded
@@ -700,17 +706,21 @@ fn stop_recording_and_transcribe(
 
                 let _ = app_handle.emit(events::event::TRANSCRIPTION_RESULT, &text);
                 let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
-                update_tray_status(&app_handle, "idle");
-                update_tray_last_result(&app_handle, &text);
+                let text_for_tray = text.clone();
+                dispatch_to_main(&app_handle, move |app| {
+                    update_tray_status(app, "idle");
+                    update_tray_last_result(app, &text_for_tray);
+                });
                 info!("Transcription flow complete, app should remain running");
             }
             Err(e) => {
                 error!("Transcription failed: {e}");
                 let mut c = ctrl.lock().unwrap();
                 c.on_transcription_error(&e.to_string());
+                drop(c);
                 let _ = app_handle.emit(events::event::ERROR, e.to_string());
                 let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
-                update_tray_status(&app_handle, "idle");
+                dispatch_to_main(&app_handle, |app| update_tray_status(app, "idle"));
                 info!("Error flow complete, app should remain running");
             }
         }
@@ -812,15 +822,30 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                     Err(e) => {
                         error!("Failed to register new hotkey '{}': {e}", new_settings.hotkey);
                         // Re-register the old one as fallback so the app doesn't
-                        // end up with no hotkey bound at all.
+                        // end up with no hotkey bound at all. Either way the
+                        // SAVED shortcut is not registered — health must report
+                        // the saved shortcut's failure, not a false-normal for
+                        // the operational fallback.
                         match app.global_shortcut().register(old_settings.hotkey.as_str()) {
                             Ok(()) => {
                                 info!("Re-registered old hotkey '{}' as fallback", old_settings.hotkey);
-                                health.record(&old_settings.hotkey, None)
+                                health.record(
+                                    &new_settings.hotkey,
+                                    Some(format!(
+                                        "failed to register: {e}; still using previous hotkey '{}'",
+                                        old_settings.hotkey
+                                    )),
+                                )
                             }
                             Err(e2) => {
                                 error!("Failed to re-register old hotkey: {e2}");
-                                health.record(&old_settings.hotkey, Some(e2.to_string()))
+                                health.record(
+                                    &new_settings.hotkey,
+                                    Some(format!(
+                                        "failed to register: {e}; fallback to '{}' also failed: {e2}",
+                                        old_settings.hotkey
+                                    )),
+                                )
                             }
                         }
                     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,7 +38,7 @@ use tauri::{
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tracing::{error, info, warn};
 
-use app_controller::{AppController, HotkeyDownResult};
+use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
 use sagascript_core::transcription::WhisperBackend;
 
@@ -443,56 +443,98 @@ fn handle_hotkey_release(
     stop_recording_and_transcribe(app, ctrl);
 }
 
+/// Run a UI closure on the macOS main thread. NSStatusItem / NSWindow (tray,
+/// overlay) APIs must not be touched from a worker thread; best-effort — logs
+/// if the dispatch itself fails.
+fn dispatch_to_main<F>(app: &tauri::AppHandle, f: F)
+where
+    F: FnOnce(&tauri::AppHandle) + Send + 'static,
+{
+    let app_for_closure = app.clone();
+    if let Err(e) = app.run_on_main_thread(move || f(&app_for_closure)) {
+        error!("Failed to dispatch UI work to main thread: {e}");
+    }
+}
+
 /// Stop recording, enforce minimum duration, and spawn transcription.
 /// Shared by both push-to-talk (on key-up) and toggle (on second key-down).
 fn stop_recording_and_transcribe(
     app: &tauri::AppHandle,
     ctrl: &tauri::State<'_, SharedController>,
 ) {
-    // Enforce minimum recording duration
+    // Compute how long we still need to hold to satisfy the minimum recording
+    // duration — but do NOT block the global-shortcut (UI) thread waiting for it
+    // (finding 2): a std::thread::sleep here freezes UI redraw and stalls
+    // subsequent hotkey events. The delay is offloaded to an async task below.
     let elapsed = {
         let c = ctrl.lock().unwrap();
         c.recording_elapsed()
     };
-
-    if elapsed < Duration::from_millis(MIN_RECORDING_MS) {
-        let remaining = Duration::from_millis(MIN_RECORDING_MS) - elapsed;
+    let min = Duration::from_millis(MIN_RECORDING_MS);
+    let remaining = if elapsed < min {
+        let rem = min - elapsed;
         info!(
-            "Recording too short ({:.0}ms), waiting {:.0}ms...",
+            "Recording too short ({:.0}ms), deferring stop by {:.0}ms off the UI thread...",
             elapsed.as_millis(),
-            remaining.as_millis()
+            rem.as_millis()
         );
-        std::thread::sleep(remaining);
-    }
-
-    // Stop recording (single lock acquisition)
-    let audio = {
-        let mut c = ctrl.lock().unwrap();
-        if c.state().is_recording() {
-            c.stop_recording()
-        } else {
-            return;
-        }
+        Some(rem)
+    } else {
+        None
     };
 
-    // Hide overlay now that recording has stopped
-    overlay::hide(app);
-
-    // Update tray to show transcribing state
-    let _ = app.emit(events::event::STATE_CHANGED, "transcribing");
-    update_tray_status(app, "transcribing");
-
-    if audio.is_empty() {
-        let mut c = ctrl.lock().unwrap();
-        c.on_transcription_error("No audio captured");
-        let _ = app.emit(events::event::STATE_CHANGED, "idle");
-        update_tray_status(app, "idle");
-        return;
-    }
-
-    // Transcribe asynchronously to avoid blocking the hotkey thread
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
+        // Min-duration top-up delay, offloaded so the UI thread stays responsive.
+        if let Some(rem) = remaining {
+            tokio::time::sleep(rem).await;
+        }
+
+        // Stop recording (single lock acquisition, re-acquired here since the
+        // controller State can't be moved into the task). Guarded so a stop that
+        // races an already-stopped session is a no-op, and a capture/resample
+        // failure surfaces as a real error (findings 3 & 4).
+        let outcome = {
+            let ctrl: tauri::State<'_, SharedController> = app_handle.state();
+            let mut c = ctrl.lock().unwrap();
+            c.stop_recording_guarded()
+        };
+        let audio = match outcome {
+            StopRecordingOutcome::NotRecording => return,
+            StopRecordingOutcome::Failed(msg) => {
+                error!("Recording stop failed: {msg}");
+                dispatch_to_main(&app_handle, |app| {
+                    overlay::hide(app);
+                    update_tray_status(app, "idle");
+                });
+                let _ = app_handle.emit(events::event::ERROR, msg);
+                let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
+                return;
+            }
+            StopRecordingOutcome::Stopped(audio) => audio,
+        };
+
+        // Hide overlay + show the transcribing state — re-dispatched to the main
+        // thread now that this runs on a worker.
+        dispatch_to_main(&app_handle, |app| {
+            overlay::hide(app);
+            update_tray_status(app, "transcribing");
+        });
+        let _ = app_handle.emit(events::event::STATE_CHANGED, "transcribing");
+
+        if audio.is_empty() {
+            {
+                let ctrl: tauri::State<'_, SharedController> = app_handle.state();
+                ctrl.lock().unwrap().on_transcription_error("No audio captured");
+            }
+            dispatch_to_main(&app_handle, |app| update_tray_status(app, "idle"));
+            let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
+            return;
+        }
+
+        // Transcribe (timeout/cancellation logic is owned by a separate work
+        // package — left unchanged). Runs in this same task, which is already
+        // off the UI thread.
         let ctrl: tauri::State<'_, SharedController> = app_handle.state();
         let whisper: tauri::State<'_, SharedWhisper> = app_handle.state();
 

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -31,6 +31,10 @@
   let downloadError: string | null = $state(null);
   let downloadComplete = $state(false);
 
+  // Language step / final "finish" step errors
+  let languageError: string | null = $state(null);
+  let finishError: string | null = $state(null);
+
   // Permissions
   // micStatus: "authorized" | "not_determined" | "denied" | "restricted" | "unsupported" | "checking"
   let micStatus: string = $state("checking");
@@ -81,8 +85,13 @@
   // -- Language --
 
   async function selectLanguageAndContinue() {
-    await setLanguage(selectedLanguage);
-    nextStep();
+    languageError = null;
+    try {
+      await setLanguage(selectedLanguage);
+      nextStep();
+    } catch (e: any) {
+      languageError = typeof e === "string" ? e : e?.message ?? "Failed to save language. Please try again.";
+    }
   }
 
   // -- Model download --
@@ -167,9 +176,14 @@
   }
 
   async function finish() {
-    stopPoll();
-    await setOnboardingCompleted();
-    oncomplete();
+    finishError = null;
+    try {
+      stopPoll();
+      await setOnboardingCompleted();
+      oncomplete();
+    } catch (e: any) {
+      finishError = typeof e === "string" ? e : e?.message ?? "Failed to complete setup. Please try again.";
+    }
   }
 
   function formatProgress(pct: number): string {
@@ -312,6 +326,12 @@
             <span class="lang-name">Norsk</span>
           </button>
         </div>
+        {#if languageError}
+          <div class="status-indicator error">
+            <span class="status-dot"></span>
+            <span>{languageError}</span>
+          </div>
+        {/if}
         <div class="actions">
           <button class="primary" onclick={selectLanguageAndContinue}>Continue</button>
         </div>
@@ -553,6 +573,13 @@
         {/if}
 
         <p class="subdescription">You can change any of this in Settings.</p>
+
+        {#if finishError}
+          <div class="status-indicator error">
+            <span class="status-dot"></span>
+            <span>{finishError}</span>
+          </div>
+        {/if}
 
         <div class="actions">
           <button class="primary" onclick={finish}>Start Using Sagascript</button>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -45,6 +45,14 @@
 
   let platform: string = $state("macos");
 
+  // Initial data-fetch + settings-mutation error states
+  let initError: string = $state("");
+  let settingsError: string = $state("");
+
+  // Model selection state
+  let selecting: boolean = $state(false);
+  let modelError: string = $state("");
+
   let accessibilityGranted: boolean = $state(true); // assume true; checked on mount for macOS
 
   // Hotkey recorder state
@@ -74,24 +82,10 @@
   let transcribePrompt: string = $state('');
   let transcribeDiarize: boolean = $state(false);
 
-  onMount(async () => {
-    settings = await getSettings();
-    platform = await getPlatform();
-    if (platform === "macos") {
-      accessibilityGranted = await checkAccessibilityPermission();
-    }
-    buildInfo = await getBuildInfo();
-    models = await getModelInfo();
-    loadedModel = await getLoadedModel();
-    supportedFormats = await getSupportedFormats();
-
-    // Check URL params for initial tab
-    const params = new URLSearchParams(window.location.search);
-    const tab = params.get("tab");
-    if (tab === "dictate" || tab === "transcribe" || tab === "settings") {
-      activeTab = tab;
-    }
-
+  onMount(() => {
+    // Register listeners + drag-drop FIRST — they don't depend on the data
+    // fetched below, so a rejected invoke in the fetch sequence must never
+    // prevent them from wiring up (e.g. a stuck-at-0% download).
     listen("model-download-progress", (event: any) => {
       downloadProgress = event.payload.progress;
     });
@@ -131,29 +125,74 @@
         dragOver = false;
       }
     });
+
+    // Fetch initial data. A rejection here surfaces as a visible inline
+    // error instead of leaving a half-initialized window.
+    (async () => {
+      initError = "";
+      try {
+        settings = await getSettings();
+        platform = await getPlatform();
+        if (platform === "macos") {
+          accessibilityGranted = await checkAccessibilityPermission();
+        }
+        buildInfo = await getBuildInfo();
+        models = await getModelInfo();
+        loadedModel = await getLoadedModel();
+        supportedFormats = await getSupportedFormats();
+
+        // Check URL params for initial tab
+        const params = new URLSearchParams(window.location.search);
+        const tab = params.get("tab");
+        if (tab === "dictate" || tab === "transcribe" || tab === "settings") {
+          activeTab = tab;
+        }
+      } catch (e: any) {
+        initError = typeof e === "string" ? e : e?.message || "Failed to load settings.";
+      }
+    })();
   });
+
+  /**
+   * Shared wrapper for the common "mutate then refresh settings" pattern.
+   * On failure: records a visible error and forces bound controls back to
+   * last-known-good by reassigning `settings` to a fresh object (one-way
+   * bindings re-render from state, so a native control that already shows
+   * the rejected value snaps back). Never re-throws.
+   */
+  async function applySetting(mutate: () => Promise<void>): Promise<boolean> {
+    settingsError = "";
+    try {
+      await mutate();
+      settings = await getSettings();
+      return true;
+    } catch (e: any) {
+      settingsError = typeof e === "string" ? e : e?.message || "Failed to save setting.";
+      if (settings) settings = { ...settings };
+      return false;
+    }
+  }
 
   async function onLanguageChange(e: Event) {
     const value = (e.target as HTMLSelectElement).value as Language;
-    await setLanguage(value);
-    settings = await getSettings();
-    models = await getModelInfo();
-    loadedModel = await getLoadedModel();
+    const ok = await applySetting(() => setLanguage(value));
+    if (ok) {
+      models = await getModelInfo();
+      loadedModel = await getLoadedModel();
+    }
   }
 
   async function onHotkeyModeChange(e: Event) {
     const value = (e.target as HTMLSelectElement).value as HotkeyMode;
-    await setHotkeyMode(value);
-    settings = await getSettings();
+    await applySetting(() => setHotkeyMode(value));
   }
 
   async function onAutoPasteToggle() {
     if (!settings) return;
     const enabling = !settings.auto_paste;
-    await setAutoPaste(enabling);
-    settings = await getSettings();
+    const ok = await applySetting(() => setAutoPaste(enabling));
     // When enabling on macOS, check Accessibility permission
-    if (enabling && platform === "macos") {
+    if (ok && enabling && platform === "macos") {
       accessibilityGranted = await checkAccessibilityPermission();
       if (!accessibilityGranted) {
         await requestAccessibilityPermission();
@@ -163,36 +202,37 @@
 
   async function onShowOverlayToggle() {
     if (!settings) return;
-    await setShowOverlay(!settings.show_overlay);
-    settings = await getSettings();
+    const next = !settings.show_overlay;
+    await applySetting(() => setShowOverlay(next));
   }
 
   async function onInitialPromptBlur(e: Event) {
     if (!settings) return;
     const value = (e.target as HTMLTextAreaElement).value;
-    await setInitialPrompt(value);
-    settings = await getSettings();
+    await applySetting(() => setInitialPrompt(value));
   }
 
   async function onBeamSizeChange(e: Event) {
     const value = Number((e.target as HTMLSelectElement).value);
-    await setBeamSize(value);
-    settings = await getSettings();
+    await applySetting(() => setBeamSize(value));
   }
 
   async function onTemperatureFallbackToggle() {
     if (!settings) return;
-    await setTemperatureFallback(!settings.temperature_fallback);
-    settings = await getSettings();
+    const next = !settings.temperature_fallback;
+    await applySetting(() => setTemperatureFallback(next));
   }
 
   async function onVadToggle() {
     if (!settings) return;
-    await setVadEnabled(!settings.vad_enabled);
-    settings = await getSettings();
+    const next = !settings.vad_enabled;
+    await applySetting(() => setVadEnabled(next));
   }
 
   async function selectModel(model: WhisperModel) {
+    if (selecting) return;
+    selecting = true;
+    modelError = "";
     try {
       if (!model.downloaded) {
         downloading = model.id;
@@ -205,11 +245,12 @@
       settings = await getSettings();
       models = await getModelInfo();
       loadedModel = await getLoadedModel();
-    } catch (e) {
-      console.error("Model selection failed:", e);
+    } catch (e: any) {
+      modelError = typeof e === "string" ? e : e?.message || "Model selection failed.";
     } finally {
       downloading = null;
       downloadProgress = 0;
+      selecting = false;
     }
   }
 
@@ -240,6 +281,7 @@
   }
 
   async function handleFileTranscription(filePath: string) {
+    if (transcribing) return;
     transcribing = true;
     transcriptionProgress = 0;
     transcribeError = "";
@@ -405,6 +447,12 @@
 
   {#if settings}
     <div class="content">
+      {#if initError}
+        <div class="transcribe-error">{initError}</div>
+      {/if}
+      {#if settingsError}
+        <div class="transcribe-error">{settingsError}</div>
+      {/if}
       {#if activeTab === "dictate"}
         <button class="active-config-bar" onclick={() => (activeTab = "settings")}>
           <div class="active-config-row">
@@ -583,7 +631,7 @@
               class:active={model.active}
               class:downloading={downloading === model.id}
               onclick={() => selectModel(model)}
-              disabled={downloading !== null}
+              disabled={downloading !== null || selecting}
             >
               <div class="model-card-header">
                 <span class="model-card-name">{model.display_name}</span>
@@ -604,6 +652,10 @@
             </button>
           {/each}
         </div>
+
+        {#if modelError}
+          <div class="transcribe-error">{modelError}</div>
+        {/if}
 
         <div class="model-hint">
           Pick a size. Larger models are more accurate but take longer to transcribe.
@@ -684,7 +736,13 @@
       {/if}
     </div>
   {:else}
-    <div class="loading">Loading settings...</div>
+    <div class="loading">
+      {#if initError}
+        <div class="transcribe-error">{initError}</div>
+      {:else}
+        Loading settings...
+      {/if}
+    </div>
   {/if}
 
   {#if downloading}

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -755,7 +755,7 @@
             {#if buildInfo}
               Sagascript {buildInfo.version} ({buildInfo.git_hash}) - Built {buildInfo.build_date}
             {:else}
-              Sagascript 0.1.0
+              Sagascript
             {/if}
           </div>
         </div>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -23,12 +23,14 @@
     requestAccessibilityPermission,
     startRecording,
     stopAndTranscribe,
+    hotkeyStatus,
     type Settings,
     type BuildInfo,
     type Language,
     type HotkeyMode,
     type WhisperModel,
     type LoadedModelInfo,
+    type HotkeyStatus,
   } from "./api";
   import { listen } from "@tauri-apps/api/event";
   import { open } from "@tauri-apps/plugin-dialog";
@@ -59,6 +61,14 @@
   let recordingHotkey: boolean = $state(false);
   let hotkeyError: string = $state("");
   let hotkeyRecorderEl: HTMLButtonElement | undefined = $state();
+
+  // Hotkey registration health — is the saved hotkey actually bound right
+  // now? (distinct from hotkeyError above, which is about validating a
+  // shortcut the user is in the middle of entering.) Assume healthy until
+  // proven otherwise so there's no flash of a warning before the initial
+  // fetch resolves.
+  let hotkeyStatusOk: boolean = $state(true);
+  let hotkeyStatusError: string = $state("");
 
   $effect(() => {
     if (recordingHotkey && hotkeyRecorderEl) {
@@ -101,6 +111,15 @@
       loadedModel = await getLoadedModel();
     });
 
+    // Hotkey registration health can change at any time (settings-file
+    // hot-reload, a failed re-register racing a Spotlight/Raycast combo
+    // claim, etc.) — not just as a result of something this window did.
+    listen("hotkey-registration-changed", (event: any) => {
+      const status = event.payload as HotkeyStatus;
+      hotkeyStatusOk = status.ok;
+      hotkeyStatusError = status.error ?? "";
+    });
+
     // Listen for tab navigation from tray menu
     listen("navigate_tab", (event: any) => {
       const t = event.payload;
@@ -140,6 +159,9 @@
         models = await getModelInfo();
         loadedModel = await getLoadedModel();
         supportedFormats = await getSupportedFormats();
+        const status = await hotkeyStatus();
+        hotkeyStatusOk = status.ok;
+        hotkeyStatusError = status.error ?? "";
 
         // Check URL params for initial tab
         const params = new URLSearchParams(window.location.search);
@@ -490,6 +512,10 @@
           {/if}
           {#if hotkeyError}
             <div class="hotkey-error">{hotkeyError}</div>
+          {:else if !hotkeyStatusOk}
+            <div class="hotkey-error">
+              ⚠ Not registered{hotkeyStatusError ? `: ${hotkeyStatusError}` : ""} — this shortcut may already be in use by another app. Try a different combination.
+            </div>
           {/if}
           <div class="hotkey-hint">Modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key (A–Z, 0–9, F1–F12, Space, arrows)</div>
         </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -42,6 +42,12 @@ export interface LoadedModelInfo {
 
 export type AppState = "idle" | "recording" | "transcribing" | "error";
 
+export interface HotkeyStatus {
+  ok: boolean;
+  error: string | null;
+  shortcut: string;
+}
+
 export async function getState(): Promise<AppState> {
   return invoke("get_state");
 }
@@ -72,6 +78,12 @@ export async function setHotkeyMode(mode: HotkeyMode): Promise<void> {
 
 export async function setHotkey(shortcut: string): Promise<void> {
   return invoke("set_hotkey", { shortcut });
+}
+
+/** Whether the hotkey is actually registered right now (not just the saved
+ * setting) — reads the backend's process-wide registration-health flag. */
+export async function hotkeyStatus(): Promise<HotkeyStatus> {
+  return invoke("hotkey_status");
 }
 
 export async function setAutoPaste(enabled: boolean): Promise<void> {


### PR DESCRIPTION
### Summary

This PR addresses 46 adversarially verified findings from a multi-agent stability audit of the Sagascript codebase, implementing 6 of 7 planned work packages. The seventh (whisper-timeout cancellation) lands as a separate PR because it touches warm-state locking.

### Work packages

- **WP1 Crash safety** (`fix(stability)`)
  - Tray tooltip truncated transcriptions at a fixed *byte* offset — Swedish/emoji text panicked mid-character at byte 57 **while the AppController mutex was held**, poisoning it: every command and the global hotkey then panicked until app restart. Fixed with char-boundary `truncate_for_tray()` + dropping the guard before tray updates.
  - NaN-safe speaker-clustering sort (was `partial_cmp().unwrap()`); `l2_normalize` sanitizes non-finite embedding components.
  - `app_data_dir()` no longer panics when the platform data directory is missing.

- **WP3 Download pipeline** (`fix(models)`)
  - The stream-to-tmp-then-rename routine was triplicated (whisper/VAD/diarization models) and drifting; now one shared `download_to_path` in `sagascript-core`.
  - Every error path deletes the partial `.tmp` (previously multi-hundred-MB orphans persisted forever).
  - Validates `Content-Length` and ggml magic before rename (previously an HTML rate-limit page or git-LFS pointer got renamed to `ggml-*.bin` and wedged transcription until a manual delete).
  - Unique per-invocation tmp names prevent concurrent-download corruption; orphan `.tmp` sweep added.
  - FlowDictate → Sagascript model-dir migration extracted and covered with 4 tempdir tests.

- **WP6 Frontend** (`fix(ui)`)
  - Settings listeners register before data fetches (one failed invoke used to silently kill all event wiring).
  - All 8 settings mutation handlers get try/catch with snap-back to last-known-good.
  - Re-entrancy guards on drag-drop transcription and model selection; visible error states for model selection and onboarding failures.

- **WP7 Hygiene** (`chore(hygiene)`)
  - Shared `resolve_effective_model` for the `transcribe`/`record` CLI commands (branch was duplicated verbatim; the only existing tests covered a *dead* function with different semantics — false coverage). Dead `resolve_model` deleted.
  - CI now checks/tests/clippies the `diarization` feature on macOS (61 diarization tests previously never compiled in CI).
  - `app_controller` event strings wired to `log_events` constants; never-constructed `DictationError::HotkeyError` removed; unused `tracing` dep dropped.
  - `--diarize-threshold` validated (finite, 0.0–2.0); `package.json` version aligned to 0.0.1.

- **WP2a Recording state machine** (`fix(recording)`)
  - `start_recording()` now reports whether it actually started — push-to-talk no longer shows a phantom recording overlay when held during transcription.
  - The 300ms min-duration sleep moved off the macOS main/UI thread (was freezing redraw and hotkey events); UI work re-dispatched via `run_on_main_thread`.
  - GUI `stop_and_transcribe` guarded against non-recording invokes; `stop_capture()` returns `Result` so resample failures surface as real errors instead of a misleading "No audio captured".

- **WP4 Durability** (`fix(durability)`)
  - Log rotation reopens the file handle — after the first 5MB rotation the handle kept writing to the renamed inode forever (`tail -f` on the documented log path showed nothing; rotation never fired again).
  - Settings load logs a warning instead of silently resetting everything on parse failure; settings save backs up a corrupt existing file to `.bak` before writing (previously silently dropped preserved keys like `hasCompletedOnboarding`).
  - FlowDictate settings-migration rename failure now logged; audio decode has a documented ~4h cap against OOM on huge media; whisper segment UTF-8 conversion failures logged instead of silently dropped.

- **WP5 Hotkey observability** (`feat(hotkey)`)
  - Hotkey registration failure (combo claimed by Spotlight/Raycast) was invisible — the app looked idle but was dead.
  - New `HotkeyHealth` state (deliberately outside the controller mutex) recorded at all three registration sites; sticky "Hotkey unavailable" tray label that normal state transitions cannot overwrite; `hotkey-registration-changed` event + `hotkey_status` command; warning badge in Settings.

### Verification

- 232 Rust tests pass (183 at baseline, 49 net-new); `cargo clippy --workspace --all-targets -- -D warnings` clean.
- 173 tests pass with `--features diarization`; `svelte-check` 0 errors (10 pre-existing a11y warnings unchanged); `vite build` clean.
- End-to-end CLI transcription smoke-tested on a real clip through the refactored pipeline.
- Fixes were developed red/green — failing test first wherever a deterministic seam existed.
- Risky fix variants (field-level settings recovery, streaming decode, lossy segment rendering, HotkeyService source-of-truth refactor) were deliberately deferred and documented in the audit plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
