### PR TITLE
fix(onboarding): finalize fast model downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Test frontend lifecycle helpers
+        run: npm run test:frontend
+
       - name: Build frontend
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "node scripts/build-frontend.mjs",
+    "test:frontend": "node --test scripts/test-onboarding-download-state.mjs",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "release:check": "node scripts/check-release.mjs",

--- a/scripts/test-onboarding-download-state.mjs
+++ b/scripts/test-onboarding-download-state.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  awaitDownloadCompletion,
+  completedDownloadState,
+} from "../src/lib/onboarding-download-state.js";
+
+const expected = {
+  downloading: false,
+  downloadComplete: true,
+  downloadProgress: 100,
+};
+
+test("fast download completion is authoritative without an event", async () => {
+  assert.deepEqual(await awaitDownloadCompletion(Promise.resolve()), expected);
+});
+
+test("completion state is published only after the command resolves", async () => {
+  let resolveDownload;
+  const download = new Promise((resolve) => {
+    resolveDownload = resolve;
+  });
+  let completed = false;
+  const pending = awaitDownloadCompletion(download).then((state) => {
+    completed = true;
+    return state;
+  });
+
+  await Promise.resolve();
+  assert.equal(completed, false);
+  resolveDownload();
+  assert.deepEqual(await pending, expected);
+});
+
+test("failed downloads do not publish successful state", async () => {
+  await assert.rejects(
+    awaitDownloadCompletion(Promise.reject(new Error("download failed"))),
+    /download failed/,
+  );
+});
+
+test("event and command completion are idempotent", () => {
+  assert.deepEqual(completedDownloadState(), completedDownloadState());
+  assert.notEqual(completedDownloadState(), completedDownloadState());
+});

--- a/scripts/test-onboarding-download-state.mjs
+++ b/scripts/test-onboarding-download-state.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   awaitDownloadCompletion,
   completedDownloadState,
+  registerDownloadListeners,
 } from "../src/lib/onboarding-download-state.js";
 
 const expected = {
@@ -13,7 +14,14 @@ const expected = {
 };
 
 test("fast download completion is authoritative without an event", async () => {
-  assert.deepEqual(await awaitDownloadCompletion(Promise.resolve()), expected);
+  let state;
+  assert.deepEqual(
+    await awaitDownloadCompletion(Promise.resolve(), (completed) => {
+      state = completed;
+    }),
+    expected,
+  );
+  assert.deepEqual(state, expected);
 });
 
 test("completion state is published only after the command resolves", async () => {
@@ -22,9 +30,8 @@ test("completion state is published only after the command resolves", async () =
     resolveDownload = resolve;
   });
   let completed = false;
-  const pending = awaitDownloadCompletion(download).then((state) => {
+  const pending = awaitDownloadCompletion(download, () => {
     completed = true;
-    return state;
   });
 
   await Promise.resolve();
@@ -35,12 +42,82 @@ test("completion state is published only after the command resolves", async () =
 
 test("failed downloads do not publish successful state", async () => {
   await assert.rejects(
-    awaitDownloadCompletion(Promise.reject(new Error("download failed"))),
+    awaitDownloadCompletion(Promise.reject(new Error("download failed")), () => {
+      throw new Error("completion callback must not run");
+    }),
     /download failed/,
   );
 });
 
-test("event and command completion are idempotent", () => {
-  assert.deepEqual(completedDownloadState(), completedDownloadState());
-  assert.notEqual(completedDownloadState(), completedDownloadState());
+test("event and command completion share an idempotent state transition", async () => {
+  let state = { downloading: true, downloadComplete: false, downloadProgress: 20 };
+  const markComplete = () => {
+    state = completedDownloadState();
+  };
+  // Simulate model-ready arriving before the command promise resolves.
+  markComplete();
+  await awaitDownloadCompletion(Promise.resolve(), markComplete);
+  assert.deepEqual(state, expected);
+});
+
+test("listener registration starts before initialization and returns both owners", async () => {
+  const calls = [];
+  const listeners = registerDownloadListeners(
+    async () => {
+      calls.push("progress");
+      return () => calls.push("unlisten-progress");
+    },
+    async () => {
+      calls.push("ready");
+      return () => calls.push("unlisten-ready");
+    },
+    () => false,
+  );
+  calls.push("initialize-after-registration-started");
+
+  assert.deepEqual(calls, ["progress", "ready", "initialize-after-registration-started"]);
+  const owned = await listeners;
+  assert.equal(owned.length, 2);
+  owned.forEach((unlisten) => unlisten());
+});
+
+test("partial registration failure cleans up the successful listener", async () => {
+  let cleaned = false;
+  await assert.rejects(
+    registerDownloadListeners(
+      async () => () => {
+        cleaned = true;
+      },
+      async () => {
+        throw new Error("ready registration failed");
+      },
+      () => false,
+    ),
+    /ready registration failed/,
+  );
+  assert.equal(cleaned, true);
+});
+
+test("destroyed component immediately releases late registrations", async () => {
+  let cancelled = false;
+  let cleaned = 0;
+  let resolveProgress;
+  let resolveReady;
+  const progressRegistered = new Promise((resolve) => {
+    resolveProgress = resolve;
+  });
+  const readyRegistered = new Promise((resolve) => {
+    resolveReady = resolve;
+  });
+  const pending = registerDownloadListeners(
+    () => progressRegistered,
+    () => readyRegistered,
+    () => cancelled,
+  );
+  cancelled = true;
+  resolveProgress(() => cleaned++);
+  resolveReady(() => cleaned++);
+
+  assert.equal(await pending, null);
+  assert.equal(cleaned, 2);
 });

--- a/scripts/test-onboarding-download-state.mjs
+++ b/scripts/test-onboarding-download-state.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  adoptDownloadListeners,
   awaitDownloadCompletion,
   completedDownloadState,
   registerDownloadListeners,
@@ -120,4 +121,34 @@ test("destroyed component immediately releases late registrations", async () => 
 
   assert.equal(await pending, null);
   assert.equal(cleaned, 2);
+});
+
+test("destruction before ownership adoption releases both listeners", () => {
+  let cleaned = 0;
+  let adopted = false;
+  const listeners = [
+    () => cleaned++,
+    () => cleaned++,
+  ];
+
+  assert.equal(
+    adoptDownloadListeners(listeners, () => true, () => {
+      adopted = true;
+    }),
+    false,
+  );
+  assert.equal(cleaned, 2);
+  assert.equal(adopted, false);
+});
+
+test("live component atomically adopts both listener owners", () => {
+  const listeners = [() => {}, () => {}];
+  let adopted;
+  assert.equal(
+    adoptDownloadListeners(listeners, () => false, (progress, ready) => {
+      adopted = [progress, ready];
+    }),
+    true,
+  );
+  assert.deepEqual(adopted, listeners);
 });

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { listen } from "@tauri-apps/api/event";
-  import { awaitDownloadCompletion, completedDownloadState } from "./onboarding-download-state.js";
+  import {
+    awaitDownloadCompletion,
+    completedDownloadState,
+    registerDownloadListeners,
+  } from "./onboarding-download-state.js";
   import {
     getPlatform,
     getSettings,
@@ -116,15 +120,13 @@
     downloadProgress = 0;
 
     try {
-      const completed = await awaitDownloadCompletion(
+      await awaitDownloadCompletion(
         downloadModel(recommendedModelId[selectedLanguage]),
+        markDownloadComplete,
       );
       // The command result is authoritative. `model-ready` remains useful for
       // live progress, but a fast verification may emit it before listeners
       // finish registering.
-      downloading = completed.downloading;
-      downloadComplete = completed.downloadComplete;
-      downloadProgress = completed.downloadProgress;
     } catch (e: any) {
       downloading = false;
       downloadError = typeof e === "string" ? e : e?.message ?? "Download failed. Check your internet connection.";
@@ -302,21 +304,22 @@
     // Start listener registration before any initialization invokes. The
     // component is interactive while awaits are pending, so registering these
     // after permission/settings calls can miss a fast model-ready event.
-    const listenerRegistrations = Promise.all([
-      listen("model-download-progress", (event: any) => {
-        downloadProgress = event.payload.progress;
-      }),
-      listen("model-ready", markDownloadComplete),
-    ]);
-
-    const [registeredProgress, registeredReady] = await listenerRegistrations;
-    if (componentDestroyed) {
-      registeredProgress();
-      registeredReady();
-      return;
+    let registeredListeners: [() => void, () => void] | null = null;
+    try {
+      registeredListeners = await registerDownloadListeners(
+        () => listen("model-download-progress", (event: any) => {
+          downloadProgress = event.payload.progress;
+        }),
+        () => listen("model-ready", markDownloadComplete),
+        () => componentDestroyed,
+      );
+    } catch (error) {
+      console.error("Failed to register onboarding download listeners", error);
     }
-    unlistenProgress = registeredProgress;
-    unlistenReady = registeredReady;
+    if (componentDestroyed) return;
+    if (registeredListeners) {
+      [unlistenProgress, unlistenReady] = registeredListeners;
+    }
 
     platform = await getPlatform();
     try {
@@ -338,7 +341,6 @@
     } catch {
       // keep defaults
     }
-
   });
 
   onDestroy(() => {

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { listen } from "@tauri-apps/api/event";
+  import { awaitDownloadCompletion, completedDownloadState } from "./onboarding-download-state.js";
   import {
     getPlatform,
     getSettings,
@@ -52,6 +53,7 @@
   // Cleanup for event listeners
   let unlistenProgress: (() => void) | null = null;
   let unlistenReady: (() => void) | null = null;
+  let componentDestroyed = false;
 
   // Model info per onboarding language (no "auto" — onboarding always picks a specific language)
   const modelInfo: Record<OnboardingLanguage, { name: string; size: string }> = {
@@ -100,14 +102,29 @@
 
   // -- Model download --
 
+  function markDownloadComplete() {
+    const completed = completedDownloadState();
+    downloading = completed.downloading;
+    downloadComplete = completed.downloadComplete;
+    downloadProgress = completed.downloadProgress;
+  }
+
   async function startDownload() {
     downloading = true;
+    downloadComplete = false;
     downloadError = null;
     downloadProgress = 0;
 
     try {
-      await downloadModel(recommendedModelId[selectedLanguage]);
-      // model-ready event will set downloadComplete
+      const completed = await awaitDownloadCompletion(
+        downloadModel(recommendedModelId[selectedLanguage]),
+      );
+      // The command result is authoritative. `model-ready` remains useful for
+      // live progress, but a fast verification may emit it before listeners
+      // finish registering.
+      downloading = completed.downloading;
+      downloadComplete = completed.downloadComplete;
+      downloadProgress = completed.downloadProgress;
     } catch (e: any) {
       downloading = false;
       downloadError = typeof e === "string" ? e : e?.message ?? "Download failed. Check your internet connection.";
@@ -282,6 +299,25 @@
   }
 
   onMount(async () => {
+    // Start listener registration before any initialization invokes. The
+    // component is interactive while awaits are pending, so registering these
+    // after permission/settings calls can miss a fast model-ready event.
+    const listenerRegistrations = Promise.all([
+      listen("model-download-progress", (event: any) => {
+        downloadProgress = event.payload.progress;
+      }),
+      listen("model-ready", markDownloadComplete),
+    ]);
+
+    const [registeredProgress, registeredReady] = await listenerRegistrations;
+    if (componentDestroyed) {
+      registeredProgress();
+      registeredReady();
+      return;
+    }
+    unlistenProgress = registeredProgress;
+    unlistenReady = registeredReady;
+
     platform = await getPlatform();
     try {
       micStatus = await microphoneStatus();
@@ -303,19 +339,10 @@
       // keep defaults
     }
 
-    // Listen for download progress — use backend-computed progress field
-    unlistenProgress = await listen("model-download-progress", (event: any) => {
-      downloadProgress = event.payload.progress;
-    });
-
-    unlistenReady = await listen("model-ready", () => {
-      downloading = false;
-      downloadComplete = true;
-      downloadProgress = 100;
-    });
   });
 
   onDestroy(() => {
+    componentDestroyed = true;
     stopPoll();
     unlistenProgress?.();
     unlistenReady?.();

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import { listen } from "@tauri-apps/api/event";
   import {
+    adoptDownloadListeners,
     awaitDownloadCompletion,
     completedDownloadState,
     registerDownloadListeners,
@@ -316,10 +317,15 @@
     } catch (error) {
       console.error("Failed to register onboarding download listeners", error);
     }
+    adoptDownloadListeners(
+      registeredListeners,
+      () => componentDestroyed,
+      (progress, ready) => {
+        unlistenProgress = progress;
+        unlistenReady = ready;
+      },
+    );
     if (componentDestroyed) return;
-    if (registeredListeners) {
-      [unlistenProgress, unlistenReady] = registeredListeners;
-    }
 
     platform = await getPlatform();
     try {

--- a/src/lib/onboarding-download-state.js
+++ b/src/lib/onboarding-download-state.js
@@ -55,3 +55,18 @@ export async function registerDownloadListeners(registerProgress, registerReady,
 
   return /** @type {[() => void, () => void]} */ (owned);
 }
+
+/**
+ * @param {[() => void, () => void] | null} listeners
+ * @param {() => boolean} isCancelled
+ * @param {(progress: () => void, ready: () => void) => void} adopt
+ */
+export function adoptDownloadListeners(listeners, isCancelled, adopt) {
+  if (!listeners) return false;
+  if (isCancelled()) {
+    listeners.forEach((unlisten) => unlisten());
+    return false;
+  }
+  adopt(...listeners);
+  return true;
+}

--- a/src/lib/onboarding-download-state.js
+++ b/src/lib/onboarding-download-state.js
@@ -4,12 +4,54 @@ const COMPLETED_DOWNLOAD_STATE = Object.freeze({
   downloadProgress: 100,
 });
 
+/** @typedef {typeof COMPLETED_DOWNLOAD_STATE} DownloadCompletionState */
+
 export function completedDownloadState() {
   return { ...COMPLETED_DOWNLOAD_STATE };
 }
 
-/** @param {Promise<unknown>} downloadRequest */
-export async function awaitDownloadCompletion(downloadRequest) {
+/**
+ * @param {Promise<unknown>} downloadRequest
+ * @param {(state: DownloadCompletionState) => void} onComplete
+ */
+export async function awaitDownloadCompletion(downloadRequest, onComplete) {
   await downloadRequest;
-  return completedDownloadState();
+  const completed = completedDownloadState();
+  onComplete(completed);
+  return completed;
+}
+
+/**
+ * @param {() => Promise<() => void>} registerProgress
+ * @param {() => Promise<() => void>} registerReady
+ * @param {() => boolean} isCancelled
+ * @returns {Promise<[() => void, () => void] | null>}
+ */
+export async function registerDownloadListeners(registerProgress, registerReady, isCancelled) {
+  /** @param {() => Promise<() => void>} register */
+  const ownRegistration = async (register) => {
+    const unlisten = await register();
+    if (isCancelled()) {
+      unlisten();
+      return null;
+    }
+    return unlisten;
+  };
+
+  const results = await Promise.allSettled([
+    ownRegistration(registerProgress),
+    ownRegistration(registerReady),
+  ]);
+  const owned = results.flatMap((result) =>
+    result.status === "fulfilled" && result.value ? [result.value] : [],
+  );
+  const failure = results.find((result) => result.status === "rejected");
+
+  if (isCancelled() || failure || owned.length !== 2) {
+    owned.forEach((unlisten) => unlisten());
+    if (failure) throw failure.reason;
+    return null;
+  }
+
+  return /** @type {[() => void, () => void]} */ (owned);
 }

--- a/src/lib/onboarding-download-state.js
+++ b/src/lib/onboarding-download-state.js
@@ -1,0 +1,15 @@
+const COMPLETED_DOWNLOAD_STATE = Object.freeze({
+  downloading: false,
+  downloadComplete: true,
+  downloadProgress: 100,
+});
+
+export function completedDownloadState() {
+  return { ...COMPLETED_DOWNLOAD_STATE };
+}
+
+/** @param {Promise<unknown>} downloadRequest */
+export async function awaitDownloadCompletion(downloadRequest) {
+  await downloadRequest;
+  return completedDownloadState();
+}


### PR DESCRIPTION
## Summary
- register onboarding model listeners before asynchronous permission/settings initialization
- make successful download commands authoritative so fast model verification cannot leave onboarding stuck
- clean up late listener registrations after component destruction
- add dependency-free frontend lifecycle regression tests and run them in macOS CI

## Validation
- npm run test:frontend (4 passed)
- npm run check (0 errors, 0 warnings)
- npm run build
- git diff --check