### PR TITLE
Fix Accessibility onboarding System Settings navigation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,6 +44,23 @@ The `/usr/local/bin/sagascript` link above points into the app bundle, so it
 automatically reaches the replacement executable. If it points elsewhere,
 repeat the `ln -sfn` command before testing the upgraded CLI.
 
+### Accessibility onboarding release check
+
+Release acceptance must exercise the case where System Settings is already
+open on an unrelated pane:
+
+1. Install and launch the signed `/Applications/Sagascript.app`; do not use an
+   unsigned development bundle for this check.
+2. Leave System Settings open on Wi-Fi (or another unrelated pane).
+3. Reset only the release app's grant with
+   `tccutil reset Accessibility ai.gille.sagascript`.
+4. In onboarding, click **Open System Settings**.
+5. Verify System Settings comes forward on **Privacy & Security >
+   Accessibility**, enable the exact installed Sagascript row, and confirm
+   onboarding changes to **Accessibility granted** without an app relaunch.
+6. Confirm **I'll paste manually** remains available while permission is not
+   granted.
+
 ### Homebrew (planned)
 
 ```

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -947,7 +947,7 @@ pub async fn check_accessibility_permission() -> Result<bool, String> {
 pub async fn request_accessibility_permission() -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        crate::platform::macos::request_accessibility_permission();
+        crate::platform::macos::request_accessibility_permission()?;
     }
     Ok(())
 }

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -2,6 +2,11 @@ use core_foundation::base::TCFType;
 use core_foundation::boolean::CFBoolean;
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
+use std::io;
+use std::process::{Command, ExitStatus};
+
+const ACCESSIBILITY_SETTINGS_URL: &str =
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
 
 extern "C" {
     fn AXIsProcessTrusted() -> bool;
@@ -13,8 +18,29 @@ pub fn is_accessibility_trusted() -> bool {
     unsafe { AXIsProcessTrusted() }
 }
 
-/// Request accessibility permission (shows system dialog)
-pub fn request_accessibility_permission() {
+fn accessibility_settings_command() -> Command {
+    let mut command = Command::new("open");
+    command.arg(ACCESSIBILITY_SETTINGS_URL);
+    command
+}
+
+fn interpret_open_result(result: io::Result<ExitStatus>) -> Result<(), String> {
+    let status =
+        result.map_err(|error| format!("Failed to open Accessibility settings: {error}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Failed to open Accessibility settings: open exited with {status}"
+        ))
+    }
+}
+
+/// Request Accessibility permission and bring the relevant System Settings
+/// pane forward. AXTrustedCheckOptionPrompt alone does not reliably navigate
+/// an already-running System Settings instance away from its current pane.
+pub fn request_accessibility_permission() -> Result<(), String> {
     let key = CFString::new("AXTrustedCheckOptionPrompt");
     let value = CFBoolean::true_value();
     let options = CFDictionary::from_CFType_pairs(&[(key, value)]);
@@ -22,6 +48,8 @@ pub fn request_accessibility_permission() {
     unsafe {
         AXIsProcessTrustedWithOptions(options.as_CFTypeRef());
     }
+
+    interpret_open_result(accessibility_settings_command().status())
 }
 
 /// Set the app as an accessory (no dock icon)
@@ -30,6 +58,53 @@ pub fn set_activation_policy_accessory() {
     use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicy};
     unsafe {
         let app = NSApp();
-        app.setActivationPolicy_(NSApplicationActivationPolicy::NSApplicationActivationPolicyAccessory);
+        app.setActivationPolicy_(
+            NSApplicationActivationPolicy::NSApplicationActivationPolicyAccessory,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        accessibility_settings_command, interpret_open_result, ACCESSIBILITY_SETTINGS_URL,
+    };
+    use std::ffi::OsStr;
+    use std::io;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::ExitStatus;
+
+    #[test]
+    fn accessibility_request_opens_the_privacy_pane() {
+        let command = accessibility_settings_command();
+
+        assert_eq!(command.get_program(), OsStr::new("open"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new(ACCESSIBILITY_SETTINGS_URL)]
+        );
+    }
+
+    #[test]
+    fn accessibility_settings_launch_failure_is_reported() {
+        let error = interpret_open_result(Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "open is unavailable",
+        )))
+        .unwrap_err();
+
+        assert!(error.contains("open is unavailable"));
+    }
+
+    #[test]
+    fn accessibility_settings_nonzero_exit_is_reported() {
+        let error = interpret_open_result(Ok(ExitStatus::from_raw(1 << 8))).unwrap_err();
+
+        assert!(error.contains("open exited with"));
+    }
+
+    #[test]
+    fn accessibility_settings_success_is_accepted() {
+        assert!(interpret_open_result(Ok(ExitStatus::from_raw(0))).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- retain the native Accessibility trust prompt so macOS registers Sagascript with TCC
- explicitly deep-link an existing or closed System Settings instance to Privacy & Security > Accessibility
- propagate launcher and non-zero exit failures through the existing onboarding/settings error paths
- document the signed-app regression check for an already-open unrelated System Settings pane

Closes #99.

## Validation

- `npm run build`
- `npm run check` (0 errors, 0 warnings)
- 4 focused macOS platform tests
- `cargo test --workspace` (408 passed, outside sandbox for NSPasteboard/filesystem permission tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `rustfmt --edition 2021 --check src/platform/macos.rs`
- `git diff --check`
- exact `x-apple.systempreferences:...Privacy_Accessibility` deep link exits successfully on macOS 26.5.1

## Review

Independent agent review: approved with no blocking findings.
