### PR TITLE
Clamp CLI transcription progress

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -13,6 +13,10 @@ use std::path::PathBuf;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Generator, Shell};
 
+pub(crate) fn set_transcription_progress(progress: &indicatif::ProgressBar, percentage: i32) {
+    progress.set_position(percentage.clamp(0, 100) as u64);
+}
+
 // Root help text is feature-aware: a batch-only build (`--no-default-features`)
 // has no `record` subcommand, so the workflow/examples must not advertise it.
 #[cfg(feature = "record")]
@@ -491,6 +495,17 @@ fn render_manpage_tree(cmd: &clap::Command, dir: &PathBuf) -> Result<(), io::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transcription_progress_bar_never_renders_outside_zero_to_one_hundred() {
+        let progress = indicatif::ProgressBar::new(100);
+
+        set_transcription_progress(&progress, 101);
+        assert_eq!(progress.position(), 100);
+
+        set_transcription_progress(&progress, -1);
+        assert_eq!(progress.position(), 0);
+    }
 
     // -- Completions generation --
 

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -161,7 +161,7 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
             language,
             prompt,
             move |pct| {
-                pb_cb.set_position(pct as u64);
+                crate::set_transcription_progress(&pb_cb, pct);
             },
         )?;
         pb.finish_and_clear();

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -261,7 +261,7 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             language,
             &opts,
             move |pct| {
-                pb_cb.set_position(pct as u64);
+                crate::set_transcription_progress(&pb_cb, pct);
             },
         )?;
         pb.finish_and_clear();

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -1330,13 +1330,9 @@ mod word_grouping_tests {
     }
 }
 
-/// Pure-function tests for the segment-confidence support (#81): the
-/// avg-logprob helper and the `TranscriptSegment` JSON contract. The FFI
-/// accessor calls (no_speech_probability, token_data) need a loaded model and
-/// are covered by the end-to-end CLI smoke instead.
 #[cfg(test)]
-mod segment_confidence_tests {
-    use super::*;
+mod progress_callback_tests {
+    use super::clamped_progress_callback;
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -1353,6 +1349,15 @@ mod segment_confidence_tests {
 
         assert_eq!(*received.lock().unwrap(), [0, 0, 99, 100, 100]);
     }
+}
+
+/// Pure-function tests for the segment-confidence support (#81): the
+/// avg-logprob helper and the `TranscriptSegment` JSON contract. The FFI
+/// accessor calls (no_speech_probability, token_data) need a loaded model and
+/// are covered by the end-to-end CLI smoke instead.
+#[cfg(test)]
+mod segment_confidence_tests {
+    use super::*;
 
     #[test]
     fn mean_logprob_empty_is_none() {

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -609,7 +609,13 @@ impl WhisperBackend {
             params.enable_vad(true);
         }
 
-        params.set_progress_callback_safe(on_progress);
+        // whisper.cpp derives progress from its internal processing windows.
+        // On clips whose final window extends beyond the decoded duration it
+        // can report a value outside the documented percentage range. Keep the
+        // backend's public callback contract (0..=100) so callers such as the
+        // CLI cannot overrun their progress bar (or cast a negative value to a
+        // very large u64).
+        params.set_progress_callback_safe(clamped_progress_callback(on_progress));
 
         // Real abort callback: wire the raw FFI trampoline (bypassing whisper-rs
         // 0.15.1's unsound set_abort_callback_safe — see abort_trampoline). On
@@ -886,6 +892,14 @@ impl WhisperBackend {
             Ok(results)
         })
     }
+}
+
+/// Adapt whisper.cpp's native progress values to the backend's public
+/// percentage contract.
+fn clamped_progress_callback(
+    mut on_progress: impl FnMut(i32) + 'static,
+) -> impl FnMut(i32) + 'static {
+    move |percentage| on_progress(percentage.clamp(0, 100))
 }
 
 /// Controls whether `transcribe_chunk_timestamps` emits one entry per segment or per word.
@@ -1323,6 +1337,22 @@ mod word_grouping_tests {
 #[cfg(test)]
 mod segment_confidence_tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn final_window_progress_is_clamped_to_audio_percentage_range() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&received);
+        let mut callback = clamped_progress_callback(move |percentage| {
+            captured.lock().unwrap().push(percentage);
+        });
+
+        for percentage in [-1, 0, 99, 100, 101] {
+            callback(percentage);
+        }
+
+        assert_eq!(*received.lock().unwrap(), [0, 0, 99, 100, 100]);
+    }
 
     #[test]
     fn mean_logprob_empty_is_none() {


### PR DESCRIPTION
## Summary

- clamp Whisper progress callbacks to the documented `0..=100` range in the core
- defensively clamp CLI progress-bar positions before integer conversion
- apply the renderer consistently to file transcription and recording
- add regressions for final-window `101` and negative callback values

## Validation

- 224 core tests passed
- 81 CLI tests passed
- strict Clippy for both packages passed
- diff check passed

Closes #85