### PR TITLE
Prepare Sagascript 1.0.0 release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ Windows installers.
 Production macOS releases must be signed with a **Developer ID Application**
 certificate, use hardened runtime, and be notarized and stapled. The release
 workflow refuses to publish an unsigned or unverifiable macOS artifact.
-The production signing Team ID is **`U7MYD3Z5CB`**; the verifier rejects a
+The production signing Team ID is **`7C6WF6GFZ4`**; the verifier rejects a
 different Team ID even if the certificate is otherwise valid.
 
 ## One-time Apple setup (repository owner)
@@ -23,7 +23,7 @@ different Team ID even if the certificate is otherwise valid.
    - `APPLE_CERTIFICATE`: base64-encoded `.p12`
    - `APPLE_CERTIFICATE_PASSWORD`: export password for the `.p12`
    - `APPLE_SIGNING_IDENTITY`: full
-     `Developer ID Application: … (U7MYD3Z5CB)` name. Release verification is
+     `Developer ID Application: … (7C6WF6GFZ4)` name. Release verification is
      intentionally pinned to this production team so macOS TCC permissions
      survive upgrades.
    - `KEYCHAIN_PASSWORD`: random password for the ephemeral CI keychain

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "0.0.1",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -22,7 +22,7 @@ app=$1
 dmg=$2
 version=$3
 expected_identifier=ai.gille.sagascript
-expected_team_id=U7MYD3Z5CB
+expected_team_id=7C6WF6GFZ4
 
 [[ -d "$app" ]] || { echo "Missing app bundle: $app" >&2; exit 1; }
 [[ -f "$dmg" ]] || { echo "Missing disk image: $dmg" >&2; exit 1; }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "0.0.1"
+version = "1.0.0"
 dependencies = [
  "arboard",
  "block",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "0.0.1"
+version = "1.0.0"
 dependencies = [
  "arboard",
  "clap",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "0.0.1"
+version = "1.0.0"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump all npm, Cargo workspace, lockfile, and Tauri bundle metadata from `0.0.1` to `1.0.0`
- prepare the approved public v1 release without creating a tag or triggering publication

## Why

`v0.0.1` was the unsigned friendly-tester prerelease. The launch hardening is now merged and the repository owner approved `1.0.0` as the public launch version.

## Validation

- `npm run release:check`
- `npm run licenses:check`
- `npm run test:frontend` (9/9)
- `npm run check` (0 errors, 0 warnings)
- `npm run build`
- `cargo test --workspace` (397/397, run outside the sandbox for the named macOS pasteboard test)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Release gate

Keep this PR draft until the seven Apple signing/notarization repository secrets in `RELEASING.md` are configured. Merging this PR does not publish a release. After it merges, pushing exactly `v1.0.0` triggers the signed/notarized draft-release workflow; publish only after clean-machine acceptance.