### PR TITLE
feat(build): diarization in default features — make --diarize discoverable (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Sagascript is a low-latency, privacy-first macOS dictation app built with Tauri 
 - `cargo check --workspace` — type-check Rust (from `src-tauri/`; bare `cargo check` covers only the app crate)
 - `cargo test --workspace` — run Rust unit tests across all three crates (from `src-tauri/`)
 - `cargo clippy --workspace --all-targets -- -D warnings` — lint Rust (from `src-tauri/`)
-- `cargo build -p sagascript-cli --no-default-features` — lean batch-transcribe CLI build (no cpal/ALSA, no diarization/ONNX; ~8 MB vs ~31 MB default)
+- `cargo build -p sagascript-cli --no-default-features` — lean batch-transcribe CLI build (no cpal/ALSA, no diarization and its ONNX Runtime; ~8 MB vs ~31 MB default)
 - `npx svelte-check --tsconfig ./tsconfig.json` — type-check Svelte/TS
 - `tail -f ~/Library/Logs/Sagascript/sagascript.log` — watch logs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Sagascript is a low-latency, privacy-first macOS dictation app built with Tauri 
 - `cargo check --workspace` — type-check Rust (from `src-tauri/`; bare `cargo check` covers only the app crate)
 - `cargo test --workspace` — run Rust unit tests across all three crates (from `src-tauri/`)
 - `cargo clippy --workspace --all-targets -- -D warnings` — lint Rust (from `src-tauri/`)
-- `cargo build -p sagascript-cli --no-default-features` — pure batch-transcribe CLI build (no cpal/ALSA)
+- `cargo build -p sagascript-cli --no-default-features` — lean batch-transcribe CLI build (no cpal/ALSA, no diarization/ONNX; ~8 MB vs ~31 MB default)
 - `npx svelte-check --tsconfig ./tsconfig.json` — type-check Svelte/TS
 - `tail -f ~/Library/Logs/Sagascript/sagascript.log` — watch logs
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,7 +77,9 @@ notify = { version = "7" }
 workspace = true
 
 [features]
-default = ["custom-protocol"]
+# `diarization` default-on to match the CLI (#81): a plain `cargo tauri build`
+# .app ships with speaker diarization available.
+default = ["custom-protocol", "diarization"]
 custom-protocol = ["tauri/custom-protocol"]
 diarization = ["sagascript-core/diarization", "sagascript-cli/diarization"]
 

--- a/src-tauri/crates/sagascript-cli/Cargo.toml
+++ b/src-tauri/crates/sagascript-cli/Cargo.toml
@@ -32,7 +32,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ctrlc = { version = "3", optional = true }
 
 [features]
-default = ["record"]
+# `diarization` is default-on for discoverability (#81): a default build must
+# show `--diarize` in --help, or users never learn it exists (#75). It adds
+# ~23 MB of statically-linked ONNX Runtime; the lean batch build
+# (`--no-default-features`) strips it along with `record`.
+default = ["record", "diarization"]
 record = ["sagascript-core/record", "dep:ctrlc"]
 diarization = ["sagascript-core/diarization"]
 


### PR DESCRIPTION
Item 2 of #81. Decision + measurements discussed in-session; option A (default-on) chosen over docs-only and stub-flag alternatives.

## Why

The #75 field reporter never found speaker diarization: `--diarize` only exists behind the opt-in `diarization` cargo feature, so a default build's `--help` doesn't show it. Docs can't fix a flag that isn't in the binary you're holding.

## What

- **`sagascript-cli`**: `default = ["record", "diarization"]`. Measured cost: binary 7.9 → 30.7 MB (statically-linked ONNX Runtime). The documented lean batch build (`--no-default-features`) still strips it (along with `record`/cpal — no ALSA on Linux).
- **App crate**: `default = ["custom-protocol", "diarization"]` — a plain `cargo tauri build` .app ships diarization too (its file-transcription path already uses it when compiled in).
- **CLAUDE.md**: lean-build line now documents the size trade-off.

Runtime models (~38 MB) remain download-on-demand (`sagascript download-model diarization`) — unchanged.

## Verification

- Default `cargo test -p sagascript-cli`: **80 pass** (previously feature-gated diarization tests now run by default).
- `--diarize` + `--diarize-threshold` present in default-build `--help`.
- `--no-default-features` lean build still compiles.
- Workspace `cargo check` + `clippy --all-targets -- -D warnings`: clean.

Item 1 of #81 (per-segment confidence in `--json`) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)