### PR TITLE
fix(transcription): highlight repeated music markers

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -8,7 +8,9 @@ use sagascript_core::audio::decoder::decode_audio_file;
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{Language, WhisperModel};
 use sagascript_core::transcription::model;
-use sagascript_core::transcription::{TranscribeOptions, WhisperBackend};
+use sagascript_core::transcription::{
+    TranscribeOptions, WhisperBackend, normalize_nonspeech_markers,
+};
 
 #[derive(Args)]
 pub struct TranscribeArgs {
@@ -174,7 +176,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             .collect();
 
         let diarized = merge_with_transcript(&speaker_segments, &transcript);
-        let consolidated = consolidate(&diarized);
+        let mut consolidated = consolidate(&diarized);
+        for segment in &mut consolidated {
+            segment.text = normalize_nonspeech_markers(&segment.text, language);
+        }
 
         if args.json {
             let speakers: Vec<String> = {
@@ -268,22 +273,23 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         eprintln!("Transcribing...");
         backend.transcribe_sync_with_options_segments(&audio, language, &opts, |_| {})?
     };
-    // Same join+trim as WhisperBackend::transcribe_sync_with_options, so the
-    // plain-text output is byte-identical to what it was before segments.
-    let text = segments
+    // Keep timestamped segment text source-faithful, while the rendered
+    // top-level text uses the same display normalization as live dictation.
+    let raw_text = segments
         .iter()
         .map(|s| s.text.as_str())
         .collect::<String>()
         .trim()
         .to_string();
+    let text = normalize_nonspeech_markers(&raw_text, language);
 
     // Output
     if args.json {
         // Per-segment confidence (#81): avg_logprob is the mean token
         // log-probability (null when a segment has no scoreable tokens);
         // no_speech_prob near 1.0 flags likely-hallucinated segments.
-        // Segment text is trimmed for consumers; top-level `text` keeps the
-        // exact pre-segments contract.
+        // Segment text is trimmed but otherwise raw for confidence/timing
+        // consumers; top-level `text` is the display-normalized rendering.
         let json_segments: Vec<serde_json::Value> = segments
             .iter()
             .map(|s| {

--- a/src-tauri/crates/sagascript-core/src/transcription/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/mod.rs
@@ -1,4 +1,5 @@
 pub mod model;
+mod postprocess;
 pub mod whisper_backend;
 
 #[cfg(target_os = "macos")]
@@ -7,3 +8,4 @@ mod metal_preflight;
 pub use whisper_backend::{
     FILE_TRANSCRIBE_BEAM, TranscribeOptions, TranscriptSegment, WhisperBackend,
 };
+pub use postprocess::normalize_nonspeech_markers;

--- a/src-tauri/crates/sagascript-core/src/transcription/postprocess.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/postprocess.rs
@@ -1,0 +1,185 @@
+use crate::settings::Language;
+
+#[derive(Clone, Copy)]
+struct Token<'a> {
+    start: usize,
+    end: usize,
+    text: &'a str,
+}
+
+/// Make Whisper's music annotations readable without rewriting ordinary speech.
+///
+/// Explicit labels such as `[Music]` and `(Musik)` are always canonicalized.
+/// Bare labels are only treated as annotations when Whisper repeats them at
+/// least three times in a row; this preserves genuine phrases such as
+/// "jag gillar musik" and even a spoken double repetition.
+pub fn normalize_nonspeech_markers(text: &str, language: Language) -> String {
+    let tokens = token_spans(text);
+    if tokens.is_empty() {
+        return text.to_string();
+    }
+
+    let marker = music_marker(language);
+    let mut rendered = String::with_capacity(text.len());
+    let mut cursor = 0;
+    let mut index = 0;
+
+    while index < tokens.len() {
+        let Some(mut has_explicit_label) = classify_music_token(tokens[index].text) else {
+            index += 1;
+            continue;
+        };
+
+        let mut end = index + 1;
+        while end < tokens.len() {
+            let Some(explicit) = classify_music_token(tokens[end].text) else {
+                break;
+            };
+            has_explicit_label |= explicit;
+            end += 1;
+        }
+
+        let run_len = end - index;
+        if has_explicit_label || run_len >= 3 {
+            rendered.push_str(&text[cursor..tokens[index].start]);
+            rendered.push_str(marker);
+            cursor = tokens[end - 1].end;
+        }
+        index = end;
+    }
+
+    if cursor == 0 {
+        return text.to_string();
+    }
+    rendered.push_str(&text[cursor..]);
+    rendered
+}
+
+fn token_spans(text: &str) -> Vec<Token<'_>> {
+    let mut tokens = Vec::new();
+    let mut start = None;
+    for (index, character) in text.char_indices() {
+        if character.is_whitespace() {
+            if let Some(token_start) = start.take() {
+                tokens.push(Token {
+                    start: token_start,
+                    end: index,
+                    text: &text[token_start..index],
+                });
+            }
+        } else if start.is_none() {
+            start = Some(index);
+        }
+    }
+    if let Some(token_start) = start {
+        tokens.push(Token {
+            start: token_start,
+            end: text.len(),
+            text: &text[token_start..],
+        });
+    }
+    tokens
+}
+
+fn music_marker(language: Language) -> &'static str {
+    match language {
+        Language::Swedish => "[MUSIK]",
+        Language::Norwegian => "[MUSIKK]",
+        Language::English | Language::Auto => "[MUSIC]",
+    }
+}
+
+/// Returns whether the token is an explicitly delimited music label.
+fn classify_music_token(token: &str) -> Option<bool> {
+    let without_terminal = token.trim_end_matches(['.', ',', '!', '?', ';', ':']);
+    let (inner, explicit) = if let Some(inner) = without_terminal
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        (inner, true)
+    } else if let Some(inner) = without_terminal
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        (inner, true)
+    } else {
+        (without_terminal, false)
+    };
+
+    matches!(inner.to_lowercase().as_str(), "music" | "musik" | "musikk").then_some(explicit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collapses_long_bare_swedish_runs() {
+        assert_eq!(
+            normalize_nonspeech_markers(
+                "Tack! Musik musik MUSIK. Samtal Musik Musik Musik Musik",
+                Language::Swedish,
+            ),
+            "Tack! [MUSIK] Samtal [MUSIK]"
+        );
+    }
+
+    #[test]
+    fn preserves_one_or_two_bare_mentions() {
+        assert_eq!(
+            normalize_nonspeech_markers("Jag gillar musik", Language::Swedish),
+            "Jag gillar musik"
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Musik musik", Language::Swedish),
+            "Musik musik"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_explicit_labels_and_adjacent_duplicates() {
+        assert_eq!(
+            normalize_nonspeech_markers("[Musik] (MUSIC), [musikk]", Language::Swedish),
+            "[MUSIK]"
+        );
+    }
+
+    #[test]
+    fn uses_configured_language_for_the_marker() {
+        assert_eq!(
+            normalize_nonspeech_markers("Music Music Music", Language::English),
+            "[MUSIC]"
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Musik Musik Musik", Language::Norwegian),
+            "[MUSIKK]"
+        );
+    }
+
+    #[test]
+    fn separated_runs_are_not_merged() {
+        assert_eq!(
+            normalize_nonspeech_markers(
+                "Musik Musik Musik tal Musik Musik Musik",
+                Language::Swedish,
+            ),
+            "[MUSIK] tal [MUSIK]"
+        );
+    }
+
+    #[test]
+    fn normalization_is_idempotent() {
+        let once = normalize_nonspeech_markers("Musik\tMusik  Musik [Musik]", Language::Swedish);
+        assert_eq!(once, "[MUSIK]");
+        assert_eq!(normalize_nonspeech_markers(&once, Language::Swedish), once);
+    }
+
+    #[test]
+    fn no_op_preserves_whitespace_byte_for_byte() {
+        let transcript = "  Jag  gillar\tmusik.\nNästa rad.  ";
+        assert_eq!(
+            normalize_nonspeech_markers(transcript, Language::Swedish),
+            transcript
+        );
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -506,8 +506,8 @@ impl WhisperBackend {
     /// spawn_blocking.
     ///
     /// Thin wrapper over [`Self::transcribe_sync_with_options_segments`] that
-    /// concatenates the raw segment texts (whisper's leading spaces make this
-    /// lossless) and trims the result.
+    /// concatenates the raw segment texts, then applies display-only
+    /// non-speech marker normalization. Timestamped segment text stays raw.
     pub fn transcribe_sync_with_options(
         &self,
         audio: &[f32],
@@ -521,7 +521,7 @@ impl WhisperBackend {
         for seg in &segments {
             transcript.push_str(&seg.text);
         }
-        Ok(transcript.trim().to_string())
+        Ok(super::normalize_nonspeech_markers(transcript.trim(), language))
     }
 
     /// Like [`Self::transcribe_sync_with_options`] but returns the individual

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -778,7 +778,13 @@ pub async fn transcribe_file(
             .collect();
 
         let diarized = merge_with_transcript(&speaker_segments, &transcript);
-        let consolidated = consolidate(&diarized);
+        let mut consolidated = consolidate(&diarized);
+        for segment in &mut consolidated {
+            segment.text = sagascript_core::transcription::normalize_nonspeech_markers(
+                &segment.text,
+                language,
+            );
+        }
 
         let text = consolidated
             .iter()


### PR DESCRIPTION
## Summary
- render explicit music labels as localized uppercase markers such as `[MUSIK]`
- collapse pathological runs of 3+ bare `Musik`/`Music`/`Musikk` tokens into one marker
- preserve singleton/double mentions and all unrelated text/whitespace byte-for-byte
- apply the shared rendering to GUI, CLI, and late diarized output while keeping raw confidence segments intact

## Launch finding
A long quiet lead-in during signed v1.0.0 UI acceptance produced `Musik Musik Musik ...`; this makes the non-speech annotation prominent without rewriting genuine phrases such as `jag gillar musik`.

## Validation
- 7 focused normalization tests
- 404 Rust workspace tests
- strict workspace/all-target Clippy
- production frontend build
- Svelte/TypeScript check
- independent review and re-review: no blocking findings

Fable remains waived per owner instruction for this launch sequence.