### PR TITLE
Close release integrity verification gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: npm run release:check
 
+      - name: Test deterministic release helpers
+        run: |
+          ./scripts/test-verify-audio-entitlement.sh
+          en_sort=$(LC_ALL=en_US.UTF-8 node scripts/generate-third-party-notices.mjs --test-sort)
+          sv_sort=$(LC_ALL=sv_SE.UTF-8 node scripts/generate-third-party-notices.mjs --test-sort)
+          [[ "$en_sort" == "$sv_sort" ]]
+
       - name: Verify third-party notices
         run: npm run licenses:check
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -64,14 +64,14 @@ link; the upstream repository is authoritative for its license terms.
 | byteorder-lite | 0.1.0 | Unlicense OR MIT | [upstream](https://github.com/image-rs/byteorder-lite) |
 | bytes | 1.11.1 | MIT | [upstream](https://github.com/tokio-rs/bytes) |
 | camino | 1.2.2 | MIT OR Apache-2.0 | [upstream](https://github.com/camino-rs/camino) |
+| cargo-platform | 0.1.9 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang/cargo) |
 | cargo_metadata | 0.19.2 | MIT | [upstream](https://github.com/oli-obk/cargo_metadata) |
 | cargo_toml | 0.22.3 | Apache-2.0 OR MIT | [upstream](https://gitlab.com/lib.rs/cargo_toml) |
-| cargo-platform | 0.1.9 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang/cargo) |
 | cc | 1.2.56 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang/cc-rs) |
 | cexpr | 0.6.0 | Apache-2.0/MIT | [upstream](https://github.com/jethrogb/rust-cexpr) |
 | cfb | 0.7.3 | MIT | [upstream](https://github.com/mdsteele/rust-cfb) |
-| cfg_aliases | 0.2.1 | MIT | [upstream](https://github.com/katharostech/cfg_aliases) |
 | cfg-if | 1.0.4 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang/cfg-if) |
+| cfg_aliases | 0.2.1 | MIT | [upstream](https://github.com/katharostech/cfg_aliases) |
 | chrono | 0.4.43 | MIT OR Apache-2.0 | [upstream](https://github.com/chronotope/chrono) |
 | clang-sys | 1.8.1 | Apache-2.0 | [upstream](https://github.com/KyleMayes/clang-sys) |
 | clap | 4.5.60 | MIT OR Apache-2.0 | [upstream](https://github.com/clap-rs/clap) |
@@ -126,8 +126,8 @@ link; the upstream repository is authoritative for its license terms.
 | dunce | 1.0.5 | CC0-1.0 OR MIT-0 OR Apache-2.0 | [upstream](https://gitlab.com/kornelski/dunce) |
 | dyn-clone | 1.0.20 | MIT OR Apache-2.0 | [upstream](https://github.com/dtolnay/dyn-clone) |
 | either | 1.15.0 | MIT OR Apache-2.0 | [upstream](https://github.com/rayon-rs/either) |
-| embed_plist | 1.2.2 | MIT OR Apache-2.0 | [upstream](https://github.com/nvzqz/embed-plist-rs) |
 | embed-resource | 3.0.6 | MIT | [upstream](https://github.com/nabijaczleweli/rust-embed-resource) |
+| embed_plist | 1.2.2 | MIT OR Apache-2.0 | [upstream](https://github.com/nvzqz/embed-plist-rs) |
 | encoding_rs | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause | [upstream](https://github.com/hsivonen/encoding_rs) |
 | enigo | 0.6.1 | MIT | [upstream](https://github.com/enigo-rs/enigo) |
 | equivalent | 1.0.2 | Apache-2.0 OR MIT | [upstream](https://github.com/indexmap-rs/equivalent) |
@@ -146,8 +146,8 @@ link; the upstream repository is authoritative for its license terms.
 | foreign-types-macros | 0.2.3 | MIT/Apache-2.0 | [upstream](https://github.com/sfackler/foreign-types) |
 | foreign-types-shared | 0.3.1 | MIT/Apache-2.0 | [upstream](https://github.com/sfackler/foreign-types) |
 | form_urlencoded | 1.2.2 | MIT OR Apache-2.0 | [upstream](https://github.com/servo/rust-url) |
-| fs_extra | 1.3.0 | MIT | [upstream](https://github.com/webdesus/fs_extra) |
 | fs2 | 0.4.3 | MIT/Apache-2.0 | [upstream](https://github.com/danburkert/fs2-rs) |
+| fs_extra | 1.3.0 | MIT | [upstream](https://github.com/webdesus/fs_extra) |
 | fsevent-sys | 4.1.0 | MIT | [upstream](https://github.com/octplane/fsevent-rust/tree/master/fsevent-sys) |
 | futf | 0.1.5 | MIT / Apache-2.0 | [upstream](https://github.com/servo/futf) |
 | futures-channel | 0.3.32 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang/futures-rs) |
@@ -243,11 +243,11 @@ link; the upstream repository is authoritative for its license terms.
 | notify | 7.0.0 | CC0-1.0 | [upstream](https://github.com/notify-rs/notify.git) |
 | notify-types | 1.0.1 | MIT OR Apache-2.0 | [upstream](https://github.com/notify-rs/notify.git) |
 | nu-ansi-term | 0.50.3 | MIT | [upstream](https://github.com/nushell/nu-ansi-term) |
-| num_cpus | 1.17.0 | MIT OR Apache-2.0 | [upstream](https://github.com/seanmonstar/num_cpus) |
 | num-complex | 0.4.6 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-num/num-complex) |
 | num-conv | 0.2.0 | MIT OR Apache-2.0 | [upstream](https://github.com/jhpratt/num-conv) |
 | num-integer | 0.1.46 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-num/num-integer) |
 | num-traits | 0.2.19 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-num/num-traits) |
+| num_cpus | 1.17.0 | MIT OR Apache-2.0 | [upstream](https://github.com/seanmonstar/num_cpus) |
 | number_prefix | 0.4.0 | MIT | [upstream](https://github.com/ogham/rust-number-prefix) |
 | objc | 0.2.7 | MIT | [upstream](http://github.com/SSheldon/rust-objc) |
 | objc2 | 0.6.3 | MIT | [upstream](https://github.com/madsmtm/objc2) |
@@ -326,8 +326,8 @@ link; the upstream repository is authoritative for its license terms.
 | ring | 0.17.14 | Apache-2.0 AND ISC | [upstream](https://github.com/briansmith/ring) |
 | roff | 0.2.2 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-cli/roff-rs) |
 | rubato | 0.14.1 | MIT | [upstream](https://github.com/HEnquist/rubato) |
-| rustc_version | 0.4.1 | MIT OR Apache-2.0 | [upstream](https://github.com/djc/rustc-version-rs) |
 | rustc-hash | 2.1.1 | Apache-2.0 OR MIT | [upstream](https://github.com/rust-lang/rustc-hash) |
+| rustc_version | 0.4.1 | MIT OR Apache-2.0 | [upstream](https://github.com/djc/rustc-version-rs) |
 | rustfft | 6.4.1 | MIT OR Apache-2.0 | [upstream](https://github.com/ejmahler/RustFFT) |
 | rustix | 1.1.3 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | [upstream](https://github.com/bytecodealliance/rustix) |
 | rustls | 0.23.36 | Apache-2.0 OR ISC OR MIT | [upstream](https://github.com/rustls/rustls) |
@@ -345,6 +345,7 @@ link; the upstream repository is authoritative for its license terms.
 | selectors | 0.24.0 | MPL-2.0 | [upstream](https://github.com/servo/servo) |
 | semver | 1.0.27 | MIT OR Apache-2.0 | [upstream](https://github.com/dtolnay/semver) |
 | serde | 1.0.228 | MIT OR Apache-2.0 | [upstream](https://github.com/serde-rs/serde) |
+| serde-untagged | 0.1.9 | MIT OR Apache-2.0 | [upstream](https://github.com/dtolnay/serde-untagged) |
 | serde_core | 1.0.228 | MIT OR Apache-2.0 | [upstream](https://github.com/serde-rs/serde) |
 | serde_derive | 1.0.228 | MIT OR Apache-2.0 | [upstream](https://github.com/serde-rs/serde) |
 | serde_derive_internals | 0.29.1 | MIT OR Apache-2.0 | [upstream](https://github.com/serde-rs/serde) |
@@ -354,7 +355,6 @@ link; the upstream repository is authoritative for its license terms.
 | serde_urlencoded | 0.7.1 | MIT/Apache-2.0 | [upstream](https://github.com/nox/serde_urlencoded) |
 | serde_with | 3.16.1 | MIT OR Apache-2.0 | [upstream](https://github.com/jonasbb/serde_with/) |
 | serde_with_macros | 3.16.1 | MIT OR Apache-2.0 | [upstream](https://github.com/jonasbb/serde_with/) |
-| serde-untagged | 0.1.9 | MIT OR Apache-2.0 | [upstream](https://github.com/dtolnay/serde-untagged) |
 | serialize-to-javascript | 0.1.2 | MIT OR Apache-2.0 | [upstream](https://github.com/chippers/serialize-to-javascript) |
 | serialize-to-javascript-impl | 0.1.2 | MIT OR Apache-2.0 | [upstream](https://github.com/chippers/serialize-to-javascript) |
 | servo_arc | 0.2.0 | MIT OR Apache-2.0 | [upstream](https://github.com/servo/servo) |
@@ -461,8 +461,8 @@ link; the upstream repository is authoritative for its license terms.
 | url | 2.5.8 | MIT OR Apache-2.0 | [upstream](https://github.com/servo/rust-url) |
 | urlpattern | 0.3.0 | MIT | [upstream](https://github.com/denoland/rust-urlpattern) |
 | utf-8 | 0.7.6 | MIT OR Apache-2.0 | [upstream](https://github.com/SimonSapin/rust-utf8) |
-| utf8_iter | 1.0.4 | Apache-2.0 OR MIT | [upstream](https://github.com/hsivonen/utf8_iter) |
 | utf8-zero | 0.8.1 | MIT OR Apache-2.0 | [upstream](https://github.com/algesten/utf8-zero) |
+| utf8_iter | 1.0.4 | Apache-2.0 OR MIT | [upstream](https://github.com/hsivonen/utf8_iter) |
 | utf8parse | 0.2.2 | Apache-2.0 OR MIT | [upstream](https://github.com/alacritty/vte) |
 | uuid | 1.21.0 | Apache-2.0 OR MIT | [upstream](https://github.com/uuid-rs/uuid) |
 | version_check | 0.9.5 | MIT/Apache-2.0 | [upstream](https://github.com/SergioBenitez/version_check) |

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -14,8 +14,22 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outputPath = join(root, "THIRD_PARTY_NOTICES.md");
 const mode = process.argv[2];
 
+function compareCodeUnits(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+if (mode === "--test-sort") {
+  const fixture = ["z", "ä", "a", "å", "A"].sort(compareCodeUnits);
+  const expected = ["A", "a", "z", "ä", "å"];
+  if (fixture.join("\0") !== expected.join("\0")) {
+    throw new Error(`Unexpected deterministic sort order: ${fixture.join(", ")}`);
+  }
+  console.log(createHash("sha256").update(fixture.join("\n")).digest("hex"));
+  process.exit(0);
+}
+
 if (!new Set(["--check", "--write"]).has(mode)) {
-  console.error("Usage: node scripts/generate-third-party-notices.mjs --check|--write");
+  console.error("Usage: node scripts/generate-third-party-notices.mjs --check|--write|--test-sort");
   process.exit(2);
 }
 
@@ -108,7 +122,7 @@ function rootLicenseFiles(directory) {
     .filter((name) => /^(licen[sc]e|copying|notice)([._-].*)?$/i.test(name))
     .map((name) => join(directory, name))
     .filter((path) => statSync(path).isFile())
-    .sort();
+    .sort(compareCodeUnits);
 }
 
 const rustById = new Map();
@@ -139,7 +153,7 @@ const rustPackages = [...rustById.values()]
     source: componentSource(pkg, "Rust"),
     directory: dirname(pkg.manifest_path),
   }))
-  .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+  .sort((a, b) => compareCodeUnits(a.name, b.name) || compareCodeUnits(a.version, b.version));
 
 const lock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8"));
 const lockedNpmPackages = Object.entries(lock.packages)
@@ -156,7 +170,7 @@ const lockedNpmPackages = Object.entries(lock.packages)
       optional: pkg.optional === true,
     };
   })
-  .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+  .sort((a, b) => compareCodeUnits(a.name, b.name) || compareCodeUnits(a.version, b.version));
 // Keep every locked npm package in the inventory so output is identical on
 // Apple Silicon and Intel CI. Platform-specific optional packages are not
 // installed on the other architecture, so their SPDX metadata is recorded but
@@ -280,13 +294,13 @@ The following verbatim texts are collected from root-level \`LICENSE\`,
 texts are deduplicated while retaining the associated component list.
 
 ${[...licenseTexts.entries()]
-  .sort(([a], [b]) => a.localeCompare(b))
+  .sort(([a], [b]) => compareCodeUnits(a, b))
   .map(
     ([digest, entry]) => `### ${digest.slice(0, 12)}
 
-Components: ${entry.components.sort().join(", ")}
+Components: ${entry.components.sort(compareCodeUnits).join(", ")}
 
-Source filenames: ${[...entry.filenames].sort().join(", ")}
+Source filenames: ${[...entry.filenames].sort(compareCodeUnits).join(", ")}
 
 ~~~~text
 ${entry.content}

--- a/scripts/test-verify-audio-entitlement.sh
+++ b/scripts/test-verify-audio-entitlement.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+verifier="$root/scripts/verify-macos-release.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+make_plist() {
+  plutil -create xml1 "$1"
+}
+
+make_plist "$tmp/true.plist"
+/usr/libexec/PlistBuddy -c 'Add :com.apple.security.device.audio-input bool true' "$tmp/true.plist"
+"$verifier" --check-entitlements-plist "$tmp/true.plist"
+
+make_plist "$tmp/false.plist"
+/usr/libexec/PlistBuddy -c 'Add :com.apple.security.device.audio-input bool false' "$tmp/false.plist"
+if "$verifier" --check-entitlements-plist "$tmp/false.plist"; then
+  echo "False audio-input entitlement unexpectedly passed" >&2
+  exit 1
+fi
+
+make_plist "$tmp/missing.plist"
+if "$verifier" --check-entitlements-plist "$tmp/missing.plist"; then
+  echo "Missing audio-input entitlement unexpectedly passed" >&2
+  exit 1
+fi
+
+echo "Audio-input entitlement verifier tests passed"

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+verify_audio_input_entitlement() {
+  local value
+  value=$(plutil -extract 'com\.apple\.security\.device\.audio-input' raw "$1" 2>/dev/null) || return 1
+  [[ "$value" == "true" ]]
+}
+
+if [[ ${1:-} == "--check-entitlements-plist" ]]; then
+  [[ $# -eq 2 ]] || { echo "Usage: $0 --check-entitlements-plist /path/to/entitlements.plist" >&2; exit 2; }
+  verify_audio_input_entitlement "$2"
+  exit
+fi
+
 if [[ $# -ne 3 ]]; then
   echo "Usage: $0 /path/to/Sagascript.app /path/to/Sagascript.dmg VERSION" >&2
   exit 2
@@ -50,7 +62,7 @@ grep -Eq '^CodeDirectory .*flags=.*\(runtime\)' <<<"$signature" || {
 entitlements=$(mktemp)
 trap 'rm -f "$entitlements"' EXIT
 codesign -d --entitlements :- "$app" >"$entitlements" 2>/dev/null
-[[ "$(plutil -extract com.apple.security.device.audio-input raw "$entitlements")" == "true" ]] || {
+verify_audio_input_entitlement "$entitlements" || {
   echo "Signed app is missing the audio-input entitlement" >&2
   exit 1
 }

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -40,7 +40,8 @@ fn legacy_settings_paths() -> impl Iterator<Item = PathBuf> {
         .map(move |identifier| base.join(identifier).join(SETTINGS_FILENAME))
 }
 
-fn copy_legacy_settings(source: &PathBuf, destination: &PathBuf) -> Result<bool, String> {
+/// Caller must hold the destination's settings lock.
+fn copy_legacy_settings(source: &Path, destination: &Path) -> Result<bool, String> {
     if destination.exists() || !source.is_file() {
         return Ok(false);
     }
@@ -64,20 +65,26 @@ fn copy_legacy_settings(source: &PathBuf, destination: &PathBuf) -> Result<bool,
     object.insert("auto_paste".to_string(), serde_json::Value::Bool(false));
     let migrated = serde_json::to_string_pretty(&value)
         .map_err(|error| format!("Failed to serialize migrated settings: {error}"))?;
-    std::fs::write(destination, migrated)
+    let tmp_path = destination.with_extension("json.tmp");
+    std::fs::write(&tmp_path, migrated)
         .map_err(|error| format!("Failed to write migrated settings: {error}"))?;
+    std::fs::rename(&tmp_path, destination)
+        .map_err(|error| format!("Failed to install migrated settings: {error}"))?;
     Ok(true)
 }
 
 /// Copy settings from an earlier bundle identifier on first use of the new
 /// identifier. Keep the source in place so rolling back a pre-launch build is
 /// safe. Once the destination exists it always wins.
-fn migrate_legacy_identifier_settings(destination: &PathBuf) {
+fn migrate_legacy_identifier_settings_locked(
+    destination: &Path,
+    sources: impl IntoIterator<Item = PathBuf>,
+) {
     if destination.exists() {
         return;
     }
 
-    for source in legacy_settings_paths() {
+    for source in sources {
         if !source.is_file() {
             continue;
         }
@@ -101,8 +108,23 @@ fn migrate_legacy_identifier_settings(destination: &PathBuf) {
 /// Partial JSON files are handled by `#[serde(default)]` on Settings.
 pub fn load() -> Settings {
     let path = settings_path();
-    migrate_legacy_identifier_settings(&path);
-    load_from(&path)
+    // Existing settings are installed with atomic rename, so a read needs no
+    // lock. Only the first-run missing-file path can migrate and must share the
+    // writers' lock for its existence recheck, write, and initial read.
+    if path.exists() {
+        return load_from(&path);
+    }
+    with_settings_lock(&path, || {
+        migrate_legacy_identifier_settings_locked(&path, legacy_settings_paths());
+        Ok(load_from(&path))
+    })
+    .unwrap_or_else(|error| {
+        tracing::warn!(
+            "Failed to lock settings file at {} for loading: {error} — falling back to defaults",
+            path.display()
+        );
+        Settings::default()
+    })
 }
 
 /// Load settings from a specific path. Returns defaults if missing or unreadable.
@@ -138,8 +160,10 @@ pub fn load_from(path: &Path) -> Settings {
 /// Uses atomic write: write to .tmp then rename.
 pub fn save(settings: &Settings) -> Result<(), String> {
     let path = settings_path();
-    migrate_legacy_identifier_settings(&path);
-    with_settings_lock(&path, || save_to(&path, settings))
+    with_settings_lock(&path, || {
+        migrate_legacy_identifier_settings_locked(&path, legacy_settings_paths());
+        save_to(&path, settings)
+    })
 }
 
 /// Apply a field-level settings mutation to the latest on-disk snapshot and
@@ -152,15 +176,27 @@ where
     F: FnOnce(&mut Settings),
 {
     let path = settings_path();
-    migrate_legacy_identifier_settings(&path);
-    update_at(&path, mutate)
+    update_at_with_legacy_sources(&path, legacy_settings_paths(), mutate)
 }
 
+#[cfg(test)]
 fn update_at<F>(path: &Path, mutate: F) -> Result<Settings, String>
 where
     F: FnOnce(&mut Settings),
 {
+    update_at_with_legacy_sources(path, std::iter::empty(), mutate)
+}
+
+fn update_at_with_legacy_sources<F>(
+    path: &Path,
+    sources: impl IntoIterator<Item = PathBuf>,
+    mutate: F,
+) -> Result<Settings, String>
+where
+    F: FnOnce(&mut Settings),
+{
     with_settings_lock(path, || {
+        migrate_legacy_identifier_settings_locked(path, sources);
         let mut settings = load_from(path);
         mutate(&mut settings);
         save_to(path, &settings)?;
@@ -267,6 +303,8 @@ mod tests {
     use super::*;
     use crate::settings::{HotkeyMode, Language, WhisperModel};
     use std::fs;
+    use std::sync::mpsc;
+    use std::thread;
 
     /// Helper: create a temp dir and override settings_path for testing
     fn with_temp_settings<F: FnOnce(PathBuf)>(f: F) {
@@ -336,6 +374,76 @@ mod tests {
         assert_eq!(migrated["has_completed_onboarding"], true);
         assert!(migrated.get("hasCompletedOnboarding").is_none());
         assert_eq!(migrated["future_key"]["x"], 1);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn concurrent_first_run_update_waits_for_atomic_migration() {
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-concurrent-migration-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let legacy = root.join("legacy").join(SETTINGS_FILENAME);
+        let destination = root.join("current").join(SETTINGS_FILENAME);
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(
+            &legacy,
+            r#"{"language":"sv","auto_paste":true,"future_key":{"x":1}}"#,
+        )
+        .unwrap();
+
+        let (migration_locked_tx, migration_locked_rx) = mpsc::channel();
+        let (release_migration_tx, release_migration_rx) = mpsc::channel();
+        let migration_destination = destination.clone();
+        let migration_legacy = legacy.clone();
+        let migration = thread::spawn(move || {
+            with_settings_lock(&migration_destination, || {
+                migrate_legacy_identifier_settings_locked(
+                    &migration_destination,
+                    [migration_legacy],
+                );
+                migration_locked_tx.send(()).unwrap();
+                release_migration_rx.recv().unwrap();
+                Ok(())
+            })
+        });
+
+        // Hold the lock after the atomic migration has installed the file,
+        // then start an update in a second thread. It cannot read or write the
+        // destination until the migration's critical section is released.
+        migration_locked_rx.recv().unwrap();
+        let (update_blocked_tx, update_blocked_rx) = mpsc::channel();
+        let update_destination = destination.clone();
+        let update_legacy = legacy.clone();
+        let update = thread::spawn(move || {
+            let lock_probe = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(update_destination.with_extension("json.lock"))
+                .unwrap();
+            assert!(
+                lock_probe.try_lock_exclusive().is_err(),
+                "migration must still hold the settings lock"
+            );
+            update_blocked_tx.send(()).unwrap();
+            update_at_with_legacy_sources(&update_destination, [update_legacy], |settings| {
+                settings.language = Language::Norwegian;
+            })
+        });
+        update_blocked_rx.recv().unwrap();
+        release_migration_tx.send(()).unwrap();
+
+        migration.join().unwrap().unwrap();
+        let updated = update.join().unwrap().unwrap();
+        assert_eq!(updated.language, Language::Norwegian);
+        assert!(!updated.auto_paste);
+
+        let contents = fs::read_to_string(&destination).unwrap();
+        let persisted: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        assert_eq!(persisted["language"], "no");
+        assert_eq!(persisted["auto_paste"], false);
+        assert_eq!(persisted["future_key"]["x"], 1);
+        assert!(!destination.with_extension("json.tmp").exists());
         let _ = fs::remove_dir_all(root);
     }
 


### PR DESCRIPTION
## Summary

- extract the literal dotted macOS audio-input entitlement correctly and test true/false/missing fixtures in the release quality gate
- move first-run legacy settings migration under the shared settings lock and install it atomically
- preserve concurrent updates, unknown settings keys, and fail-closed auto-paste migration
- replace locale-dependent notice sorting with deterministic code-unit ordering and gate it across locales

## Validation

- 377 workspace Rust tests passed
- strict workspace Clippy passed
- frontend build passed
- entitlement fixture and en/sv sort-hash checks passed
- license generation/check passed (456 Rust, 113 npm)
- release metadata, Bash syntax, workflow YAML, and diff checks passed

Addresses launch-wide Fable review findings in the release verifier, settings migration, and notice reproducibility.