### PR TITLE
feat(cli): --hint / --hint-file vocabulary hinting for transcribe + record (#75)

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -698,6 +698,7 @@ mod tests {
             "--model", "kb-whisper-base",
             "--json",
             "--clipboard",
+            "--prompt", "Notre Dame, Sara",
         ]).unwrap();
         match cli.command.unwrap() {
             Command::Transcribe(args) => {
@@ -706,9 +707,50 @@ mod tests {
                 assert_eq!(args.model.as_deref(), Some("kb-whisper-base"));
                 assert!(args.json);
                 assert!(args.clipboard);
+                assert_eq!(args.prompt.as_deref(), Some("Notre Dame, Sara"));
+                assert!(args.prompt_file.is_none());
             }
             _ => panic!("expected Transcribe"),
         }
+    }
+
+    #[test]
+    fn parse_transcribe_hint_alias() {
+        // --hint is a visible alias of --prompt and populates the same field.
+        let cli = Cli::try_parse_from([
+            "sagascript", "transcribe", "f.wav", "--hint", "Estrid, Grimnir",
+        ]).unwrap();
+        match cli.command.unwrap() {
+            Command::Transcribe(args) => {
+                assert_eq!(args.prompt.as_deref(), Some("Estrid, Grimnir"));
+            }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn parse_transcribe_prompt_file() {
+        // --hint-file is a visible alias of --prompt-file.
+        let cli = Cli::try_parse_from([
+            "sagascript", "transcribe", "f.wav", "--hint-file", "vocab.txt",
+        ]).unwrap();
+        match cli.command.unwrap() {
+            Command::Transcribe(args) => {
+                assert_eq!(args.prompt_file, Some(PathBuf::from("vocab.txt")));
+                assert!(args.prompt.is_none());
+            }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn parse_transcribe_prompt_and_file_conflict() {
+        // --prompt and --prompt-file are mutually exclusive.
+        let result = Cli::try_parse_from([
+            "sagascript", "transcribe", "f.wav",
+            "--prompt", "inline", "--prompt-file", "vocab.txt",
+        ]);
+        assert!(result.is_err(), "expected --prompt + --prompt-file to conflict");
     }
 
     #[test]
@@ -737,6 +779,8 @@ mod tests {
                 assert!(args.output.is_none());
                 assert!(!args.json);
                 assert!(!args.clipboard);
+                assert!(args.prompt.is_none());
+                assert!(args.prompt_file.is_none());
             }
             _ => panic!("expected Record"),
         }
@@ -753,6 +797,7 @@ mod tests {
             "--output", "capture.wav",
             "--json",
             "--clipboard",
+            "--hint", "Notre Dame, Sara",
         ]).unwrap();
         match cli.command.unwrap() {
             Command::Record(args) => {
@@ -762,6 +807,8 @@ mod tests {
                 assert_eq!(args.output.as_deref(), Some("capture.wav"));
                 assert!(args.json);
                 assert!(args.clipboard);
+                // --hint populates the same `prompt` field as --prompt.
+                assert_eq!(args.prompt.as_deref(), Some("Notre Dame, Sara"));
             }
             _ => panic!("expected Record"),
         }

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -12,6 +13,7 @@ use sagascript_core::transcription::WhisperBackend;
 
 use super::transcribe::{
     copy_to_clipboard, model_id_string, parse_language, resolve_effective_model,
+    resolve_effective_prompt,
 };
 
 #[derive(Args)]
@@ -39,6 +41,17 @@ pub struct RecordArgs {
     /// Copy transcription result to clipboard
     #[arg(long)]
     pub clipboard: bool,
+
+    /// Hint the decoder with domain-specific vocabulary (Whisper initial prompt).
+    /// Reduces mishearings of proper nouns, foreign names, and jargon.
+    /// Example: --hint "Notre Dame, Sara, Grimnir"
+    #[arg(long, visible_alias = "hint", value_name = "TEXT")]
+    pub prompt: Option<String>,
+
+    /// Read the hint/initial prompt from a file instead of the command line.
+    /// Mutually exclusive with --hint/--prompt.
+    #[arg(long, visible_alias = "hint-file", value_name = "PATH", conflicts_with = "prompt")]
+    pub prompt_file: Option<PathBuf>,
 }
 
 pub fn run(args: RecordArgs) -> Result<(), DictationError> {
@@ -47,6 +60,14 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         Some(l) => parse_language(l)?,
         None => stored.language,
     };
+    // Effective hint/prompt: --prompt-file, else --hint/--prompt, else the saved
+    // initial_prompt. Resolved up front so a bad --prompt-file fails before we
+    // spend time recording.
+    let effective_prompt = resolve_effective_prompt(
+        args.prompt.as_deref(),
+        args.prompt_file.as_deref(),
+        &stored.initial_prompt,
+    )?;
     let save_only = args.output.is_some();
 
     // Only validate model if we're going to transcribe
@@ -122,6 +143,7 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
+    let prompt = effective_prompt.as_deref();
     let text = if duration > 10.0 {
         let pb = ProgressBar::new(100);
         pb.set_style(
@@ -129,14 +151,19 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
                 .unwrap(),
         );
         let pb_cb = pb.clone();
-        let text = backend.transcribe_sync_with_progress(&audio, language, move |pct| {
-            pb_cb.set_position(pct as u64);
-        })?;
+        let text = backend.transcribe_sync_with_progress_and_prompt(
+            &audio,
+            language,
+            prompt,
+            move |pct| {
+                pb_cb.set_position(pct as u64);
+            },
+        )?;
         pb.finish_and_clear();
         text
     } else {
         eprintln!("Transcribing...");
-        backend.transcribe_sync(&audio, language)?
+        backend.transcribe_sync_with_progress_and_prompt(&audio, language, prompt, |_| {})?
     };
 
     // Output

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -60,15 +60,20 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         Some(l) => parse_language(l)?,
         None => stored.language,
     };
+    let save_only = args.output.is_some();
     // Effective hint/prompt: --prompt-file, else --hint/--prompt, else the saved
     // initial_prompt. Resolved up front so a bad --prompt-file fails before we
-    // spend time recording.
-    let effective_prompt = resolve_effective_prompt(
-        args.prompt.as_deref(),
-        args.prompt_file.as_deref(),
-        &stored.initial_prompt,
-    )?;
-    let save_only = args.output.is_some();
+    // spend time recording — but skipped entirely on the save-only path, which
+    // never transcribes, so `--output` isn't blocked by an unusable hint file.
+    let effective_prompt = if save_only {
+        None
+    } else {
+        resolve_effective_prompt(
+            args.prompt.as_deref(),
+            args.prompt_file.as_deref(),
+            &stored.initial_prompt,
+        )?
+    };
 
     // Only validate model if we're going to transcribe
     let model = if !save_only {

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 
@@ -43,11 +43,18 @@ pub struct TranscribeArgs {
           help = "Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.")]
     pub diarize_threshold: f32,
 
-    /// Initial prompt to prime the decoder with domain-specific vocabulary.
-    /// Reduces hallucination on technical terms, proper nouns, and jargon.
-    /// Example: --prompt "Grimnir, MCP, Fortnox, bokföring, kontering, saldo"
-    #[arg(long, value_name = "TEXT")]
+    /// Hint the decoder with domain-specific vocabulary (Whisper initial prompt).
+    /// Reduces mishearings of proper nouns, foreign names, and jargon by priming
+    /// the model with likely terms.
+    /// Example: --hint "Notre Dame, Sara, Estrid, Grimnir, MCP, Fortnox"
+    #[arg(long, visible_alias = "hint", value_name = "TEXT")]
     pub prompt: Option<String>,
+
+    /// Read the hint/initial prompt from a file instead of the command line
+    /// (handy for longer vocabulary lists). Mutually exclusive with --hint/--prompt.
+    /// Leading/trailing whitespace is trimmed; an empty file means no hint.
+    #[arg(long, visible_alias = "hint-file", value_name = "PATH", conflicts_with = "prompt")]
+    pub prompt_file: Option<PathBuf>,
 
     /// Enable voice activity detection (Silero VAD) to skip non-speech regions,
     /// reducing silence hallucination and repetition loops. Downloads a small
@@ -100,12 +107,13 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
-    // Effective prompt: an explicit --prompt, otherwise the saved initial_prompt.
-    // Used by both the diarized and standard paths.
-    let effective_prompt: Option<String> = args.prompt.clone().or_else(|| {
-        let saved = stored.initial_prompt.trim();
-        (!saved.is_empty()).then(|| saved.to_string())
-    });
+    // Effective hint/prompt: --prompt-file, else --hint/--prompt, else the saved
+    // initial_prompt. Used by both the diarized and standard paths.
+    let effective_prompt = resolve_effective_prompt(
+        args.prompt.as_deref(),
+        args.prompt_file.as_deref(),
+        &stored.initial_prompt,
+    )?;
 
     // Diarization branch
     #[cfg(feature = "diarization")]
@@ -342,6 +350,40 @@ pub fn resolve_effective_model(
     }
 }
 
+/// Resolves the effective initial prompt (a.k.a. the "hint") for a run, in
+/// precedence order:
+///   1. `--prompt-file` / `--hint-file` — the file's contents (trimmed;
+///      an empty or whitespace-only file yields no hint).
+///   2. `--hint` / `--prompt` — the inline string (an explicit empty string
+///      suppresses the hint and does *not* fall back to the saved setting).
+///   3. the saved `initial_prompt` setting (empty ⇒ no hint).
+///
+/// Returns `Ok(None)` when no source provides a non-empty prompt. Shared by
+/// `transcribe::run()` and `record::run()` so both surfaces prime the decoder
+/// identically — keep their call sites pointed here rather than re-deriving it.
+pub fn resolve_effective_prompt(
+    cli_prompt: Option<&str>,
+    cli_prompt_file: Option<&Path>,
+    stored_initial_prompt: &str,
+) -> Result<Option<String>, DictationError> {
+    if let Some(path) = cli_prompt_file {
+        let contents = std::fs::read_to_string(path).map_err(|e| {
+            DictationError::FileDecodeError(format!(
+                "Failed to read prompt file '{}': {e}",
+                path.display()
+            ))
+        })?;
+        let trimmed = contents.trim();
+        return Ok((!trimmed.is_empty()).then(|| trimmed.to_string()));
+    }
+    if let Some(p) = cli_prompt {
+        // An explicit `--hint ""` means "no hint", not "use the saved setting".
+        return Ok((!p.is_empty()).then(|| p.to_string()));
+    }
+    let saved = stored_initial_prompt.trim();
+    Ok((!saved.is_empty()).then(|| saved.to_string()))
+}
+
 pub fn parse_model(s: &str) -> Result<WhisperModel, DictationError> {
     match s {
         "tiny.en" => Ok(WhisperModel::TinyEn),
@@ -408,6 +450,74 @@ pub fn copy_to_clipboard(text: &str) -> Result<(), DictationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- resolve_effective_prompt --
+
+    #[test]
+    fn effective_prompt_cli_flag_wins_over_stored() {
+        let got = resolve_effective_prompt(Some("Notre Dame"), None, "saved vocab").unwrap();
+        assert_eq!(got.as_deref(), Some("Notre Dame"));
+    }
+
+    #[test]
+    fn effective_prompt_falls_back_to_stored() {
+        let got = resolve_effective_prompt(None, None, "  saved vocab  ").unwrap();
+        // Stored value is trimmed.
+        assert_eq!(got.as_deref(), Some("saved vocab"));
+    }
+
+    #[test]
+    fn effective_prompt_none_when_all_empty() {
+        assert!(resolve_effective_prompt(None, None, "").unwrap().is_none());
+        assert!(resolve_effective_prompt(None, None, "   ").unwrap().is_none());
+    }
+
+    #[test]
+    fn effective_prompt_explicit_empty_flag_suppresses_stored() {
+        // `--hint ""` means "no hint" — it must NOT fall through to the setting.
+        let got = resolve_effective_prompt(Some(""), None, "saved vocab").unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn effective_prompt_file_wins_and_is_trimmed() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "sagascript_hint_test_{}_{}.txt",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "  Estrid, Grimnir\n").unwrap();
+
+        // File beats both the inline flag and the stored setting.
+        let got = resolve_effective_prompt(Some("inline"), Some(&path), "saved").unwrap();
+        assert_eq!(got.as_deref(), Some("Estrid, Grimnir"));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn effective_prompt_empty_file_yields_none() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "sagascript_hint_test_{}_{}.txt",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "   \n\t").unwrap();
+
+        let got = resolve_effective_prompt(None, Some(&path), "saved").unwrap();
+        assert!(got.is_none());
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn effective_prompt_missing_file_errors() {
+        let path = Path::new("/nonexistent/sagascript/hint/vocab.txt");
+        let err = resolve_effective_prompt(None, Some(path), "saved").unwrap_err();
+        assert!(matches!(err, DictationError::FileDecodeError(_)));
+    }
 
     // -- parse_language --
 


### PR DESCRIPTION
Closes part 1 of #75 (the `--hint` flag). Part 2 (speaker diarization) is intentionally out of scope.

## Problem

Field report #75: transcribing a Swedish voice memo, Whisper mangled foreign proper nouns and names into plausible-but-wrong words (`"Notre Dame"` → `"nåt och damm"`, `"Sara"` → `"sval"`). Whisper's `initial_prompt` fixes exactly this, but it was only reachable on `transcribe` as `--prompt` — `record` (live dictation) had no hinting at all.

## What this does

- **`--hint`** — visible alias of the existing `--prompt` on `transcribe`; the ticket's requested UX (`--hint "Notre Dame, Sara, Estrid"`).
- **`--hint-file` / `--prompt-file`** — read a longer vocab list from a file (trimmed; empty file ⇒ no hint; mutually exclusive with `--hint`).
- **`record` gains the same flags** — the real gap. It previously routed through the no-prompt backend variant; now both surfaces prime the decoder identically.
- **Shared `resolve_effective_prompt()` helper** centralizes precedence: `--hint-file` > `--hint`/`--prompt` > saved `initial_prompt` setting (an explicit `--hint ""` suppresses and does **not** fall back to the setting).

The `initial_prompt` **settings key is kept as-is** — `config set initial_prompt "..."` already works as the persistent default; renaming it to `hint` would churn config tests for no user benefit.

## Testing

- `cargo test -p sagascript-cli --all-features` → **80 pass**, clippy clean. New: 6 `resolve_effective_prompt` unit tests (precedence / trim / empty / missing-file) + clap parse/alias/conflict tests for both subcommands.
- **Real end-to-end** against `nb-whisper-tiny`: `--hint`, `--hint-file`, and missing-file error paths all verified on the actual binary.
- **Codex cross-model review** (gpt-5.5, xhigh): found one Low regression — `record --output` (save-only) shouldn't fail on a bad hint-file — **fixed and verified** in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)