### PR TITLE
Fix v1 release for Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+          targets: aarch64-apple-darwin
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -130,9 +130,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             src-tauri/target
-          key: macos-universal-release-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: macos-arm64-release-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
-            macos-universal-release-cargo-
+            macos-arm64-release-cargo-
 
       - name: Install npm dependencies
         run: npm ci
@@ -175,7 +175,7 @@ jobs:
           echo "SAGASCRIPT_GIT_HASH=$(printf '%s' "$GITHUB_SHA" | cut -c1-7)" >> "$GITHUB_ENV"
           echo "SAGASCRIPT_BUILD_DATE=$(date -u +%F)" >> "$GITHUB_ENV"
 
-      - name: Build, sign, notarize, and staple universal app
+      - name: Build, sign, notarize, and staple Apple Silicon app
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -183,13 +183,13 @@ jobs:
         run: |
           : "${APPLE_SIGNING_IDENTITY:?APPLE_SIGNING_IDENTITY secret is required}"
           : "${APPLE_API_ISSUER:?APPLE_API_ISSUER secret is required}"
-          npx tauri build --target universal-apple-darwin
+          npx tauri build --target aarch64-apple-darwin
 
       - name: Verify macOS release artifact
         run: |
           version=$(node -p "require('./package.json').version")
-          app="src-tauri/target/universal-apple-darwin/release/bundle/macos/Sagascript.app"
-          dmg=$(find src-tauri/target/universal-apple-darwin/release/bundle/dmg -name '*.dmg' -print -quit)
+          app="src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Sagascript.app"
+          dmg=$(find src-tauri/target/aarch64-apple-darwin/release/bundle/dmg -name '*.dmg' -print -quit)
           [[ -n "$dmg" ]]
           ./scripts/verify-macos-release.sh "$app" "$dmg" "$version"
           mkdir -p artifacts
@@ -199,7 +199,7 @@ jobs:
       - name: Gate upgrade and installed CLI transcription
         run: |
           version=$(node -p "require('./package.json').version")
-          app="src-tauri/target/universal-apple-darwin/release/bundle/macos/Sagascript.app"
+          app="src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Sagascript.app"
 
           # Seed an obsolete executable at the normal installation path, then
           # perform the same replace operation expected when upgrading the app.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for your interest in contributing! This guide will help you get set up an
 
 **macOS:**
 
-- macOS 13.0+ (Apple Silicon recommended)
+- macOS 13.0+ on Apple Silicon for the default diarization-enabled build
 
 **Windows:**
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -3,8 +3,8 @@
 ## macOS
 
 Download **Sagascript.dmg** from the [latest release](https://github.com/Magnus-Gille/sagascript/releases/latest).
-The artifact is a universal binary. Apple Silicon is the tested launch
-platform; the Intel slice remains pending clean-machine hardware acceptance.
+The v1 artifact is an Apple Silicon binary. Intel Macs are not supported by the
+v1 binary release.
 
 Open the DMG, drag Sagascript to Applications, and launch the copy in
 `/Applications`. Official releases are signed with Developer ID and notarized by
@@ -37,5 +37,5 @@ diarization, or VAD model.
 
 ## System requirements
 
-- **macOS:** 13.0 (Ventura) or later; Apple Silicon tested at launch
+- **macOS:** 13.0 (Ventura) or later on Apple Silicon
 - **Windows preview:** 10 or later, built from source

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ speech or diarization model.
 - **CLI + GUI** -- full CLI for scripting and automation, menu bar app for everyday use
 - **File transcription** -- transcribe audio and video files (MP3, WAV, M4A, FLAC, MP4, MKV, OGG, and more)
 - **Configurable** -- choose your model, language, hotkey, and output behavior
-- **macOS v1** -- official releases are signed and notarized for macOS 13+; Apple Silicon is the tested launch platform, while the universal build's Intel slice still requires hardware acceptance
+- **macOS v1** -- official releases are signed and notarized for macOS 13+ on Apple Silicon; Intel Macs are not supported by the v1 binary release
 - **Windows preview** -- the Windows port remains available for build-from-source testing; no official Windows binaries are published yet
 
 ## Building from source
 
 ### Prerequisites
 
-- **macOS**: macOS 13.0+ (Apple Silicon tested; the universal build's Intel slice requires hardware acceptance before support is claimed)
+- **macOS**: macOS 13.0+ on Apple Silicon (Intel Macs are not supported by the v1 binary release)
 - **Windows preview**: Windows 10+ (build from source; not an official v1 release)
 - **Linux** (experimental): X11 session; GTK/WebKit dev libraries + `xdotool` — see [Linux notes](docs/linux-notes.md)
 - Rust 1.75+ (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,7 @@ keychain and set `APPLE_SIGNING_IDENTITY`. Set `APPLE_API_ISSUER`,
 3. Merge the release commit to `main`, then create and push exactly `vVERSION`.
 4. The Release workflow gates the macOS build on tests, checks version/tag
    consistency, imports the Apple certificate into an ephemeral keychain, and
-   lets Tauri sign, notarize, and staple the universal macOS build.
+   lets Tauri sign, notarize, and staple the Apple Silicon macOS build.
 5. The workflow independently verifies the Developer ID authority, Team ID,
    hardened-runtime flag, audio-input entitlement, notarization tickets,
    Gatekeeper acceptance, and bundle metadata before creating a draft release.
@@ -68,7 +68,8 @@ link from silently continuing to execute a stale binary after an upgrade.
 - Confirm `sagascript --version` reports the release Git revision, and run one
   file transcription through `/usr/local/bin/sagascript` after upgrading an
   existing installation.
-- Test both Apple Silicon and Intel hardware before claiming universal support.
+- Test the signed artifact on Apple Silicon. Do not claim Intel support for v1;
+  the diarization runtime does not provide the required Intel macOS binary.
 - Confirm the draft contains `Sagascript.dmg`, `Sagascript.app.tar.gz`, and
   `SHA256SUMS`; no Windows installer is a v1 release artifact. Verify both
   downloads against the published checksums before clean-machine testing.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,7 +1,7 @@
 # Third-party notices
 
 This notice covers the runtime and build-time dependencies used to produce the
-official universal macOS build, plus the separately downloaded models
+official Apple Silicon macOS build, plus the separately downloaded models
 Sagascript can use. It is generated from the locked Rust and npm dependency
 graphs; do not edit the generated inventories by hand. Sagascript itself is
 licensed under the MIT License in `LICENSE`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,9 +5,8 @@
 ### System requirements
 
 - macOS 13.0 (Ventura) or later
-- Apple Silicon (M1+) is the tested launch platform. The release is built as a
-  universal binary, but Intel x86_64 support remains pending clean-machine
-  hardware acceptance.
+- Apple Silicon (M1+) is required for the v1 binary release. Intel Macs are not
+  supported by the v1 installer.
 - ~200 MB disk space (plus Whisper model files)
 
 ### Download

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -126,7 +126,7 @@ function rootLicenseFiles(directory) {
 }
 
 const rustById = new Map();
-for (const target of ["aarch64-apple-darwin", "x86_64-apple-darwin"]) {
+for (const target of ["aarch64-apple-darwin"]) {
   const metadata = cargoMetadata(target);
   const nodes = new Map(metadata.resolve.nodes.map((node) => [node.id, node]));
   const resolvedIds = new Set();
@@ -251,7 +251,7 @@ function table(packages) {
 const generated = `# Third-party notices
 
 This notice covers the runtime and build-time dependencies used to produce the
-official universal macOS build, plus the separately downloaded models
+official Apple Silicon macOS build, plus the separately downloaded models
 Sagascript can use. It is generated from the locked Rust and npm dependency
 graphs; do not edit the generated inventories by hand. Sagascript itself is
 licensed under the MIT License in \`LICENSE\`.

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -39,6 +39,13 @@ actual_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' 
   exit 1
 }
 
+binary="$app/Contents/MacOS/sagascript"
+actual_architectures=$(lipo -archs "$binary")
+[[ "$actual_architectures" == "arm64" ]] || {
+  echo "Unexpected release architectures: $actual_architectures (wanted arm64)" >&2
+  exit 1
+}
+
 codesign --verify --deep --strict --verbose=2 "$app"
 signature=$(codesign -dvvv "$app" 2>&1)
 grep -q '^Authority=Developer ID Application:' <<<"$signature" || {


### PR DESCRIPTION
## Summary

- Build the signed v1 macOS artifact for Apple Silicon only.
- Fail closed if the release binary is not exactly arm64.
- Align installation, contributor, release, and license documentation with the supported architecture.

## Why

The first v1.0.0 release run failed before signing because the diarization ONNX runtime does not provide an x86_64 macOS prebuilt binary. Intel hardware was not accepted for launch, so preserving diarization and shipping the tested Apple Silicon target is the safe v1 policy.

Failed run: https://github.com/Magnus-Gille/sagascript/actions/runs/29165755255

## Validation

- Native arm64 Tauri release build passed.
- Built executable reports exactly arm64.
- Release metadata and third-party notices checks passed.
- Svelte/TypeScript check and frontend build passed.
- Shell syntax and diff checks passed.
- Independent release-hotfix review found no issues.
