### PR TITLE
fix(release): notarize disk image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,22 @@ jobs:
           : "${APPLE_API_ISSUER:?APPLE_API_ISSUER secret is required}"
           npx tauri build --target aarch64-apple-darwin
 
+      - name: Notarize and staple disk image
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          : "${APPLE_API_ISSUER:?APPLE_API_ISSUER secret is required}"
+          : "${APPLE_API_KEY:?APPLE_API_KEY secret is required}"
+          dmg=$(find src-tauri/target/aarch64-apple-darwin/release/bundle/dmg -name '*.dmg' -print -quit)
+          [[ -n "$dmg" ]]
+          xcrun notarytool submit "$dmg" \
+            --key "$APPLE_API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$dmg"
+
       - name: Verify macOS release artifact
         run: |
           version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary
- submit the signed DMG to Apple Notary Service after Tauri creates it
- wait for acceptance and staple the DMG before strict release verification
- keep existing app/DMG Gatekeeper and ticket validation unchanged

## Root cause
Tauri notarized and stapled the app before creating the DMG. The release verifier correctly rejected the later-created DMG because it had no stapled ticket.

## Validation
- `npm run release:check`
- release workflow YAML parsed locally
- `git diff --check`
- Xcode CLI help confirms `notarytool submit --key --key-id --issuer --wait` and `stapler staple` support signed UDIF images
- independent read-only review confirmed the sequence and fix

Fable review remains waived per owner instruction for this launch sequence.