### PR TITLE
Align onboarding and permission enable flows

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -52,7 +52,7 @@ Valid values per key:
                        nb-whisper-base, nb-whisper-small
   hotkey_mode          push, toggle
   show_overlay         true, false
-  auto_paste           true, false
+  auto_paste           true, false (enabling requires Accessibility approval for the installed GUI)
   auto_select_model    true, false
   hotkey               Modifier+Key (e.g. Control+Shift+Space, Option+Space)
   initial_prompt       Any string (e.g. names, jargon, preferred spellings)
@@ -210,7 +210,17 @@ fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
     .map_err(DictationError::SettingsError)?;
 
     eprintln!("Set {key} = {}", get_setting_value(&settings, key));
+    if let Some(warning) = setting_warning(key, &settings) {
+        eprintln!("Warning: {warning}");
+    }
     Ok(())
+}
+
+fn setting_warning(key: &str, settings: &Settings) -> Option<&'static str> {
+    (key == "auto_paste" && settings.auto_paste).then_some(
+        "auto-paste requires Accessibility approval for the installed Sagascript app; \
+         until it is granted, the GUI will keep or reset auto-paste to false",
+    )
 }
 
 fn apply_setting_value(
@@ -702,5 +712,20 @@ mod tests {
     fn get_setting_value_unknown_key_returns_unknown() {
         let settings = Settings::default();
         assert_eq!(get_setting_value(&settings, "nonexistent"), "unknown");
+    }
+
+    #[test]
+    fn enabling_auto_paste_warns_about_gui_accessibility_requirement() {
+        let settings = Settings::default();
+        let warning = setting_warning("auto_paste", &settings).unwrap();
+        assert!(warning.contains("Accessibility approval"));
+        assert!(warning.contains("reset auto-paste to false"));
+
+        let disabled = Settings {
+            auto_paste: false,
+            ..Default::default()
+        };
+        assert!(setting_warning("auto_paste", &disabled).is_none());
+        assert!(setting_warning("show_overlay", &Settings::default()).is_none());
     }
 }

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -667,6 +667,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn config_set_help_explains_auto_paste_permission_requirement() {
+        let cmd = Cli::command();
+        let config = cmd.find_subcommand("config").unwrap();
+        let set = config.find_subcommand("set").unwrap();
+        let help = get_long_help(set);
+        assert!(
+            help.contains("enabling requires Accessibility approval for the installed GUI"),
+            "config set help should explain the auto-paste permission requirement"
+        );
+    }
+
     /// Batch-only builds must not advertise the absent `record` subcommand
     /// anywhere in the root help (workflow, examples) — the batch contract
     /// is "no record", and stale mentions would send users to a command

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -995,6 +995,7 @@ mod macos_mic {
 
     /// AVAuthorizationStatus values
     const AV_AUTH_STATUS_NOT_DETERMINED: isize = 0;
+    const AV_AUTH_STATUS_DENIED: isize = 2;
 
     /// Returns true if the binary is running from inside a proper .app bundle.
     /// When running via `cargo run` or `cargo tauri dev` without a bundle,
@@ -1064,6 +1065,22 @@ mod macos_mic {
         }
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    enum AccessRequestDecision {
+        QuerySystem,
+        Complete(bool),
+    }
+
+    fn access_request_decision(status: isize) -> AccessRequestDecision {
+        match status {
+            AV_AUTH_STATUS_NOT_DETERMINED | AV_AUTH_STATUS_DENIED => {
+                AccessRequestDecision::QuerySystem
+            }
+            3 => AccessRequestDecision::Complete(true),
+            _ => AccessRequestDecision::Complete(false),
+        }
+    }
+
     /// Return the raw authorization status as a string.
     /// AVCaptureDevice can cache `authorizationStatus` in-process, so when it
     /// reports "denied" we re-query via `requestAccess` which returns the
@@ -1112,13 +1129,10 @@ mod macos_mic {
         let media_type = av_media_type_audio();
 
         let status: isize = unsafe { msg_send![cls, authorizationStatusForMediaType: media_type] };
-        if status != AV_AUTH_STATUS_NOT_DETERMINED {
-            // Already determined (authorized, denied, or restricted) — fire callback immediately
-            callback(authorization_status_label(status, false) == "authorized");
-            return;
+        match access_request_decision(status) {
+            AccessRequestDecision::QuerySystem => request_access_from_system(callback),
+            AccessRequestDecision::Complete(granted) => callback(granted),
         }
-
-        request_access_from_system(callback);
     }
 
     /// Invoke AVFoundation's request API without consulting the potentially
@@ -1151,7 +1165,7 @@ mod macos_mic {
 
     #[cfg(test)]
     mod tests {
-        use super::authorization_status_label;
+        use super::{AccessRequestDecision, access_request_decision, authorization_status_label};
 
         #[test]
         fn maps_avfoundation_authorization_constants_correctly() {
@@ -1165,6 +1179,24 @@ mod macos_mic {
         fn denied_cache_can_be_refreshed_without_remapping_authorized() {
             assert_eq!(authorization_status_label(2, true), "authorized");
             assert_eq!(authorization_status_label(3, false), "authorized");
+        }
+
+        #[test]
+        fn request_decision_live_queries_undetermined_and_cached_denied() {
+            assert_eq!(access_request_decision(0), AccessRequestDecision::QuerySystem);
+            assert_eq!(access_request_decision(2), AccessRequestDecision::QuerySystem);
+        }
+
+        #[test]
+        fn request_decision_completes_known_restricted_and_authorized_states() {
+            assert_eq!(
+                access_request_decision(1),
+                AccessRequestDecision::Complete(false)
+            );
+            assert_eq!(
+                access_request_decision(3),
+                AccessRequestDecision::Complete(true)
+            );
         }
     }
 }

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -150,6 +150,7 @@
   // -- Accessibility --
 
   async function grantAccessibility() {
+    accessibilityError = null;
     accessibilityChecking = true;
     try {
       await requestAccessibilityPermission();
@@ -161,7 +162,24 @@
           stopPoll();
         }
       });
-    } catch {
+    } catch (e: any) {
+      accessibilityError =
+        typeof e === "string" ? e : e?.message ?? "Failed to request Accessibility permission. Please try again.";
+      accessibilityChecking = false;
+    }
+  }
+
+  async function continueWithAccessibility() {
+    stopPoll();
+    accessibilityChecking = true;
+    accessibilityError = null;
+    try {
+      await setAutoPaste(true);
+      nextStep();
+    } catch (e: any) {
+      accessibilityError =
+        typeof e === "string" ? e : e?.message ?? "Failed to enable auto-paste. Please try again.";
+    } finally {
       accessibilityChecking = false;
     }
   }
@@ -535,7 +553,9 @@
 
         <div class="actions">
           {#if accessibilityGranted}
-            <button class="primary" onclick={nextStep}>Continue</button>
+            <button class="primary" onclick={continueWithAccessibility} disabled={accessibilityChecking}>
+              {accessibilityChecking ? "Saving…" : "Continue"}
+            </button>
           {:else}
             <button class="primary" onclick={grantAccessibility} disabled={accessibilityChecking}>
               {#if accessibilityChecking}

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -155,11 +155,20 @@
     try {
       await requestAccessibilityPermission();
       startPoll(async () => {
-        const granted = await checkAccessibilityPermission();
-        if (granted) {
-          accessibilityGranted = true;
-          accessibilityChecking = false;
+        try {
+          const granted = await checkAccessibilityPermission();
+          if (!accessibilityChecking) return;
+          if (granted) {
+            accessibilityGranted = true;
+            accessibilityChecking = false;
+            stopPoll();
+          }
+        } catch (e: any) {
+          if (!accessibilityChecking) return;
           stopPoll();
+          accessibilityChecking = false;
+          accessibilityError =
+            typeof e === "string" ? e : e?.message ?? "Failed to check Accessibility permission. Please try again.";
         }
       });
     } catch (e: any) {
@@ -186,6 +195,7 @@
 
   async function skipAccessibility() {
     stopPoll();
+    accessibilityChecking = false;
     savingManualPaste = true;
     accessibilityError = null;
     try {
@@ -571,7 +581,7 @@
           {/if}
         </div>
         {#if accessibilityError}
-          <div class="status-indicator error">
+          <div class="status-indicator error" role="alert" aria-live="assertive">
             <span class="status-dot"></span>
             <span>{accessibilityError}</span>
           </div>

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -43,7 +43,8 @@
   let accessibilityGranted = $state(false);
   let accessibilityChecking = $state(false);
   let savingManualPaste = $state(false);
-  let pollTimer: ReturnType<typeof setInterval> | null = $state(null);
+  let pollTimer: ReturnType<typeof setTimeout> | null = $state(null);
+  let pollGeneration = 0;
 
   // Hotkey (read from settings)
   let hotkeyParts: string[] = $state(["Ctrl", "Shift", "Space"]);
@@ -121,50 +122,72 @@
 
   // -- Microphone --
 
+  function startMicrophonePoll(generation: number) {
+    startPoll(generation, async (isCurrent) => {
+      try {
+        const polled = await microphoneStatus();
+        if (!isCurrent()) return;
+        micStatus = polled;
+        if (polled === "authorized") stopPoll();
+      } catch {
+        // A transient query failure is retried by the serialized poll loop.
+      }
+    });
+  }
+
+  async function openMicrophoneSettingsAndPoll() {
+    const generation = beginPollOperation();
+    try {
+      await openMicrophoneSettings();
+      if (!isPollCurrent(generation)) return;
+      startMicrophonePoll(generation);
+    } catch {
+      // Leave the denied state visible so the user can retry opening Settings.
+    }
+  }
+
   async function grantMicrophone() {
+    const generation = beginPollOperation();
     try {
       micStatus = "checking";
       const result = await requestMicrophoneAccess();
+      if (!isPollCurrent(generation)) return;
       micStatus = result;
       if (result === "denied") {
         // macOS won't re-show the dialog — open System Settings and poll
         await openMicrophoneSettings();
-        startPoll(async () => {
-          try {
-            const polled = await microphoneStatus();
-            micStatus = polled;
-            if (polled === "authorized") {
-              stopPoll();
-            }
-          } catch {
-            // keep polling
-          }
-        });
+        if (!isPollCurrent(generation)) return;
+        startMicrophonePoll(generation);
       }
     } catch (e) {
+      if (!isPollCurrent(generation)) return;
       // Prevent spinner getting stuck
-      micStatus = await microphoneStatus().catch(() => "not_determined");
+      const fallback = await microphoneStatus().catch(() => "not_determined");
+      if (!isPollCurrent(generation)) return;
+      micStatus = fallback;
     }
   }
 
   // -- Accessibility --
 
   async function grantAccessibility() {
+    const generation = beginPollOperation();
     accessibilityError = null;
     accessibilityChecking = true;
     try {
       await requestAccessibilityPermission();
-      startPoll(async () => {
+      if (!isPollCurrent(generation)) return;
+      startPoll(generation, async (isCurrent) => {
         try {
           const granted = await checkAccessibilityPermission();
-          if (!accessibilityChecking) return;
+          if (!isCurrent()) return;
           if (granted) {
             accessibilityGranted = true;
             accessibilityChecking = false;
             stopPoll();
           }
         } catch (e: any) {
-          if (!accessibilityChecking) return;
+          if (!isCurrent()) return;
           stopPoll();
           accessibilityChecking = false;
           accessibilityError =
@@ -172,6 +195,7 @@
         }
       });
     } catch (e: any) {
+      if (!isPollCurrent(generation)) return;
       accessibilityError =
         typeof e === "string" ? e : e?.message ?? "Failed to request Accessibility permission. Please try again.";
       accessibilityChecking = false;
@@ -211,14 +235,33 @@
     }
   }
 
-  function startPoll(fn: () => Promise<void>) {
+  function beginPollOperation(): number {
     stopPoll();
-    pollTimer = setInterval(fn, 1000);
+    return pollGeneration;
+  }
+
+  function isPollCurrent(generation: number): boolean {
+    return generation === pollGeneration;
+  }
+
+  function startPoll(generation: number, fn: (isCurrent: () => boolean) => Promise<void>) {
+    if (!isPollCurrent(generation)) return;
+
+    const run = async () => {
+      if (!isPollCurrent(generation)) return;
+      pollTimer = null;
+      await fn(() => isPollCurrent(generation));
+      if (!isPollCurrent(generation)) return;
+      pollTimer = setTimeout(run, 1000);
+    };
+
+    pollTimer = setTimeout(run, 1000);
   }
 
   function stopPoll() {
+    pollGeneration += 1;
     if (pollTimer) {
-      clearInterval(pollTimer);
+      clearTimeout(pollTimer);
       pollTimer = null;
     }
   }
@@ -484,7 +527,7 @@
             <strong>System Settings &rsaquo; Privacy &amp; Security &rsaquo; Microphone</strong>.
           </p>
           <div class="actions">
-            <button class="primary" onclick={() => { openMicrophoneSettings(); startPoll(async () => { try { const s = await microphoneStatus(); micStatus = s; if (s === "authorized") stopPoll(); } catch {} }); }}>
+            <button class="primary" onclick={openMicrophoneSettingsAndPoll}>
               <span class="button-spinner"></span>
               Waiting — Open System Settings
             </button>


### PR DESCRIPTION
## Summary

- explicitly re-enable auto-paste when a user continues after granting Accessibility during onboarding
- keep onboarding on the permission step and surface an error if persistence fails
- live-query macOS microphone access for both undetermined and cached-denied states
- warn CLI users that `auto_paste=true` still requires Accessibility approval for the installed GUI

## Validation

- npm audit: zero vulnerabilities
- frontend check: zero errors/warnings
- production frontend build passed
- app tests: 73/73
- CLI tests: 83/83
- strict app/CLI Clippy passed
- diff check passed

Addresses launch-wide Fable review findings on permission state consistency.