### PR TITLE
Repair invalid models and preserve clipboard ownership

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/models.rs
+++ b/src-tauri/crates/sagascript-cli/src/models.rs
@@ -142,28 +142,16 @@ pub async fn download(args: DownloadModelArgs) -> Result<(), DictationError> {
     }
 
     let whisper_model = parse_model(&args.model)?;
-
-    if model::is_model_downloaded(whisper_model) {
-        let path = model::model_path(whisper_model);
+    let was_present = model::is_model_downloaded(whisper_model);
+    if was_present {
+        eprintln!("Verifying {}...", whisper_model.display_name());
+    } else {
         eprintln!(
-            "Model '{}' is already downloaded at {}",
+            "Downloading {} (~{} MB)...",
             whisper_model.display_name(),
-            path.display()
+            whisper_model.size_mb()
         );
-        // Backfill the CoreML encoder if it's missing (no-op if already present
-        // or unavailable for this model).
-        if let Err(e) = model::backfill_coreml_encoder(whisper_model).await {
-            eprintln!("Note: CoreML encoder not installed: {e}");
-        }
-        println!("{}", path.display());
-        return Ok(());
     }
-
-    eprintln!(
-        "Downloading {} (~{} MB)...",
-        whisper_model.display_name(),
-        whisper_model.size_mb()
-    );
 
     let path = model::download_model(whisper_model, |downloaded, total| {
         if total > 0 {
@@ -178,8 +166,8 @@ pub async fn download(args: DownloadModelArgs) -> Result<(), DictationError> {
     })
     .await?;
 
-    eprintln!(); // newline after progress
-    eprintln!("Download complete.");
+    eprintln!(); // newline after progress (or verification message)
+    eprintln!("Model ready.");
     println!("{}", path.display());
     Ok(())
 }
@@ -191,21 +179,14 @@ async fn download_diarization_model(
     use sagascript_core::diarization::model as diar_model;
 
     if diar_model::is_model_downloaded(model) {
-        let path = diar_model::model_path(model);
+        eprintln!("Verifying {}...", model.display_name());
+    } else {
         eprintln!(
-            "Model '{}' is already downloaded at {}",
+            "Downloading {} (~{} MB)...",
             model.display_name(),
-            path.display()
+            model.size_mb()
         );
-        println!("{}", path.display());
-        return Ok(());
     }
-
-    eprintln!(
-        "Downloading {} (~{} MB)...",
-        model.display_name(),
-        model.size_mb()
-    );
 
     let path = diar_model::download_model(model, |downloaded, total| {
         if total > 0 {
@@ -221,7 +202,7 @@ async fn download_diarization_model(
     .await?;
 
     eprintln!(); // newline after progress
-    eprintln!("Download complete.");
+    eprintln!("Model ready.");
     println!("{}", path.display());
     Ok(())
 }

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -220,12 +220,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     };
     let vad_model_path = if vad_enabled {
         let path = model::vad_model_path();
-        if !path.exists() {
-            eprintln!("Downloading Silero VAD model (~0.9 MB)...");
-            tokio::runtime::Runtime::new()
-                .map_err(|e| DictationError::ModelDownloadFailed(format!("tokio runtime: {e}")))?
-                .block_on(model::download_vad_model(|_, _| {}))?;
-        }
+        eprintln!("Verifying Silero VAD model...");
+        tokio::runtime::Runtime::new()
+            .map_err(|e| DictationError::ModelDownloadFailed(format!("tokio runtime: {e}")))?
+            .block_on(model::download_vad_model(|_, _| {}))?;
         path.to_str().map(str::to_string)
     } else {
         None

--- a/src-tauri/crates/sagascript-core/src/diarization/model.rs
+++ b/src-tauri/crates/sagascript-core/src/diarization/model.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use tracing::info;
 
-use crate::download::{DownloadIntegrity, download_to_path, verify_file};
+use crate::download::{
+    DownloadIntegrity, ExistingArtifact, download_to_path, prepare_existing_artifact,
+};
 use crate::error::DictationError;
 
 /// ONNX models used for speaker diarization.
@@ -119,8 +121,7 @@ pub async fn download_model(
 ) -> Result<PathBuf, DictationError> {
     let path = model_path(model);
 
-    if path.exists() {
-        verify_file(&path, model.download_integrity())?;
+    if prepare_existing_artifact(&path, model.download_integrity())? == ExistingArtifact::Verified {
         info!(
             "Diarization model {} already exists at {}",
             model.display_name(),

--- a/src-tauri/crates/sagascript-core/src/download.rs
+++ b/src-tauri/crates/sagascript-core/src/download.rs
@@ -68,6 +68,19 @@ pub struct DownloadIntegrity {
     pub size: u64,
 }
 
+/// Result of preparing an app-managed artifact for a download attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistingArtifact {
+    Missing,
+    Verified,
+    RemovedInvalid,
+}
+
+enum VerificationFailure {
+    IntegrityMismatch(String),
+    Other(DictationError),
+}
+
 /// Stream `url` to `dest`, via a uniquely-named temp file in the same
 /// directory so the final rename is atomic and same-filesystem.
 ///
@@ -263,31 +276,86 @@ pub fn validate_download(
 /// parsers. This also covers models downloaded by older Sagascript versions,
 /// which predate the immutable integrity manifest.
 pub fn verify_file(path: &Path, integrity: DownloadIntegrity) -> Result<(), DictationError> {
+    verify_file_detailed(path, integrity).map_err(|failure| match failure {
+        VerificationFailure::IntegrityMismatch(message) => {
+            DictationError::ModelDownloadFailed(message)
+        }
+        VerificationFailure::Other(error) => error,
+    })
+}
+
+/// Verify an app-managed artifact and remove it only when its bytes are proven
+/// not to match the immutable manifest. I/O failures and invalid manifest data
+/// are returned without touching the file.
+pub fn prepare_existing_artifact(
+    path: &Path,
+    integrity: DownloadIntegrity,
+) -> Result<ExistingArtifact, DictationError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ExistingArtifact::Missing);
+        }
+        Err(error) => {
+            return Err(DictationError::ModelDownloadFailed(format!(
+                "Failed to inspect model before integrity verification ({}): {error}",
+                path.display()
+            )));
+        }
+    }
+
+    match verify_file_detailed(path, integrity) {
+        Ok(()) => Ok(ExistingArtifact::Verified),
+        Err(VerificationFailure::Other(error)) => Err(error),
+        Err(VerificationFailure::IntegrityMismatch(message)) => {
+            std::fs::remove_file(path).map_err(|error| {
+                DictationError::ModelDownloadFailed(format!(
+                    "{message} The invalid artifact could not be removed ({}): {error}",
+                    path.display()
+                ))
+            })?;
+            tracing::warn!(
+                "Removed invalid app-managed artifact {}; downloading a verified replacement",
+                path.display()
+            );
+            Ok(ExistingArtifact::RemovedInvalid)
+        }
+    }
+}
+
+fn verify_file_detailed(
+    path: &Path,
+    integrity: DownloadIntegrity,
+) -> Result<(), VerificationFailure> {
+    // Validate trusted program metadata before inspecting or mutating a user
+    // file. A packaging bug must never turn into an artifact deletion.
+    if !is_sha256(integrity.sha256) {
+        return Err(VerificationFailure::Other(
+            DictationError::ModelDownloadFailed(
+                "Internal model manifest contains an invalid SHA-256 digest".to_string(),
+            ),
+        ));
+    }
+
     let file = std::fs::File::open(path).map_err(|e| {
-        DictationError::ModelDownloadFailed(format!(
+        VerificationFailure::Other(DictationError::ModelDownloadFailed(format!(
             "Failed to open model for integrity verification ({}): {e}",
             path.display()
-        ))
+        )))
     })?;
     let metadata = file.metadata().map_err(|e| {
-        DictationError::ModelDownloadFailed(format!(
+        VerificationFailure::Other(DictationError::ModelDownloadFailed(format!(
             "Failed to inspect model before integrity verification ({}): {e}",
             path.display()
-        ))
+        )))
     })?;
     if metadata.len() != integrity.size {
-        return Err(DictationError::ModelDownloadFailed(format!(
+        return Err(VerificationFailure::IntegrityMismatch(format!(
             "Model integrity check failed for {}: expected {} bytes, got {}. Delete and re-download the model.",
             path.display(),
             integrity.size,
             metadata.len()
         )));
-    }
-
-    if !is_sha256(integrity.sha256) {
-        return Err(DictationError::ModelDownloadFailed(
-            "Internal model manifest contains an invalid SHA-256 digest".to_string(),
-        ));
     }
 
     if verification_cache_matches(path, &metadata, integrity) {
@@ -299,10 +367,10 @@ pub fn verify_file(path: &Path, integrity: DownloadIntegrity) -> Result<(), Dict
     let mut buffer = [0_u8; 1024 * 1024];
     loop {
         let read = reader.read(&mut buffer).map_err(|e| {
-            DictationError::ModelDownloadFailed(format!(
+            VerificationFailure::Other(DictationError::ModelDownloadFailed(format!(
                 "Failed while hashing model {}: {e}",
                 path.display()
-            ))
+            )))
         })?;
         if read == 0 {
             break;
@@ -311,7 +379,7 @@ pub fn verify_file(path: &Path, integrity: DownloadIntegrity) -> Result<(), Dict
     }
     let actual = format!("{:x}", hasher.finalize());
     if !actual.eq_ignore_ascii_case(integrity.sha256) {
-        return Err(DictationError::ModelDownloadFailed(format!(
+        return Err(VerificationFailure::IntegrityMismatch(format!(
             "Model integrity check failed for {}: SHA-256 mismatch. Delete and re-download the model.",
             path.display()
         )));
@@ -588,6 +656,179 @@ mod tests {
         assert!(verify_file(&path, expected).is_ok());
         std::fs::write(&path, b"tampered model").unwrap();
         assert!(verify_file(&path, expected).is_err());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn prepare_existing_artifact_keeps_verified_file() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"verified model").unwrap();
+        let expected = DownloadIntegrity {
+            sha256: "6c736b3dfa943bf4e7c61df78d1dfcad9a3d8b56369f0559670497b19127e74d",
+            size: 14,
+        };
+
+        assert_eq!(
+            prepare_existing_artifact(&path, expected).unwrap(),
+            ExistingArtifact::Verified
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"verified model");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn prepare_existing_artifact_removes_same_size_hash_mismatch() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"tampered model").unwrap();
+        let expected = DownloadIntegrity {
+            sha256: "6c736b3dfa943bf4e7c61df78d1dfcad9a3d8b56369f0559670497b19127e74d",
+            size: 14,
+        };
+
+        assert_eq!(
+            prepare_existing_artifact(&path, expected).unwrap(),
+            ExistingArtifact::RemovedInvalid
+        );
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn prepare_existing_artifact_preserves_file_for_invalid_manifest() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"untrusted bytes").unwrap();
+        let invalid_manifest = DownloadIntegrity {
+            sha256: "not-a-sha256",
+            size: 1,
+        };
+
+        assert!(prepare_existing_artifact(&path, invalid_manifest).is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"untrusted bytes");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn prepare_existing_artifact_preserves_path_on_io_error() {
+        let dir = temp_test_dir();
+        let path = dir.join("model.bin");
+        std::fs::create_dir_all(&path).unwrap();
+        let expected = DownloadIntegrity {
+            sha256: TEST_SHA,
+            size: std::fs::metadata(&path).unwrap().len(),
+        };
+
+        assert!(prepare_existing_artifact(&path, expected).is_err());
+        assert!(path.is_dir(), "generic I/O failure must not delete the path");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_existing_artifact_preserves_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        symlink(dir.join("missing-target"), &path).unwrap();
+
+        assert!(prepare_existing_artifact(&path, integrity(1)).is_err());
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "an open failure must not remove or replace the existing path"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    fn serve_once(body: &'static [u8]) -> String {
+        use std::io::{Read as _, Write as _};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .unwrap();
+            stream.write_all(body).unwrap();
+        });
+        format!("http://{address}/model.bin")
+    }
+
+    #[tokio::test]
+    async fn invalid_existing_artifact_is_replaced_by_verified_download() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"tampered model").unwrap();
+        let expected = DownloadIntegrity {
+            sha256: "6c736b3dfa943bf4e7c61df78d1dfcad9a3d8b56369f0559670497b19127e74d",
+            size: 14,
+        };
+
+        assert_eq!(
+            prepare_existing_artifact(&path, expected).unwrap(),
+            ExistingArtifact::RemovedInvalid
+        );
+        download_to_path(
+            &serve_once(b"verified model"),
+            &path,
+            "bin",
+            expected,
+            None,
+            |_, _| {},
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"verified model");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn failed_replacement_never_installs_partial_artifact() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"tampered model").unwrap();
+        let expected = DownloadIntegrity {
+            sha256: "6c736b3dfa943bf4e7c61df78d1dfcad9a3d8b56369f0559670497b19127e74d",
+            size: 14,
+        };
+
+        prepare_existing_artifact(&path, expected).unwrap();
+        assert!(
+            download_to_path(
+                &serve_once(b"partial"),
+                &path,
+                "bin",
+                expected,
+                None,
+                |_, _| {},
+            )
+            .await
+            .is_err()
+        );
+        assert!(!path.exists());
+        assert!(
+            std::fs::read_dir(&dir).unwrap().next().is_none(),
+            "failed replacement must clean its unique temp file"
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src-tauri/crates/sagascript-core/src/transcription/model.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/model.rs
@@ -1,8 +1,13 @@
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::time::{Duration, SystemTime};
 
 use tracing::info;
 
-use crate::download::{DownloadIntegrity, GGML_MAGIC, download_to_path, verify_file};
+use crate::download::{
+    DownloadIntegrity, ExistingArtifact, GGML_MAGIC, download_to_path,
+    prepare_existing_artifact, verify_file,
+};
 use crate::error::DictationError;
 use crate::settings::WhisperModel;
 
@@ -68,6 +73,8 @@ const VAD_MODEL_INTEGRITY: DownloadIntegrity = DownloadIntegrity {
 };
 #[cfg(target_os = "macos")]
 const COREML_INTEGRITY_MARKER: &str = ".sagascript-archive-sha256";
+#[cfg(target_os = "macos")]
+const COREML_ORPHAN_MAX_AGE: Duration = Duration::from_secs(60 * 60);
 
 /// Full path to the Silero VAD model in the models directory.
 pub fn vad_model_path() -> PathBuf {
@@ -85,8 +92,7 @@ pub async fn download_vad_model(
     progress_callback: impl Fn(u64, u64) + Send + 'static,
 ) -> Result<PathBuf, DictationError> {
     let path = vad_model_path();
-    if path.exists() {
-        verify_vad_model(&path)?;
+    if prepare_existing_artifact(&path, VAD_MODEL_INTEGRITY)? == ExistingArtifact::Verified {
         return Ok(path);
     }
 
@@ -136,8 +142,7 @@ pub async fn download_model(
     let dir = models_dir();
     let path = dir.join(model.ggml_filename());
 
-    if path.exists() {
-        verify_file(&path, model.download_integrity())?;
+    if prepare_existing_artifact(&path, model.download_integrity())? == ExistingArtifact::Verified {
         info!("Model {} already exists at {}", model.display_name(), path.display());
         // Backfill the CoreML encoder for models downloaded before it was added.
         #[cfg(target_os = "macos")]
@@ -195,6 +200,8 @@ async fn ensure_coreml_encoder(
     else {
         return Ok(()); // this model has no CoreML encoder
     };
+
+    sweep_orphaned_coreml_extract_dirs(dir, &dirname);
 
     let dest = dir.join(&dirname);
     if dest.exists() {
@@ -265,6 +272,50 @@ async fn ensure_coreml_encoder(
     install?;
     info!("CoreML encoder installed: {}", dest.display());
     Ok(())
+}
+
+/// Remove only stale extraction directories created by this encoder's exact
+/// UUID staging-name scheme. Fresh directories may belong to a concurrent
+/// backfill and malformed/foreign paths are never touched.
+#[cfg(target_os = "macos")]
+fn sweep_orphaned_coreml_extract_dirs(dir: &Path, dirname: &str) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let prefix = format!(".{dirname}.");
+    let suffix = ".extract";
+    let now = SystemTime::now();
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let Some(unique) = name
+            .strip_prefix(&prefix)
+            .and_then(|rest| rest.strip_suffix(suffix))
+        else {
+            continue;
+        };
+        if uuid::Uuid::parse_str(unique).is_err() {
+            continue;
+        }
+        let Ok(modified) = entry.metadata().and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(modified) else {
+            continue;
+        };
+        if age > COREML_ORPHAN_MAX_AGE {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 /// Keep unverified CoreML bundles away from whisper.cpp's native CoreML
@@ -396,6 +447,50 @@ mod migrate_legacy_models_dir_tests {
         quarantine_unverified_coreml_encoder_at(&verified, integrity).unwrap();
         assert!(verified.exists());
 
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn coreml_sweep_removes_only_stale_owned_extract_directories() {
+        let base = temp_base();
+        std::fs::create_dir_all(&base).unwrap();
+        let dirname = "ggml-base-encoder.mlmodelc";
+        let stale = base.join(format!(
+            ".{dirname}.{}.extract",
+            uuid::Uuid::new_v4()
+        ));
+        let fresh = base.join(format!(
+            ".{dirname}.{}.extract",
+            uuid::Uuid::new_v4()
+        ));
+        let malformed = base.join(format!(".{dirname}.not-a-uuid.extract"));
+        let other_model = base.join(format!(
+            ".ggml-small-encoder.mlmodelc.{}.extract",
+            uuid::Uuid::new_v4()
+        ));
+        let matching_file = base.join(format!(
+            ".{dirname}.{}.extract",
+            uuid::Uuid::new_v4()
+        ));
+        for path in [&stale, &fresh, &malformed, &other_model] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        std::fs::write(&matching_file, b"not a staging directory").unwrap();
+
+        let ancient = SystemTime::now() - (COREML_ORPHAN_MAX_AGE + Duration::from_secs(60));
+        let stale_dir = std::fs::File::open(&stale).unwrap();
+        stale_dir
+            .set_times(std::fs::FileTimes::new().set_modified(ancient))
+            .unwrap();
+
+        sweep_orphaned_coreml_extract_dirs(&base, dirname);
+
+        assert!(!stale.exists());
+        assert!(fresh.exists());
+        assert!(malformed.exists());
+        assert!(other_model.exists());
+        assert!(matching_file.exists());
         let _ = std::fs::remove_dir_all(base);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -651,9 +651,10 @@ pub async fn transcribe_file(
     }
 
     // Ensure model is loaded
-    whisper
-        .ensure_model(effective_model)
-        .map_err(|e| e.to_string())?;
+    if let Err(error) = whisper.ensure_model(effective_model) {
+        let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+        return Err(error.to_string());
+    }
 
     let _ = app.emit(crate::events::event::STATE_CHANGED, "transcribing");
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -593,8 +593,8 @@ pub async fn set_vad_enabled(
     }
     // Fetch the Silero VAD model so it's ready for the next dictation. Done
     // after releasing the lock (no lock held across await).
-    if enabled && !model::is_vad_model_downloaded() {
-        info!("Downloading VAD model...");
+    if enabled {
+        info!("Verifying or downloading VAD model...");
         model::download_vad_model(|_, _| {})
             .await
             .map_err(|e| format!("Failed to download VAD model: {e}"))?;
@@ -665,15 +665,18 @@ pub async fn transcribe_file(
             DiarizeConfig, TimestampedSegment,
             diarize as run_diarize,
             merge::{consolidate, merge_with_transcript},
-            model::all_models_downloaded,
+            model::{DiarizationModel, download_model as download_diarization_model},
         };
 
-        if !all_models_downloaded() {
-            let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
-            return Err(
-                "Diarization models not downloaded. Use Settings → Models to download them."
-                    .to_string(),
-            );
+        // Checking diarization in the file-transcription UI is an explicit
+        // action: verify existing app-managed artifacts and repair only exact
+        // integrity mismatches before native ONNX parsing. This never runs as
+        // a silent startup download.
+        for diarization_model in DiarizationModel::ALL {
+            if let Err(error) = download_diarization_model(*diarization_model, |_, _| {}).await {
+                let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+                return Err(error.to_string());
+            }
         }
 
         let whisper_ref = whisper.inner().clone();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -310,16 +310,23 @@ fn main() {
                     }
                 });
 
-                // If VAD is enabled (e.g. set via the CLI), make sure the Silero
-                // model is present for the next dictation.
-                if vad_enabled && !sagascript_core::transcription::model::is_vad_model_downloaded() {
-                    tauri::async_runtime::spawn(async {
+                // Startup is verification-only: model repair/download remains
+                // tied to an explicit GUI enable action or CLI transcription.
+                if vad_enabled {
+                    let vad_path = sagascript_core::transcription::model::vad_model_path();
+                    if vad_path.exists() {
                         if let Err(e) =
-                            sagascript_core::transcription::model::download_vad_model(|_, _| {}).await
+                            sagascript_core::transcription::model::verify_vad_model(&vad_path)
                         {
-                            warn!("VAD model preload failed: {e}");
+                            warn!(
+                                "VAD model startup verification failed; re-enable VAD or use the CLI to repair it: {e}"
+                            );
                         }
-                    });
+                    } else {
+                        warn!(
+                            "VAD is enabled but its model is missing; re-enable VAD or use the CLI to download it"
+                        );
+                    }
                 }
 
                 // Model and accelerator assets are downloaded only from an

--- a/src-tauri/src/paste/macos_clipboard.rs
+++ b/src-tauri/src/paste/macos_clipboard.rs
@@ -72,38 +72,76 @@ pub(super) fn change_count() -> isize {
     }
 }
 
+#[derive(Debug)]
+pub(super) struct TemporaryTextWriteError {
+    pub(super) message: String,
+    pub(super) owned_generation: isize,
+}
+
 /// Replace the pasteboard with temporary UTF-8 text and return the generation
 /// created by our own `clearContents` call. Capturing ownership at the clear,
 /// rather than sampling `changeCount` after the write, ensures a foreign copy
 /// racing immediately afterward can never be mistaken for ours.
-pub(super) fn set_temporary_text(text: &str) -> Result<isize, String> {
+pub(super) fn set_temporary_text(text: &str) -> Result<isize, TemporaryTextWriteError> {
     unsafe {
         let pool: id = msg_send![class!(NSAutoreleasePool), new];
         let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
         if pasteboard == nil {
             let _: () = msg_send![pool, drain];
-            return Err("general pasteboard is unavailable".to_string());
+            return Err(TemporaryTextWriteError {
+                message: "general pasteboard is unavailable".to_string(),
+                owned_generation: -1,
+            });
         }
 
-        let owned_generation: isize = msg_send![pasteboard, clearContents];
-        let value = NSString::alloc(nil).init_str(text);
-        let pasteboard_type = NSString::alloc(nil).init_str("public.utf8-plain-text");
-        let written: bool = msg_send![pasteboard, setString: value forType: pasteboard_type];
-        let current_generation: isize = msg_send![pasteboard, changeCount];
-        let _: () = msg_send![value, release];
-        let _: () = msg_send![pasteboard_type, release];
+        let result = set_temporary_text_on_pasteboard(pasteboard, text);
         let _: () = msg_send![pool, drain];
+        result
+    }
+}
 
-        if written && generation_still_owned(owned_generation, current_generation) {
-            Ok(owned_generation)
-        } else if written {
-            // The text write succeeded, but another owner raced our clear (or
-            // AppKit reported a different generation). Paste it, but disable
-            // restoration rather than risk clobbering foreign content.
-            Ok(-1)
-        } else {
-            Err("NSPasteboard failed to store temporary text".to_string())
-        }
+/// Documented AppKit write path: populate an unattached NSPasteboardItem, then
+/// publish it with `writeObjects:` after taking ownership via `clearContents`.
+unsafe fn set_temporary_text_on_pasteboard(
+    pasteboard: id,
+    text: &str,
+) -> Result<isize, TemporaryTextWriteError> {
+    let owned_generation: isize = msg_send![pasteboard, clearContents];
+    let item: id = msg_send![class!(NSPasteboardItem), new];
+    let value = NSString::alloc(nil).init_str(text);
+    let pasteboard_type = NSString::alloc(nil).init_str("public.utf8-plain-text");
+    let item_ready: bool = msg_send![item, setString: value forType: pasteboard_type];
+
+    let items: id = msg_send![class!(NSMutableArray), arrayWithCapacity: 1usize];
+    let _: () = msg_send![items, addObject: item];
+    let still_owned_before_write = generation_still_owned(
+        owned_generation,
+        msg_send![pasteboard, changeCount],
+    );
+    let written = item_ready
+        && still_owned_before_write
+        && msg_send![pasteboard, writeObjects: items];
+    let current_generation: isize = msg_send![pasteboard, changeCount];
+
+    let _: () = msg_send![value, release];
+    let _: () = msg_send![pasteboard_type, release];
+    let _: () = msg_send![item, release];
+
+    if written && generation_still_owned(owned_generation, current_generation) {
+        Ok(owned_generation)
+    } else {
+        Err(TemporaryTextWriteError {
+            message: if !item_ready {
+                "NSPasteboardItem failed to store temporary text".to_string()
+            } else if !still_owned_before_write
+                || !generation_still_owned(owned_generation, current_generation)
+            {
+                "pasteboard ownership changed during temporary text write".to_string()
+            } else {
+                "NSPasteboard writeObjects failed to publish temporary text".to_string()
+            },
+            owned_generation,
+        })
     }
 }
 
@@ -154,7 +192,10 @@ pub(super) fn restore_if_unchanged(snapshot: Snapshot, expected_change_count: is
 
 #[cfg(test)]
 mod tests {
-    use super::{generation_still_owned, should_restore};
+    use super::{generation_still_owned, set_temporary_text_on_pasteboard, should_restore};
+    use cocoa::base::{id, nil};
+    use cocoa::foundation::NSString;
+    use objc::{class, msg_send, sel, sel_impl};
 
     #[test]
     fn restores_only_when_app_still_owns_pasteboard() {
@@ -178,5 +219,31 @@ mod tests {
         assert!(generation_still_owned(100, 100));
         assert!(!generation_still_owned(100, 101));
         assert!(!generation_still_owned(-1, -1));
+    }
+
+    #[test]
+    fn named_pasteboard_utf8_roundtrip_preserves_clear_generation() {
+        unsafe {
+            let pool: id = msg_send![class!(NSAutoreleasePool), new];
+            let pasteboard: id = msg_send![class!(NSPasteboard), pasteboardWithUniqueName];
+            assert_ne!(pasteboard, nil);
+
+            let expected = "Sagascript – räksmörgås 🎙️";
+            let owned_generation =
+                set_temporary_text_on_pasteboard(pasteboard, expected).unwrap();
+            let current_generation: isize = msg_send![pasteboard, changeCount];
+            assert_eq!(owned_generation, current_generation);
+
+            let pasteboard_type = NSString::alloc(nil).init_str("public.utf8-plain-text");
+            let value: id = msg_send![pasteboard, stringForType: pasteboard_type];
+            assert_ne!(value, nil);
+            let utf8: *const std::os::raw::c_char = msg_send![value, UTF8String];
+            assert!(!utf8.is_null());
+            assert_eq!(std::ffi::CStr::from_ptr(utf8).to_string_lossy(), expected);
+
+            let _: () = msg_send![pasteboard_type, release];
+            let _: () = msg_send![pasteboard, releaseGlobally];
+            let _: () = msg_send![pool, drain];
+        }
     }
 }

--- a/src-tauri/src/paste/macos_clipboard.rs
+++ b/src-tauri/src/paste/macos_clipboard.rs
@@ -72,8 +72,47 @@ pub(super) fn change_count() -> isize {
     }
 }
 
+/// Replace the pasteboard with temporary UTF-8 text and return the generation
+/// created by our own `clearContents` call. Capturing ownership at the clear,
+/// rather than sampling `changeCount` after the write, ensures a foreign copy
+/// racing immediately afterward can never be mistaken for ours.
+pub(super) fn set_temporary_text(text: &str) -> Result<isize, String> {
+    unsafe {
+        let pool: id = msg_send![class!(NSAutoreleasePool), new];
+        let pasteboard: id = msg_send![class!(NSPasteboard), generalPasteboard];
+        if pasteboard == nil {
+            let _: () = msg_send![pool, drain];
+            return Err("general pasteboard is unavailable".to_string());
+        }
+
+        let owned_generation: isize = msg_send![pasteboard, clearContents];
+        let value = NSString::alloc(nil).init_str(text);
+        let pasteboard_type = NSString::alloc(nil).init_str("public.utf8-plain-text");
+        let written: bool = msg_send![pasteboard, setString: value forType: pasteboard_type];
+        let current_generation: isize = msg_send![pasteboard, changeCount];
+        let _: () = msg_send![value, release];
+        let _: () = msg_send![pasteboard_type, release];
+        let _: () = msg_send![pool, drain];
+
+        if written && generation_still_owned(owned_generation, current_generation) {
+            Ok(owned_generation)
+        } else if written {
+            // The text write succeeded, but another owner raced our clear (or
+            // AppKit reported a different generation). Paste it, but disable
+            // restoration rather than risk clobbering foreign content.
+            Ok(-1)
+        } else {
+            Err("NSPasteboard failed to store temporary text".to_string())
+        }
+    }
+}
+
+fn generation_still_owned(owned: isize, current: isize) -> bool {
+    owned >= 0 && owned == current
+}
+
 fn should_restore(expected: isize, current: isize) -> bool {
-    expected >= 0 && expected == current
+    generation_still_owned(expected, current)
 }
 
 /// Restore only while Sagascript's temporary text is still the newest write.
@@ -115,12 +154,29 @@ pub(super) fn restore_if_unchanged(snapshot: Snapshot, expected_change_count: is
 
 #[cfg(test)]
 mod tests {
-    use super::should_restore;
+    use super::{generation_still_owned, should_restore};
 
     #[test]
     fn restores_only_when_app_still_owns_pasteboard() {
         assert!(should_restore(42, 42));
         assert!(!should_restore(42, 43));
         assert!(!should_restore(-1, -1));
+    }
+
+    #[test]
+    fn foreign_copy_after_our_clear_invalidates_ownership() {
+        let generation_returned_by_our_clear = 100;
+        let generation_after_foreign_copy = 101;
+        assert!(!should_restore(
+            generation_returned_by_our_clear,
+            generation_after_foreign_copy
+        ));
+    }
+
+    #[test]
+    fn write_never_adopts_a_later_generation() {
+        assert!(generation_still_owned(100, 100));
+        assert!(!generation_still_owned(100, 101));
+        assert!(!generation_still_owned(-1, -1));
     }
 }

--- a/src-tauri/src/paste/service.rs
+++ b/src-tauri/src/paste/service.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "macos"))]
 use arboard::Clipboard;
 #[cfg(target_os = "macos")]
 #[path = "macos_clipboard.rs"]
@@ -29,8 +30,9 @@ impl PasteService {
             return Ok(());
         }
 
-        let mut clipboard =
-            Clipboard::new().map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
+        #[cfg(not(target_os = "macos"))]
+        let mut clipboard = Clipboard::new()
+            .map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
 
         // On macOS, preserve every pasteboard item and declared representation
         // (RTF, images, file URLs, custom app formats, etc.), not just plain text.
@@ -41,13 +43,17 @@ impl PasteService {
         #[cfg(not(target_os = "macos"))]
         let saved_text = clipboard.get_text().ok();
 
-        // Set new text
+        // Set new text. On macOS the native write returns the pasteboard
+        // generation created by our clear, closing the race that a later
+        // changeCount sample could accidentally attribute to another app.
+        #[cfg(target_os = "macos")]
+        let owned_change_count = macos_clipboard::set_temporary_text(text)
+            .map_err(|e| DictationError::PasteError(format!("Failed to set clipboard: {e}")))?;
+
+        #[cfg(not(target_os = "macos"))]
         clipboard
             .set_text(text)
             .map_err(|e| DictationError::PasteError(format!("Failed to set clipboard: {e}")))?;
-
-        #[cfg(target_os = "macos")]
-        let owned_change_count = macos_clipboard::change_count();
 
         info!("Text copied to clipboard ({} chars)", text.len());
 

--- a/src-tauri/src/paste/service.rs
+++ b/src-tauri/src/paste/service.rs
@@ -47,8 +47,23 @@ impl PasteService {
         // generation created by our clear, closing the race that a later
         // changeCount sample could accidentally attribute to another app.
         #[cfg(target_os = "macos")]
-        let owned_change_count = macos_clipboard::set_temporary_text(text)
-            .map_err(|e| DictationError::PasteError(format!("Failed to set clipboard: {e}")))?;
+        let owned_change_count = match macos_clipboard::set_temporary_text(text) {
+            Ok(generation) => generation,
+            Err(error) => {
+                if let Some(snapshot) = saved_pasteboard {
+                    // A failed write may already have cleared the pasteboard.
+                    // Restore only if no other app has taken ownership since.
+                    let _ = macos_clipboard::restore_if_unchanged(
+                        snapshot,
+                        error.owned_generation,
+                    );
+                }
+                return Err(DictationError::PasteError(format!(
+                    "Failed to set clipboard: {}",
+                    error.message
+                )));
+            }
+        };
 
         #[cfg(not(target_os = "macos"))]
         clipboard

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -299,13 +299,13 @@
     selecting = true;
     modelError = "";
     try {
-      if (!model.downloaded) {
-        downloading = model.id;
-        downloadingName = model.display_name;
-        downloadProgress = 0;
-        await downloadModel(model.id);
-        // model_ready event will refresh the list
-      }
+      // The backend verifies Ready models and replaces only artifacts whose
+      // bytes provably fail the immutable integrity manifest.
+      downloading = model.id;
+      downloadingName = model.display_name;
+      downloadProgress = 0;
+      await downloadModel(model.id);
+      // model_ready event will refresh the list
       await setWhisperModel(model.id);
       settings = await getSettings();
       models = await getModelInfo();


### PR DESCRIPTION
## Summary

- verify and self-repair app-managed Whisper, VAD, and diarization artifacts when exact integrity checks fail
- preserve artifacts on ambiguous I/O, manifest, or removal failures
- remove CLI/GUI size-only bypasses while keeping downloads explicit rather than startup-silent
- capture macOS pasteboard ownership from Sagascript's own clear generation and refuse restoration after any later copy
- reclaim only stale CoreML staging directories matching the exact app-owned UUID naming scheme

## Validation

- focused loopback/security tests passed (18/18 plus final preparation suite 5/5)
- workspace tests passed: 73 app, 81 CLI, 231 core
- strict workspace/all-targets/all-features Clippy passed
- Svelte check: zero errors/warnings
- frontend production build and app cargo check passed
- isolated named-pasteboard AppKit smoke verified generation behavior without touching the user's clipboard
- diff check passed

Addresses launch-wide Fable review findings on corrupt-model recovery, clipboard ownership, and CoreML staging cleanup.