### PR TITLE
fix(diarization): permutation-align pyannote windows — un-collapse multi-speaker output (#75)

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -36,11 +36,11 @@ pub struct TranscribeArgs {
     #[arg(long)]
     pub diarize: bool,
 
-    /// Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.
+    /// Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.75). Higher = fewer speakers.
     #[cfg(feature = "diarization")]
-    #[arg(long, value_name = "THRESHOLD", default_value = "0.85",
+    #[arg(long, value_name = "THRESHOLD", default_value = "0.75",
           value_parser = parse_diarize_threshold,
-          help = "Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.85). Higher = fewer speakers.")]
+          help = "Agglomerative clustering threshold for speaker diarization (0.0–2.0, default 0.75). Higher = fewer speakers.")]
     pub diarize_threshold: f32,
 
     /// Hint the decoder with domain-specific vocabulary (Whisper initial prompt).
@@ -144,6 +144,11 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             ..DiarizeConfig::default()
         })?;
         eprintln!("Found {} speaker segment(s)", speaker_segments.len());
+        if std::env::var("SAGA_DIAR_DEBUG").is_ok() {
+            for s in &speaker_segments {
+                eprintln!("DIARSEG\t{:.3}\t{:.3}\t{}", s.start, s.end, s.speaker);
+            }
+        }
 
         eprintln!("Transcribing with word-level timestamps...");
         // Prefer word-level timestamps: each word gets its own entry so the
@@ -164,6 +169,11 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             }
         };
         eprintln!("Got {} word/segment(s) for merging", raw_segments.len());
+        if std::env::var("SAGA_DIAR_DEBUG").is_ok() {
+            for (st, en, tx) in &raw_segments {
+                eprintln!("WORD\t{:.3}\t{:.3}\t{}", st, en, tx.replace('\t', " "));
+            }
+        }
 
         let transcript: Vec<TimestampedSegment> = raw_segments
             .into_iter()
@@ -736,7 +746,7 @@ mod diarize_threshold_tests {
 
     #[test]
     fn accepts_default_value() {
-        assert_eq!(parse_threshold("0.85").unwrap(), 0.85);
+        assert_eq!(parse_threshold("0.75").unwrap(), 0.75);
     }
 
     #[test]
@@ -747,7 +757,7 @@ mod diarize_threshold_tests {
     #[test]
     fn default_applies_when_flag_omitted() {
         let cli = TestCli::try_parse_from(["sagascript", "file.wav"]).unwrap();
-        assert_eq!(cli.args.diarize_threshold, 0.85);
+        assert_eq!(cli.args.diarize_threshold, 0.75);
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/diarization/clustering.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/clustering.rs
@@ -8,9 +8,9 @@ use kodama::{linkage, Method};
 
 use crate::diarization::embedding::EMBEDDING_DIM;
 
-/// Default clustering threshold (cosine distance, 0.0-2.0 range).
-/// At 0.8, embeddings with cosine similarity > 0.2 are merged.
-pub const DEFAULT_THRESHOLD: f32 = 0.8;
+// The default clustering threshold lives in `DiarizeConfig::default()`
+// (diarization/mod.rs) — the single source of truth. A stale `DEFAULT_THRESHOLD`
+// constant here (unused, and out of sync at 0.8) was removed with the #75 fix.
 
 /// Cluster embeddings and return a global speaker label per input.
 ///

--- a/src-tauri/crates/sagascript-core/src/diarization/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/mod.rs
@@ -12,7 +12,7 @@ use crate::error::DictationError;
 /// Configuration for the diarization pipeline.
 pub struct DiarizeConfig {
     /// Cosine distance threshold for agglomerative clustering (0.0–2.0).
-    /// Lower = stricter (more speakers). Default 0.85.
+    /// Lower = stricter (more speakers). Default 0.75.
     pub threshold: f32,
     /// Minimum segment duration in seconds to keep. Default 0.3s.
     pub min_segment: f64,
@@ -23,9 +23,12 @@ pub struct DiarizeConfig {
 impl Default for DiarizeConfig {
     fn default() -> Self {
         Self {
-            // 0.85 produces fewer, broader clusters — better for typical 2-speaker
-            // recordings where over-clustering is the common failure mode.
-            threshold: 0.85,
+            // Tuned against the two ground-truthed test files (dj_2022_feu FR,
+            // nb_samtale_nb12 NO) with permutation-aligned window stitching:
+            // both are DER-optimal across 0.70–0.80; 0.85 sits on a cliff where
+            // nb_samtale's two speakers merge into one cluster. 0.75 is the
+            // midpoint of the common plateau.
+            threshold: 0.75,
             min_segment: 0.3,
             min_gap: 0.5,
         }

--- a/src-tauri/crates/sagascript-core/src/diarization/segmentation.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/segmentation.rs
@@ -535,10 +535,10 @@ mod tests {
     fn stitch_swapped_slots_reunifies_speaker() {
         let mut st = WindowStitcher::new(150);
         // Window A: frames 0..100, speaker continuously active in slot 0.
-        st.add_window(0, &vec![frame(0); 100]);
+        st.add_window(0, &[frame(0); 100]);
         // Window B: frames 50..150, SAME speaker (still talking through the
         // overlap 50..100) but in local slot 1.
-        st.add_window(50, &vec![frame(1); 100]);
+        st.add_window(50, &[frame(1); 100]);
         let out = st.finish();
 
         let active_per_track: Vec<usize> = (0..MAX_SPEAKERS)
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn stitch_offset_beyond_total_is_ignored() {
         let mut st = WindowStitcher::new(10);
-        st.add_window(20, &vec![frame(0); 5]); // out of range — must not panic
+        st.add_window(20, &[frame(0); 5]); // out of range — must not panic
         let out = st.finish();
         assert!(out.iter().all(|f| f.iter().all(|&v| v == 0.0)));
     }
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     fn stitch_window_clipped_at_total_frames() {
         let mut st = WindowStitcher::new(10);
-        st.add_window(5, &vec![frame(2); 20]); // extends past end — clipped
+        st.add_window(5, &[frame(2); 20]); // extends past end — clipped
         let out = st.finish();
         assert_eq!(out.iter().filter(|f| f[2] >= 0.5).count(), 5);
     }

--- a/src-tauri/crates/sagascript-core/src/diarization/segmentation.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/segmentation.rs
@@ -121,6 +121,12 @@ impl Segmenter {
     /// Run sliding-window segmentation on full audio.
     ///
     /// Returns `FrameActivations` covering the entire audio duration.
+    ///
+    /// pyannote's speaker slots are *local to each 10s window* (slot 0 in one
+    /// window may be a different physical speaker than slot 0 in the next), so
+    /// each window's decoded activity is permutation-aligned against the
+    /// accumulated global tracks over the overlap region before aggregation.
+    /// See [`WindowStitcher`].
     pub fn segment(&mut self, audio: &[f32]) -> Result<FrameActivations, DictationError> {
         if audio.is_empty() {
             return Ok(FrameActivations {
@@ -129,17 +135,17 @@ impl Segmenter {
             });
         }
 
-        // Compute total frames across all windows after stitching
         let n_windows = if audio.len() <= WINDOW_SAMPLES {
             1
         } else {
             (audio.len() - WINDOW_SAMPLES) / STEP_SAMPLES + 2
         };
+        // Frame offsets are derived per-window from the sample position (not
+        // win_idx * rounded-frames-per-step, which drifts ~0.26 frames/window).
         let total_frames =
-            FRAMES_PER_WINDOW + (n_windows.saturating_sub(1)) * frames_per_step();
+            frame_offset_for_sample((n_windows - 1) * STEP_SAMPLES) + FRAMES_PER_WINDOW;
 
-        let mut accumulated = vec![[0.0f32; NUM_CLASSES]; total_frames];
-        let mut counts = vec![0u32; total_frames];
+        let mut stitcher = WindowStitcher::new(total_frames);
 
         for win_idx in 0..n_windows {
             let win_start = win_idx * STEP_SAMPLES;
@@ -169,51 +175,150 @@ impl Segmenter {
 
             let logits = logits.view();
 
-            // Accumulate frame probabilities in overlap region
-            let frame_offset = win_idx * frames_per_step();
+            // Decode this window's powerset logits to binary per-slot activity
+            // (argmax per frame), then let the stitcher align + accumulate.
+            let mut local = Vec::with_capacity(FRAMES_PER_WINDOW);
             for f in 0..FRAMES_PER_WINDOW {
-                let global_f = frame_offset + f;
-                if global_f >= total_frames {
-                    break;
-                }
+                let mut best_class = 0usize;
+                let mut best_logit = f32::MIN;
                 for c in 0..NUM_CLASSES {
-                    accumulated[global_f][c] += logits[[0, f, c]];
+                    let v = logits[[0, f, c]];
+                    if v > best_logit {
+                        best_logit = v;
+                        best_class = c;
+                    }
                 }
-                counts[global_f] += 1;
+                local.push(POWERSET[best_class]);
             }
+
+            stitcher.add_window(frame_offset_for_sample(win_start), &local);
         }
 
-        // Average overlapping frames, then argmax → powerset decode
-        let activity: Vec<[f32; MAX_SPEAKERS]> = accumulated
-            .iter()
-            .zip(counts.iter())
-            .map(|(frame_logits, &count)| {
-                let n = count.max(1) as f32;
-                let averaged: Vec<f32> = frame_logits.iter().map(|&v| v / n).collect();
-
-                // Argmax across 7 classes
-                let class = averaged
-                    .iter()
-                    .enumerate()
-                    .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                    .map(|(i, _)| i)
-                    .unwrap_or(0);
-
-                POWERSET[class]
-            })
-            .collect();
-
         Ok(FrameActivations {
-            activity,
+            activity: stitcher.finish(),
             frame_duration: FRAME_DURATION_S,
         })
     }
 }
 
-/// How many frames correspond to one STEP_SAMPLES shift.
-fn frames_per_step() -> usize {
-    // STEP_SAMPLES / receptive_field_shift = 16000 / 270 ≈ 59
-    (STEP_SAMPLES as f64 / (FRAME_DURATION_S * 16_000.0)).round() as usize
+/// Global frame index for a sample position (receptive_field_shift = 270 samples).
+fn frame_offset_for_sample(sample: usize) -> usize {
+    (sample as f64 / (FRAME_DURATION_S * 16_000.0)).round() as usize
+}
+
+/// All permutations of the 3 local speaker slots. Identity first, so that
+/// silence/no-signal overlap regions tie-break to "no relabeling".
+const SLOT_PERMUTATIONS: [[usize; MAX_SPEAKERS]; 6] = [
+    [0, 1, 2],
+    [0, 2, 1],
+    [1, 0, 2],
+    [1, 2, 0],
+    [2, 0, 1],
+    [2, 1, 0],
+];
+
+/// Pick the local→global slot permutation maximizing activity agreement over
+/// the overlap region. `local[f][s]` is this window's binary activity for
+/// local slot `s`; `global_avg[f][g]` is the running mean activity of global
+/// track `g` on the same frames. Returns `perm` where local slot `s` maps to
+/// global track `perm[s]`. Ties resolve to the earliest (identity-first) entry.
+fn best_permutation(
+    local: &[[f32; MAX_SPEAKERS]],
+    global_avg: &[[f32; MAX_SPEAKERS]],
+) -> [usize; MAX_SPEAKERS] {
+    let mut best = SLOT_PERMUTATIONS[0];
+    let mut best_score = f32::MIN;
+    for perm in SLOT_PERMUTATIONS {
+        let mut score = 0.0f32;
+        for (l, g) in local.iter().zip(global_avg.iter()) {
+            for s in 0..MAX_SPEAKERS {
+                score += l[s] * g[perm[s]];
+            }
+        }
+        if score > best_score {
+            best_score = score;
+            best = perm;
+        }
+    }
+    best
+}
+
+/// Accumulates per-window binary speaker activity into globally-consistent
+/// tracks. Each incoming window is permutation-aligned against the running
+/// average of already-accumulated frames in its overlap region, then majority
+/// voting (`finish`) binarizes the result.
+struct WindowStitcher {
+    /// Sum of aligned per-track activity per frame.
+    acc: Vec<[f32; MAX_SPEAKERS]>,
+    /// Number of windows contributing to each frame.
+    counts: Vec<u32>,
+}
+
+impl WindowStitcher {
+    fn new(total_frames: usize) -> Self {
+        Self {
+            acc: vec![[0.0f32; MAX_SPEAKERS]; total_frames],
+            counts: vec![0u32; total_frames],
+        }
+    }
+
+    /// Add one window's binary activity starting at `frame_offset`.
+    fn add_window(&mut self, frame_offset: usize, local: &[[f32; MAX_SPEAKERS]]) {
+        if frame_offset >= self.acc.len() {
+            return;
+        }
+        // Overlap = the window's leading frames already covered by previous
+        // windows (windows arrive in order, so coverage is a prefix).
+        let overlap_len = self.counts[frame_offset..]
+            .iter()
+            .take(local.len())
+            .take_while(|&&c| c > 0)
+            .count();
+
+        let perm = if overlap_len == 0 {
+            SLOT_PERMUTATIONS[0]
+        } else {
+            let global_avg: Vec<[f32; MAX_SPEAKERS]> = (0..overlap_len)
+                .map(|f| {
+                    let i = frame_offset + f;
+                    let n = self.counts[i] as f32;
+                    [
+                        self.acc[i][0] / n,
+                        self.acc[i][1] / n,
+                        self.acc[i][2] / n,
+                    ]
+                })
+                .collect();
+            best_permutation(&local[..overlap_len], &global_avg)
+        };
+
+        for (f, frame) in local.iter().enumerate() {
+            let i = frame_offset + f;
+            if i >= self.acc.len() {
+                break;
+            }
+            for s in 0..MAX_SPEAKERS {
+                self.acc[i][perm[s]] += frame[s];
+            }
+            self.counts[i] += 1;
+        }
+    }
+
+    /// Majority-vote binarization of the accumulated tracks.
+    fn finish(self) -> Vec<[f32; MAX_SPEAKERS]> {
+        self.acc
+            .iter()
+            .zip(self.counts.iter())
+            .map(|(a, &c)| {
+                let n = c.max(1) as f32;
+                let mut out = [0.0f32; MAX_SPEAKERS];
+                for s in 0..MAX_SPEAKERS {
+                    out[s] = if a[s] / n >= 0.5 { 1.0 } else { 0.0 };
+                }
+                out
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -343,9 +448,155 @@ mod tests {
     }
 
     #[test]
-    fn frames_per_step_is_reasonable() {
-        let fps = frames_per_step();
-        // Should be roughly 16000/270 ≈ 59
-        assert!((55..=65).contains(&fps), "frames_per_step should be ~59, got {fps}");
+    fn frame_offset_no_cumulative_drift() {
+        // Offsets must track the true sample position, not accumulate the
+        // rounding error of a per-step frame count (16000/270 ≈ 59.26).
+        assert_eq!(frame_offset_for_sample(0), 0);
+        // Window 10 starts at sample 160000 → 160000/270 = 592.6 → 593.
+        // The old `win_idx * round(59.26)` scheme would give 590.
+        assert_eq!(frame_offset_for_sample(10 * STEP_SAMPLES), 593);
+        // Window 50: 800000/270 = 2963.0 (old scheme: 2950 — 13 frames ≈ 0.22s off)
+        assert_eq!(frame_offset_for_sample(50 * STEP_SAMPLES), 2963);
+    }
+
+    // -- slot permutation alignment --
+
+    /// Frame with exactly one active local slot.
+    fn frame(active_slot: usize) -> [f32; MAX_SPEAKERS] {
+        let mut f = [0.0f32; MAX_SPEAKERS];
+        f[active_slot] = 1.0;
+        f
+    }
+
+    const SILENT: [f32; MAX_SPEAKERS] = [0.0, 0.0, 0.0];
+
+    #[test]
+    fn best_permutation_identity_when_aligned() {
+        let local = vec![frame(0); 10];
+        let global = vec![frame(0); 10];
+        assert_eq!(best_permutation(&local, &global), [0, 1, 2]);
+    }
+
+    #[test]
+    fn best_permutation_detects_swap() {
+        // Same physical speaker: local slot 1, global track 0 → map 1→0.
+        let local = vec![frame(1); 10];
+        let global = vec![frame(0); 10];
+        let perm = best_permutation(&local, &global);
+        assert_eq!(perm[1], 0, "local slot 1 should map to global track 0, got {perm:?}");
+    }
+
+    #[test]
+    fn best_permutation_silence_ties_to_identity() {
+        let local = vec![SILENT; 10];
+        let global = vec![SILENT; 10];
+        assert_eq!(best_permutation(&local, &global), [0, 1, 2]);
+    }
+
+    #[test]
+    fn best_permutation_two_speakers_crossed() {
+        // Two concurrent speakers with slots crossed between window and global.
+        let mut local = Vec::new();
+        let mut global = Vec::new();
+        for i in 0..20 {
+            // Alternate frames: speaker A then speaker B.
+            let (l, g) = if i % 2 == 0 {
+                (frame(0), frame(2)) // A: local 0 ≡ global 2
+            } else {
+                (frame(2), frame(0)) // B: local 2 ≡ global 0
+            };
+            local.push(l);
+            global.push(g);
+        }
+        let perm = best_permutation(&local, &global);
+        assert_eq!(perm[0], 2);
+        assert_eq!(perm[2], 0);
+    }
+
+    // -- window stitching --
+
+    #[test]
+    fn stitch_single_window_passthrough() {
+        let mut st = WindowStitcher::new(10);
+        let local: Vec<[f32; MAX_SPEAKERS]> =
+            (0..10).map(|f| if f < 5 { frame(1) } else { SILENT }).collect();
+        st.add_window(0, &local);
+        let out = st.finish();
+        for (f, fr) in out.iter().enumerate() {
+            assert_eq!(fr[1], if f < 5 { 1.0 } else { 0.0 }, "frame {f}");
+        }
+    }
+
+    /// The regression test for the collapse bug: one physical speaker that
+    /// pyannote assigns to slot 0 in window A but slot 1 in window B must come
+    /// out as a SINGLE global track, not two. Raw index-summed aggregation
+    /// (the old behavior) splits it across two tracks.
+    #[test]
+    fn stitch_swapped_slots_reunifies_speaker() {
+        let mut st = WindowStitcher::new(150);
+        // Window A: frames 0..100, speaker continuously active in slot 0.
+        st.add_window(0, &vec![frame(0); 100]);
+        // Window B: frames 50..150, SAME speaker (still talking through the
+        // overlap 50..100) but in local slot 1.
+        st.add_window(50, &vec![frame(1); 100]);
+        let out = st.finish();
+
+        let active_per_track: Vec<usize> = (0..MAX_SPEAKERS)
+            .map(|s| out.iter().filter(|f| f[s] >= 0.5).count())
+            .collect();
+        let total_active: usize = active_per_track.iter().sum();
+        let tracks_used = active_per_track.iter().filter(|&&n| n > 0).count();
+
+        assert_eq!(
+            tracks_used, 1,
+            "one continuous speaker must occupy one global track, got per-track {active_per_track:?}"
+        );
+        assert_eq!(total_active, 150, "speaker active for all 150 frames");
+    }
+
+    #[test]
+    fn stitch_two_speakers_stay_distinct() {
+        // Speaker A talks frames 0..60 (slot 0 in both windows); speaker B
+        // talks frames 90..150 (slot 1 in window B). A brief overlap region
+        // 50..60 lets alignment lock in.
+        let mut st = WindowStitcher::new(150);
+        let win_a: Vec<[f32; MAX_SPEAKERS]> =
+            (0..100).map(|f| if f < 60 { frame(0) } else { SILENT }).collect();
+        st.add_window(0, &win_a);
+        let win_b: Vec<[f32; MAX_SPEAKERS]> = (0..100)
+            .map(|f| {
+                let g = f + 50;
+                if g < 60 {
+                    frame(0) // A still talking in overlap, same slot
+                } else if g >= 90 {
+                    frame(1) // B
+                } else {
+                    SILENT
+                }
+            })
+            .collect();
+        st.add_window(50, &win_b);
+        let out = st.finish();
+
+        let a_frames = out.iter().filter(|f| f[0] >= 0.5).count();
+        let b_frames = out.iter().filter(|f| f[1] >= 0.5).count();
+        assert_eq!(a_frames, 60, "speaker A track");
+        assert_eq!(b_frames, 60, "speaker B track");
+    }
+
+    #[test]
+    fn stitch_offset_beyond_total_is_ignored() {
+        let mut st = WindowStitcher::new(10);
+        st.add_window(20, &vec![frame(0); 5]); // out of range — must not panic
+        let out = st.finish();
+        assert!(out.iter().all(|f| f.iter().all(|&v| v == 0.0)));
+    }
+
+    #[test]
+    fn stitch_window_clipped_at_total_frames() {
+        let mut st = WindowStitcher::new(10);
+        st.add_window(5, &vec![frame(2); 20]); // extends past end — clipped
+        let out = st.finish();
+        assert_eq!(out.iter().filter(|f| f[2] >= 0.5).count(), 5);
     }
 }

--- a/test-audio/diarization/README.md
+++ b/test-audio/diarization/README.md
@@ -94,6 +94,16 @@ The language-matched `nb-whisper-small` more than halves DER and roughly halves 
 for #67: keep the `0.85` default; it does not over-collapse native-bandwidth audio — the French
 clip's collapse was a narrowband-embedding artifact, not a default-threshold problem.
 
+> **Addendum (2026-07-04, #75 stitching fix).** The measurements and the takeaway above were
+> made against the *pre-stitching* pipeline, which summed pyannote powerset logits across
+> overlapping windows by raw class index — scrambling per-window speaker slots and feeding
+> mixed-speaker segments to the embedder. The French clip's collapse was primarily *that* bug,
+> not a narrowband artifact. With permutation-aligned window stitching
+> (`segmentation.rs::WindowStitcher`): dj_2022_feu improves 56.5 % → **26.8 %** DER (2 blobs →
+> 12 turns) and nb_samtale_nb12 holds at **7.5 %**. Both files are DER-optimal across
+> thresholds 0.70–0.80, while 0.85 sits on a cliff that merges nb_samtale's two speakers — so
+> **the shipped default is now `0.75`** (`DiarizeConfig::default()`).
+
 **Fetch audio + build:**
 ```bash
 ./test-audio/diarization/fetch.sh   # streams nb-12's 9 turns, rebuilds nb_samtale_nb12.wav
@@ -178,10 +188,10 @@ pip install pyannote-audio meeteval
 > **multilingual** model so you measure diarization, not ASR mismatch. **Pass `-l auto`
 > explicitly** — the CLI's `-l` doesn't accept `fr`, and *omitting* it falls back to your
 > configured language (e.g. `sv`), which reintroduces the exact mismatch. Also mind the
-> clustering threshold: the default `0.85` collapses this 2-speaker telephone audio to a
-> single cluster; `0.70–0.80` is the right operating point for this clip. Do **not**
-> generalize that threshold to Swedish recordings without re-validating — `0.85` exists to
-> curb over-clustering elsewhere (see #67).
+> clustering threshold: the *former* default `0.85` collapsed this 2-speaker telephone audio
+> to a single cluster; `0.70–0.80` is the right operating point for this clip, and since the
+> #75 stitching fix the shipped default is `0.75` — inside that window. (Historical context:
+> `0.85` was chosen to curb over-clustering on the pre-stitching pipeline, see #67.)
 
 ```bash
 sagascript transcribe test-audio/diarization/dj_2022_feu.wav \
@@ -195,7 +205,10 @@ Reference operating points (multilingual `small`, DER vs `--diarize-threshold`):
 |---|---|---|
 | 0.60 | 5 | 33.9% |
 | **0.70–0.80** | 3 | **~21%** |
-| 0.85 (default) | 2→1 | 55.4% |
+| 0.85 (former default; 0.75 since #75) | 2→1 | 55.4% |
+
+*(Table measured pre-stitching-fix; post-fix this clip scores 26.8 % DER at the `0.75`
+default with `large-v3-turbo` — see the #75 addendum above.)*
 
 ~21% is roughly the floor for this 8 kHz upsampled telephone clip — WeSpeaker embeddings
 degrade on narrowband audio. Tracked in #67.


### PR DESCRIPTION
Part 2 of #75. The `--hint` flag (part 1) landed in #79; this fixes the diarization collapse itself.

## Problem

Speaker diarization collapsed on multi-speaker recordings: the #75 field report's 8.5-min 2-speaker memo came out as one undifferentiated speaker. Reproduced on the ground-truthed `test-audio/diarization/dj_2022_feu.wav` (58s French emergency call, 2 speakers, 23 turns): output was **2 segments**, one spanning 49 of 58 seconds — **DER 56.5%**.

## Root cause

pyannote-segmentation-3.0 emits powerset speaker classes whose 3 speaker slots are **local to each 10-second sliding window** — slot 0 in one window can be a different physical person than slot 0 in the next. `Segmenter::segment()` summed class logits across the ~10 overlapping windows covering each frame **by raw class index**, with no per-window slot permutation alignment. This scrambled speaker identity: per-slot activity timelines became unions of both real speakers, the per-segment audio fed to the WeSpeaker embedder was mixed-voice, embeddings averaged both speakers, and agglomerative clustering collapsed everything into one label. Reference pipelines (pyannote, sherpa-onnx) do Hungarian/overlap slot stitching before aggregation; that step was missing.

Downstream stages were audited and are correct (and unchanged): embeddings are L2-normalized, cosine + average-linkage clustering is textbook, the merge/consolidate step faithfully renders its input. This also supersedes the earlier #67 conclusion that the French clip's collapse was a "narrowband-embedding artifact" — the README carries a dated addendum.

## Fix (`segmentation.rs`)

- Decode each window's powerset logits to **binary per-slot activity** (per-frame argmax).
- New **`WindowStitcher`**: aligns each window's local slots against the running average of the accumulated global tracks over the overlap region — best of the 6 slot permutations by activity agreement, identity-first tie-break for silent overlaps — then majority-votes the final binary activity.
- **Frame-offset drift fix**: offsets now derive per-window from the sample position (`round(win_start/270)`) instead of `win_idx × round(59.26)`, which drifted ~0.26 frames/window (~0.22 s/minute).
- Default `--diarize-threshold` **0.85 → 0.75**: DER sweeps on both ground-truthed files show a common optimal plateau at 0.70–0.80, and 0.85 sits on a cliff where `nb_samtale`'s two speakers merge into one cluster. The GUI inherits via `DiarizeConfig::default()`.

## Validation

Frame-based DER (0.25 s collar, optimal label mapping) against hand-labeled RTTM references:

| File | Before | After |
|---|---|---|
| `dj_2022_feu` (FR, 2 spk) | DER 56.5%, confusion 43.6%, 2 blobs | **DER 26.8%, confusion 12.6%, 12 turns** with correct doctor/patient alternation |
| `nb_samtale_nb12` (NO, 2 spk) | DER 7.5% | **DER 7.5%** — no regression on a file the old code handled |

TDD: `stitch_swapped_slots_reunifies_speaker` was written first and confirmed **red** against the old raw-index semantics (one speaker split `[100,100,0]` across two tracks), then green with alignment. 8 new unit tests for the alignment + stitcher; a drift test replaces the stale `frames_per_step` test. Workspace: **187 tests green, clippy clean** (`--all-targets --all-features -D warnings`).

Codex cross-model review (gpt-5.5, xhigh): no correctness findings; two low doc-drift findings fixed (README reconciliation, stale `DEFAULT_THRESHOLD` constant removed).

## Also in this PR

- `SAGA_DIAR_DEBUG=1` dumps intermediate speaker segments and word timestamps to stderr — the field-debugging instrumentation that pinpointed the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)