### PR TITLE
Fix installed CLI upgrade verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,28 @@ jobs:
           cp "$dmg" artifacts/Sagascript.dmg
           tar -czf artifacts/Sagascript.app.tar.gz -C "$(dirname "$app")" "$(basename "$app")"
 
+      - name: Gate upgrade and installed CLI transcription
+        run: |
+          version=$(node -p "require('./package.json').version")
+          app="src-tauri/target/universal-apple-darwin/release/bundle/macos/Sagascript.app"
+
+          # Seed an obsolete executable at the normal installation path, then
+          # perform the same replace operation expected when upgrading the app.
+          # The persistent /usr/local/bin link must consequently execute the
+          # newly installed app-bundle binary, never the stale placeholder.
+          sudo mkdir -p /Applications/Sagascript.app/Contents/MacOS /usr/local/bin
+          printf '#!/bin/sh\necho stale-install\n' > "$RUNNER_TEMP/stale-sagascript"
+          chmod +x "$RUNNER_TEMP/stale-sagascript"
+          sudo cp "$RUNNER_TEMP/stale-sagascript" /Applications/Sagascript.app/Contents/MacOS/sagascript
+          sudo ln -sfn /Applications/Sagascript.app/Contents/MacOS/sagascript /usr/local/bin/sagascript
+          sudo rm -rf /Applications/Sagascript.app
+          sudo ditto "$app" /Applications/Sagascript.app
+
+          ./scripts/smoke-installed-macos-cli.sh \
+            "$version" \
+            "${SAGASCRIPT_GIT_HASH}" \
+            test-audio/norwegian-short-3s.mp3
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,6 +53,11 @@ keychain and set `APPLE_SIGNING_IDENTITY`. Set `APPLE_API_ISSUER`,
 6. Download the draft artifacts and perform the clean-machine checklist below.
    Publish the draft only after it passes.
 
+The macOS build job also simulates replacing an obsolete
+`/Applications/Sagascript.app`, then runs a real Norwegian file transcription
+through `/usr/local/bin/sagascript`. This protects the supported app-bundle CLI
+link from silently continuing to execute a stale binary after an upgrade.
+
 ## Clean-machine acceptance checklist
 
 - Download the DMG through a browser on a Mac that has never run Sagascript.
@@ -60,6 +65,9 @@ keychain and set `APPLE_SIGNING_IDENTITY`. Set `APPLE_API_ISSUER`,
 - Confirm onboarding, model download, microphone, Accessibility, global hotkey,
   dictation, auto-paste, and quit/relaunch behavior.
 - Confirm the app does not request the same permission again after relaunch.
+- Confirm `sagascript --version` reports the release Git revision, and run one
+  file transcription through `/usr/local/bin/sagascript` after upgrading an
+  existing installation.
 - Test both Apple Silicon and Intel hardware before claiming universal support.
 - Confirm the draft contains `Sagascript.dmg`, `Sagascript.app.tar.gz`, and
   `SHA256SUMS`; no Windows installer is a v1 release artifact. Verify both

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,6 +23,28 @@ Download the latest `.dmg` from the [Releases page](https://github.com/Magnus-Gi
    - **Microphone** -- for recording audio
    - **Accessibility** -- for pasting transcriptions into the active app
 
+To make the app's CLI available in your shell, create this link once:
+
+```bash
+sudo mkdir -p /usr/local/bin
+sudo ln -sfn /Applications/Sagascript.app/Contents/MacOS/sagascript /usr/local/bin/sagascript
+sagascript --version
+```
+
+The version output includes the release's Git revision and build date so a
+stale installation is immediately visible.
+
+### Upgrade
+
+1. Quit Sagascript completely.
+2. Open the new DMG and drag Sagascript to Applications.
+3. Choose **Replace** when Finder asks; do not merge or retain the old bundle.
+4. Run `sagascript --version` and confirm it reports the new release revision.
+
+The `/usr/local/bin/sagascript` link above points into the app bundle, so it
+automatically reaches the replacement executable. If it points elsewhere,
+repeat the `ln -sfn` command before testing the upgraded CLI.
+
 ### Homebrew (planned)
 
 ```

--- a/scripts/smoke-installed-macos-cli.sh
+++ b/scripts/smoke-installed-macos-cli.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_version=${1:?usage: smoke-installed-macos-cli.sh VERSION GIT_HASH AUDIO_FILE}
+expected_git_hash=${2:?usage: smoke-installed-macos-cli.sh VERSION GIT_HASH AUDIO_FILE}
+audio_file=${3:?usage: smoke-installed-macos-cli.sh VERSION GIT_HASH AUDIO_FILE}
+
+installed_cli=/usr/local/bin/sagascript
+expected_executable=/Applications/Sagascript.app/Contents/MacOS/sagascript
+
+[[ -L "$installed_cli" ]] || {
+  echo "$installed_cli must be a symlink into the installed app bundle" >&2
+  exit 1
+}
+
+actual_target=$(readlink "$installed_cli")
+[[ "$actual_target" == "$expected_executable" ]] || {
+  echo "$installed_cli points to $actual_target, expected $expected_executable" >&2
+  exit 1
+}
+
+version_output=$("$installed_cli" --version)
+[[ "$version_output" == *"$expected_version"* ]] || {
+  echo "Installed CLI reports the wrong version: $version_output" >&2
+  exit 1
+}
+[[ "$version_output" == *"git $expected_git_hash"* ]] || {
+  echo "Installed CLI reports the wrong source revision: $version_output" >&2
+  exit 1
+}
+
+"$installed_cli" download-model nb-whisper-tiny
+result=${RUNNER_TEMP:-/tmp}/sagascript-installed-cli-smoke.json
+"$installed_cli" transcribe \
+  --language no \
+  --model nb-whisper-tiny \
+  --beam 0 \
+  --json \
+  "$audio_file" > "$result"
+
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert "storting" in d["text"].lower(); assert d["language"] == "no"; assert d["segments"]' "$result"
+
+echo "Verified installed CLI: $version_output"

--- a/src-tauri/crates/sagascript-cli/Cargo.toml
+++ b/src-tauri/crates/sagascript-cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Headless CLI for Sagascript: transcribe, record, and manage models from the terminal"
+build = "build.rs"
 
 # The binary keeps the `sagascript` name so the headless install UX is
 # unchanged (clap's command name, completions, and manpages all say

--- a/src-tauri/crates/sagascript-cli/build.rs
+++ b/src-tauri/crates/sagascript-cli/build.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+
+fn command_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|value| value.trim().to_string())
+}
+
+fn metadata_value(key: &str, fallback: impl FnOnce() -> String) -> String {
+    std::env::var(key).ok().unwrap_or_else(fallback)
+}
+
+fn emit_git_rerun_triggers() {
+    if let Some(git_dir) = command_output(&["rev-parse", "--absolute-git-dir"]) {
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        if let Some(reference) = command_output(&["symbolic-ref", "-q", "HEAD"]) {
+            if let Some(reference_path) =
+                command_output(&["rev-parse", "--git-path", reference.as_str()])
+            {
+                println!("cargo:rerun-if-changed={reference_path}");
+            }
+        }
+        if let Some(packed_refs) = command_output(&["rev-parse", "--git-path", "packed-refs"]) {
+            println!("cargo:rerun-if-changed={packed_refs}");
+        }
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=SAGASCRIPT_GIT_HASH");
+    println!("cargo:rerun-if-env-changed=SAGASCRIPT_BUILD_DATE");
+    emit_git_rerun_triggers();
+
+    let git_hash = metadata_value("SAGASCRIPT_GIT_HASH", || {
+        command_output(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
+    });
+    let build_date = metadata_value("SAGASCRIPT_BUILD_DATE", || {
+        // Keep local builds reproducible enough to identify without adding a
+        // chrono build dependency to the CLI crate. Release CI always supplies
+        // an ISO date explicitly.
+        command_output(&["show", "-s", "--format=%cs", "HEAD"])
+            .unwrap_or_else(|| "unknown".to_string())
+    });
+
+    println!("cargo:rustc-env=SAGASCRIPT_CLI_GIT_HASH={git_hash}");
+    println!("cargo:rustc-env=SAGASCRIPT_CLI_BUILD_DATE={build_date}");
+}

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -17,6 +17,18 @@ pub(crate) fn set_transcription_progress(progress: &indicatif::ProgressBar, perc
     progress.set_position(percentage.clamp(0, 100) as u64);
 }
 
+/// `--version` deliberately includes the source revision and build date. A
+/// semantic version alone cannot distinguish a stale app-bundle executable
+/// from a rebuilt release candidate with the same pre-release version.
+pub const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (git ",
+    env!("SAGASCRIPT_CLI_GIT_HASH"),
+    ", built ",
+    env!("SAGASCRIPT_CLI_BUILD_DATE"),
+    ")"
+);
+
 // Root help text is feature-aware: a batch-only build (`--no-default-features`)
 // has no `record` subcommand, so the workflow/examples must not advertise it.
 #[cfg(feature = "record")]
@@ -117,6 +129,7 @@ ENVIRONMENT:
 #[command(
     name = "sagascript",
     version,
+    long_version = LONG_VERSION,
     about = "Low-latency dictation app",
     long_about = ROOT_LONG_ABOUT,
     after_long_help = ROOT_AFTER_LONG_HELP
@@ -505,6 +518,16 @@ mod tests {
 
         set_transcription_progress(&progress, -1);
         assert_eq!(progress.position(), 0);
+    }
+
+    #[test]
+    fn long_version_identifies_the_exact_build() {
+        assert!(LONG_VERSION.contains(env!("CARGO_PKG_VERSION")));
+        assert!(LONG_VERSION.contains("git "));
+        assert!(LONG_VERSION.contains("built "));
+
+        let command = Cli::command();
+        assert_eq!(command.get_long_version(), Some(LONG_VERSION));
     }
 
     // -- Completions generation --


### PR DESCRIPTION
## Summary

- include Git revision and build date in `sagascript --version` while keeping `-V` concise
- refresh build metadata automatically when Git HEAD changes
- simulate replacing a stale `/Applications/Sagascript.app` during release CI
- transcribe a real fixture through `/usr/local/bin/sagascript` after replacement
- document CLI linking and upgrade verification

## Validation

- 81 CLI tests passed
- strict CLI Clippy passed
- workflow YAML, shell syntax, executable mode, and diff checks passed
- post-commit rebuild changed reported identity from `4f18990` to `aad98e3`

Closes #84