### PR TITLE
Fix macOS settings reload and hotkey recovery

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,9 @@ dirs = "6"
 notify = { version = "7", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+# notify 7 requires one native macOS backend feature even when this app uses
+# PollWatcher explicitly for settings (see start_settings_watcher).
+notify = { version = "7", default-features = false, features = ["macos_fsevent"] }
 # enigo (auto-paste) and the objc FFI stack are desktop-GUI integrations.
 enigo = { version = "0.6", features = ["serde"] }
 core-foundation = "0.10"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,7 +14,7 @@ const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 const ABORT_GRACE_SECS: u64 = 5;
 
 use crate::app_controller::{AppController, AppState, StopRecordingOutcome};
-use crate::hotkey::{HotkeyHealth, HotkeyStatus};
+use crate::hotkey::{HotkeyHealth, HotkeyStatus, OperationalHotkey};
 use sagascript_core::audio::decoder;
 use sagascript_core::settings::{HotkeyMode, Language, Settings, WhisperModel};
 use sagascript_core::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
@@ -214,15 +214,42 @@ pub async fn set_hotkey(
     use tauri::Emitter;
     use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
+    let _transition = health.transition_guard();
     let old_shortcut = {
         let ctrl = controller.lock().unwrap();
         ctrl.settings().hotkey.clone()
     };
 
-    // Unregister old shortcut
-    if let Err(e) = app.global_shortcut().unregister(old_shortcut.as_str()) {
-        error!("Failed to unregister old hotkey '{}': {}", old_shortcut, e);
-        // Continue anyway — might already be unregistered
+    let old_operational = health.operational_hotkey();
+
+    // The saved shortcut can differ from the operational fallback after an
+    // external hot-reload failure. Always unregister what is actually active.
+    if old_operational == OperationalHotkey::Unknown {
+        return Err(
+            "Hotkey registration state is unknown after an earlier OS error; restart Sagascript before changing the shortcut"
+                .to_string(),
+        );
+    }
+    if let OperationalHotkey::Registered(old_operational) = &old_operational {
+        if let Err(error) = app.global_shortcut().unregister(old_operational.as_str()) {
+            error!("Failed to unregister operational hotkey '{old_operational}': {error}");
+            let change = health.record(
+                &old_shortcut,
+                Some(format!(
+                    "failed to unregister active hotkey '{old_operational}': {error}; operational state is unknown"
+                )),
+                OperationalHotkey::Unknown,
+            );
+            if change.changed {
+                let _ = app.emit(
+                    crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+                    &change.status,
+                );
+            }
+            return Err(format!(
+                "Failed to unregister active hotkey '{old_operational}': {error}"
+            ));
+        }
     }
 
     // Register new shortcut
@@ -233,21 +260,53 @@ pub async fn set_hotkey(
         // (the *requested* change failed, which is already surfaced to the
         // caller via the returned Err below) — only record a health failure
         // if even the fallback re-registration fails.
-        let change = match app.global_shortcut().register(old_shortcut.as_str()) {
-            Ok(()) => {
-                info!("Re-registered old hotkey '{}' after failed change", old_shortcut);
-                health.record(&old_shortcut, None)
-            }
-            Err(e2) => {
-                error!("Failed to re-register old hotkey '{}': {}", old_shortcut, e2);
-                health.record(&old_shortcut, Some(e2.to_string()))
-            }
+        let change = match &old_operational {
+            OperationalHotkey::Registered(old_operational) => match app
+                .global_shortcut()
+                .register(old_operational.as_str())
+            {
+                Ok(()) => {
+                    info!("Re-registered old hotkey '{old_operational}' after failed change");
+                    let error = (old_shortcut.as_str() != old_operational.as_str()).then(|| {
+                        format!(
+                            "saved shortcut '{old_shortcut}' is not active; still using fallback '{old_operational}'"
+                        )
+                    });
+                    health.record(
+                        &old_shortcut,
+                        error,
+                        OperationalHotkey::Registered(old_operational.clone()),
+                    )
+                }
+                Err(e2) => {
+                    error!("Failed to re-register old hotkey '{old_operational}': {e2}");
+                    health.record(
+                        &old_shortcut,
+                        Some(e2.to_string()),
+                        OperationalHotkey::Inactive,
+                    )
+                }
+            },
+            OperationalHotkey::Inactive => health.record(
+                &old_shortcut,
+                Some("no previous hotkey was active".to_string()),
+                OperationalHotkey::Inactive,
+            ),
+            OperationalHotkey::Unknown => unreachable!("unknown state returned above"),
         };
         if change.changed {
             let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
         }
         return Err(format!("Failed to register hotkey '{}': {}", shortcut, e));
     }
+
+    // Registration changes before persistence; keep concurrent status reads
+    // truthful during that short synchronous window.
+    health.record(
+        &old_shortcut,
+        Some("hotkey change is pending persistence".to_string()),
+        OperationalHotkey::registered(&shortcut),
+    );
 
     let persisted = match sagascript_core::settings::store::update(|settings| {
         settings.hotkey = shortcut.clone();
@@ -257,25 +316,73 @@ pub async fn set_hotkey(
             // Registration already changed process-global state. If the disk
             // write fails, restore the operational shortcut so controller,
             // disk, and registration cannot diverge.
-            if let Err(e) = app.global_shortcut().unregister(shortcut.as_str()) {
-                error!("Failed to unregister unpersisted hotkey '{shortcut}': {e}");
+            if let Err(unregister_error) = app.global_shortcut().unregister(shortcut.as_str()) {
+                error!(
+                    "Failed to unregister unpersisted hotkey '{shortcut}': {unregister_error}"
+                );
+                let change = health.record(
+                    &old_shortcut,
+                    Some(format!(
+                        "failed to persist requested hotkey and could not unregister it: {unregister_error}; operational state is unknown"
+                    )),
+                    OperationalHotkey::Unknown,
+                );
+                if change.changed {
+                    let _ = app.emit(
+                        crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+                        &change.status,
+                    );
+                }
+                return Err(format!(
+                    "Failed to persist hotkey: {save_error}; failed to unregister unpersisted hotkey '{shortcut}': {unregister_error}"
+                ));
             }
-            let rollback_error = app
-                .global_shortcut()
-                .register(old_shortcut.as_str())
-                .err()
-                .map(|e| e.to_string());
-            let change = health.record(&old_shortcut, rollback_error.clone());
+            let rollback_error = match &old_operational {
+                OperationalHotkey::Registered(old_operational) => app
+                    .global_shortcut()
+                    .register(old_operational.as_str())
+                    .err()
+                    .map(|e| e.to_string()),
+                OperationalHotkey::Inactive => None,
+                OperationalHotkey::Unknown => unreachable!("unknown state returned above"),
+            };
+            let (health_error, restored_operational) =
+                match (&old_operational, rollback_error.as_deref()) {
+                (OperationalHotkey::Registered(old_operational), None) => {
+                    let error = (old_shortcut.as_str() != old_operational.as_str()).then(|| {
+                        format!(
+                            "saved shortcut '{old_shortcut}' is not active; still using fallback '{old_operational}'"
+                        )
+                    });
+                    (
+                        error,
+                        OperationalHotkey::Registered(old_operational.clone()),
+                    )
+                }
+                (OperationalHotkey::Registered(_), Some(error)) => {
+                    (Some(error.to_string()), OperationalHotkey::Inactive)
+                }
+                (OperationalHotkey::Inactive, _) => (
+                    Some("no previous hotkey was active".to_string()),
+                    OperationalHotkey::Inactive,
+                ),
+                (OperationalHotkey::Unknown, _) => unreachable!("unknown state returned above"),
+            };
+            let change = health.record(&old_shortcut, health_error, restored_operational);
             if change.changed {
                 let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
             }
-            return match rollback_error {
-                Some(error) => Err(format!(
-                    "Failed to persist hotkey: {save_error}; restoring '{old_shortcut}' also failed: {error}"
+            return match (old_operational, rollback_error) {
+                (OperationalHotkey::Registered(_), Some(error)) => Err(format!(
+                    "Failed to persist hotkey: {save_error}; restoring the previous operational hotkey also failed: {error}"
                 )),
-                None => Err(format!(
-                    "Failed to persist hotkey: {save_error}; restored '{old_shortcut}'"
+                (OperationalHotkey::Registered(_), None) => Err(format!(
+                    "Failed to persist hotkey: {save_error}; restored the previous operational hotkey"
                 )),
+                (OperationalHotkey::Inactive, _) => Err(format!(
+                    "Failed to persist hotkey: {save_error}; no previous hotkey was active"
+                )),
+                (OperationalHotkey::Unknown, _) => unreachable!("unknown state returned above"),
             };
         }
     };
@@ -287,7 +394,11 @@ pub async fn set_hotkey(
         ctrl.hotkey_service_mut().set_shortcut(&persisted.hotkey);
     }
 
-    let change = health.record(&shortcut, None);
+    let change = health.record(
+        &shortcut,
+        None,
+        OperationalHotkey::registered(&shortcut),
+    );
     if change.changed {
         let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
     }

--- a/src-tauri/src/hotkey/health.rs
+++ b/src-tauri/src/hotkey/health.rs
@@ -1,5 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 use serde::Serialize;
 
@@ -24,58 +23,102 @@ pub struct HotkeyStatusChange {
     pub changed: bool,
 }
 
+/// What this process knows about the shortcut currently registered with the OS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperationalHotkey {
+    Inactive,
+    Registered(String),
+    Unknown,
+}
+
+impl OperationalHotkey {
+    pub fn registered(shortcut: &str) -> Self {
+        Self::Registered(shortcut.to_string())
+    }
+}
+
 /// Process-wide hotkey registration health.
 ///
 /// Deliberately NOT folded into `AppController`/`HotkeyService`: routing
 /// registration outcomes through the controller mutex — which is already
 /// locked from the global-shortcut handler, the settings-watcher thread, and
 /// the `set_hotkey` command — would risk lock-ordering deadlocks for no real
-/// benefit. This is a small independent piece of shared state (an
-/// `AtomicBool` plus a couple of `Mutex<String>`s for the error/shortcut
-/// detail) instead. It is set on registration failure and cleared on
-/// registration success at all three registration sites: app startup,
-/// `commands::set_hotkey`, and the settings-file watcher's hot-reload path.
+/// benefit. Requested, operational, and error state share one mutex so status
+/// readers cannot observe a torn transition. A second mutex serializes the OS
+/// unregister/register transaction across GUI and settings-watcher callers.
 pub struct HotkeyHealth {
-    failed: AtomicBool,
-    error: Mutex<Option<String>>,
-    shortcut: Mutex<String>,
+    state: Mutex<HotkeyState>,
+    transition: Mutex<()>,
+}
+
+struct HotkeyState {
+    error: Option<String>,
+    shortcut: String,
+    operational_hotkey: OperationalHotkey,
 }
 
 impl HotkeyHealth {
     pub fn new(initial_shortcut: &str) -> Self {
         Self {
-            failed: AtomicBool::new(false),
-            error: Mutex::new(None),
-            shortcut: Mutex::new(initial_shortcut.to_string()),
+            state: Mutex::new(HotkeyState {
+                error: None,
+                shortcut: initial_shortcut.to_string(),
+                operational_hotkey: OperationalHotkey::Inactive,
+            }),
+            transition: Mutex::new(()),
         }
+    }
+
+    /// Serialize process-global unregister/register transactions from the GUI
+    /// command and the external-settings watcher.
+    pub fn transition_guard(&self) -> MutexGuard<'_, ()> {
+        self.transition.lock().unwrap()
+    }
+
+    /// The shortcut currently registered with the OS, if any. This can differ
+    /// from the saved/requested shortcut after a failed hot-reload falls back
+    /// to the previous binding.
+    pub fn operational_hotkey(&self) -> OperationalHotkey {
+        self.state.lock().unwrap().operational_hotkey.clone()
     }
 
     /// True if the most recent registration attempt failed. Sticky until the
     /// next successful registration clears it.
     pub fn is_failed(&self) -> bool {
-        self.failed.load(Ordering::SeqCst)
+        self.state.lock().unwrap().error.is_some()
     }
 
     pub fn status(&self) -> HotkeyStatus {
+        let state = self.state.lock().unwrap();
         HotkeyStatus {
-            ok: !self.is_failed(),
-            error: self.error.lock().unwrap().clone(),
-            shortcut: self.shortcut.lock().unwrap().clone(),
+            ok: state.error.is_none(),
+            error: state.error.clone(),
+            shortcut: state.shortcut.clone(),
         }
     }
 
-    /// Record the outcome of a registration attempt for `shortcut`.
+    /// Atomically record the requested shortcut, any error, and the shortcut
+    /// known to be registered with the OS.
     /// `error = None` means the registration succeeded (clears the flag);
     /// `Some(msg)` means it failed (sets the flag). Returns the resulting
     /// status plus whether any part of the status actually changed.
-    pub fn record(&self, shortcut: &str, error: Option<String>) -> HotkeyStatusChange {
-        let prev = self.status();
-        let new_failed = error.is_some();
-        self.failed.store(new_failed, Ordering::SeqCst);
-        *self.error.lock().unwrap() = error.clone();
-        *self.shortcut.lock().unwrap() = shortcut.to_string();
+    pub fn record(
+        &self,
+        shortcut: &str,
+        error: Option<String>,
+        operational_hotkey: OperationalHotkey,
+    ) -> HotkeyStatusChange {
+        let mut state = self.state.lock().unwrap();
+        let prev = HotkeyStatus {
+            ok: state.error.is_none(),
+            error: state.error.clone(),
+            shortcut: state.shortcut.clone(),
+        };
+        state.error = error.clone();
+        state.shortcut = shortcut.to_string();
+        state.operational_hotkey = operational_hotkey;
         let status = HotkeyStatus {
-            ok: !new_failed,
+            ok: error.is_none(),
             error,
             shortcut: shortcut.to_string(),
         };
@@ -98,12 +141,17 @@ mod tests {
         assert!(s.ok);
         assert!(s.error.is_none());
         assert_eq!(s.shortcut, "Control+Shift+Space");
+        assert_eq!(h.operational_hotkey(), OperationalHotkey::Inactive);
     }
 
     #[test]
     fn record_failure_sets_flag_and_reports_changed() {
         let h = HotkeyHealth::new("Control+Shift+Space");
-        let change = h.record("Control+Shift+Space", Some("already registered".to_string()));
+        let change = h.record(
+            "Control+Shift+Space",
+            Some("already registered".to_string()),
+            OperationalHotkey::Inactive,
+        );
         assert!(change.changed);
         assert!(!change.status.ok);
         assert_eq!(change.status.error.as_deref(), Some("already registered"));
@@ -113,8 +161,16 @@ mod tests {
     #[test]
     fn record_same_failure_twice_is_not_changed_second_time() {
         let h = HotkeyHealth::new("Control+Shift+Space");
-        let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
-        let second = h.record("Control+Shift+Space", Some("busy".to_string()));
+        let _ = h.record(
+            "Control+Shift+Space",
+            Some("busy".to_string()),
+            OperationalHotkey::Inactive,
+        );
+        let second = h.record(
+            "Control+Shift+Space",
+            Some("busy".to_string()),
+            OperationalHotkey::Inactive,
+        );
         assert!(!second.changed);
         assert!(!second.status.ok);
     }
@@ -122,9 +178,17 @@ mod tests {
     #[test]
     fn record_success_after_failure_clears_flag_and_reports_changed() {
         let h = HotkeyHealth::new("Control+Shift+Space");
-        let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
+        let _ = h.record(
+            "Control+Shift+Space",
+            Some("busy".to_string()),
+            OperationalHotkey::Inactive,
+        );
         assert!(h.is_failed());
-        let change = h.record("Control+Shift+Space", None);
+        let change = h.record(
+            "Control+Shift+Space",
+            None,
+            OperationalHotkey::registered("Control+Shift+Space"),
+        );
         assert!(change.changed);
         assert!(change.status.ok);
         assert!(change.status.error.is_none());
@@ -134,7 +198,11 @@ mod tests {
     #[test]
     fn record_success_after_success_is_not_changed() {
         let h = HotkeyHealth::new("Control+Shift+Space");
-        let change = h.record("Control+Shift+Space", None);
+        let change = h.record(
+            "Control+Shift+Space",
+            None,
+            OperationalHotkey::Inactive,
+        );
         assert!(!change.changed);
         assert!(change.status.ok);
     }
@@ -142,20 +210,69 @@ mod tests {
     #[test]
     fn status_reflects_latest_shortcut() {
         let h = HotkeyHealth::new("Control+Shift+Space");
-        h.record("Alt+D", None);
+        h.record("Alt+D", None, OperationalHotkey::registered("Alt+D"));
         assert_eq!(h.status().shortcut, "Alt+D");
     }
 
     #[test]
     fn failure_then_different_failure_reports_changed() {
         let h = HotkeyHealth::new("Control+Shift+Space");
-        let _ = h.record("Control+Shift+Space", Some("busy".to_string()));
-        let second = h.record("Alt+D", Some("also busy".to_string()));
+        let _ = h.record(
+            "Control+Shift+Space",
+            Some("busy".to_string()),
+            OperationalHotkey::Inactive,
+        );
+        let second = h.record(
+            "Alt+D",
+            Some("also busy".to_string()),
+            OperationalHotkey::Inactive,
+        );
         // The ok/failed flag didn't flip, but the shortcut/error detail did —
         // listeners must hear about it or the UI shows a stale failure.
         assert!(second.changed);
         assert_eq!(second.status.shortcut, "Alt+D");
         assert_eq!(second.status.error.as_deref(), Some("also busy"));
         assert_eq!(h.status().shortcut, "Alt+D");
+    }
+
+    #[test]
+    fn operational_shortcut_is_tracked_separately_from_requested_health() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        h.record(
+            "Control+ScrollLock",
+            Some("unsupported".to_string()),
+            OperationalHotkey::registered("Control+Shift+Space"),
+        );
+
+        assert_eq!(h.status().shortcut, "Control+ScrollLock");
+        assert_eq!(
+            h.operational_hotkey(),
+            OperationalHotkey::registered("Control+Shift+Space")
+        );
+
+        h.record(
+            "Shift+F6",
+            None,
+            OperationalHotkey::registered("Shift+F6"),
+        );
+        assert_eq!(
+            h.operational_hotkey(),
+            OperationalHotkey::registered("Shift+F6")
+        );
+        assert!(h.status().ok);
+    }
+
+    #[test]
+    fn unknown_operational_state_is_not_treated_as_inactive() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        h.record(
+            "Control+Shift+Space",
+            Some("unregister failed; restart required".to_string()),
+            OperationalHotkey::Unknown,
+        );
+
+        assert_eq!(h.operational_hotkey(), OperationalHotkey::Unknown);
+        assert_ne!(h.operational_hotkey(), OperationalHotkey::Inactive);
+        assert!(h.is_failed());
     }
 }

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -1,5 +1,5 @@
 pub mod health;
 pub mod service;
 
-pub use health::{HotkeyHealth, HotkeyStatus};
+pub use health::{HotkeyHealth, HotkeyStatus, OperationalHotkey};
 pub use service::HotkeyService;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -199,14 +199,22 @@ fn main() {
             match app.global_shortcut().register(shortcut.as_str()) {
                 Ok(()) => {
                     info!("Hotkey registered: {shortcut}");
-                    let change = health.record(&shortcut, None);
+                    let change = health.record(
+                        &shortcut,
+                        None,
+                        hotkey::OperationalHotkey::registered(&shortcut),
+                    );
                     if change.changed {
                         let _ = app.emit(events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
                     }
                 }
                 Err(e) => {
                     error!("Failed to register hotkey: {e}");
-                    let change = health.record(&shortcut, Some(e.to_string()));
+                    let change = health.record(
+                        &shortcut,
+                        Some(e.to_string()),
+                        hotkey::OperationalHotkey::Inactive,
+                    );
                     if change.changed {
                         let _ = app.emit(events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
                     }
@@ -770,10 +778,31 @@ fn stop_recording_and_transcribe(
     });
 }
 
+/// Whether a filesystem event may reflect creation or replacement of the settings file.
+fn settings_event_may_affect(
+    event: &notify::Event,
+    settings_path: &std::path::Path,
+) -> bool {
+    let relevant_kind = matches!(
+        event.kind,
+        notify::EventKind::Create(_) | notify::EventKind::Modify(_)
+    );
+
+    relevant_kind
+        && event
+            .paths
+            .iter()
+            .any(|path| path == settings_path)
+}
+
 /// Watch the settings file for external changes and hot-reload into the running app.
 /// Handles hotkey re-registration and emits a settings-changed event to the frontend.
 fn start_settings_watcher(app: tauri::AppHandle) {
-    use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+    use notify::{Config, RecursiveMode, Watcher};
+    #[cfg(not(target_os = "macos"))]
+    use notify::RecommendedWatcher;
+    #[cfg(target_os = "macos")]
+    use notify::PollWatcher;
     use std::sync::mpsc;
 
     let settings_path = sagascript_core::settings::store::settings_path();
@@ -784,15 +813,26 @@ fn start_settings_watcher(app: tauri::AppHandle) {
             return;
         }
     };
-    let settings_filename = settings_path
-        .file_name()
-        .map(|f| f.to_os_string())
-        .unwrap_or_default();
-
     std::thread::spawn(move || {
         let (tx, rx) = mpsc::channel();
 
-        let mut watcher = match RecommendedWatcher::new(tx, Config::default()) {
+        // notify's optional macOS kqueue backend can panic after our atomic
+        // settings-file replacement. Polling this tiny directory avoids that
+        // stale-file-descriptor path. Comparing contents is required because
+        // several rapid saves can share the same whole-second mtime and size.
+        // One-second polling keeps this background safety net inexpensive;
+        // CLI-driven settings hot reload is not latency-sensitive.
+        #[cfg(target_os = "macos")]
+        let watcher_result = PollWatcher::new(
+            tx,
+            Config::default()
+                .with_poll_interval(Duration::from_secs(1))
+                .with_compare_contents(true),
+        );
+        #[cfg(not(target_os = "macos"))]
+        let watcher_result = RecommendedWatcher::new(tx, Config::default());
+
+        let mut watcher = match watcher_result {
             Ok(w) => w,
             Err(e) => {
                 error!("Failed to create settings file watcher: {e}");
@@ -816,29 +856,16 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                 }
             };
 
-            // Only react to modify/create events on our settings file
-            let dominated = matches!(
-                event.kind,
-                EventKind::Modify(_) | EventKind::Create(_)
-            );
-            if !dominated {
-                continue;
-            }
-
-            let is_our_file = event.paths.iter().any(|p| {
-                p.file_name()
-                    .map(|f| f == settings_filename)
-                    .unwrap_or(false)
-            });
-            if !is_our_file {
+            if !settings_event_may_affect(&event, &settings_path) {
                 continue;
             }
 
             // Small delay to let atomic rename complete
             std::thread::sleep(Duration::from_millis(50));
 
+            let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
+            let _transition = health.transition_guard();
             let new_settings = load_settings_with_permission_gate();
-
             let ctrl: tauri::State<'_, SharedController> = app.state();
             let old_settings = {
                 let c = ctrl.lock().unwrap();
@@ -852,43 +879,91 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                     old_settings.hotkey, new_settings.hotkey
                 );
 
-                if let Err(e) = app.global_shortcut().unregister(old_settings.hotkey.as_str()) {
-                    error!("Failed to unregister old hotkey: {e}");
-                }
+                let old_operational = health.operational_hotkey();
+                let unregister_error = match &old_operational {
+                    hotkey::OperationalHotkey::Registered(shortcut) => app
+                        .global_shortcut()
+                        .unregister(shortcut.as_str())
+                        .err()
+                        .map(|e| {
+                            error!(
+                                "Failed to unregister operational hotkey '{shortcut}': {e}"
+                            );
+                            e.to_string()
+                        }),
+                    hotkey::OperationalHotkey::Inactive => None,
+                    hotkey::OperationalHotkey::Unknown => Some(
+                        "registration state is unknown after an earlier OS error; restart Sagascript"
+                            .to_string(),
+                    ),
+                };
 
-                let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
-                let change = match app.global_shortcut().register(new_settings.hotkey.as_str()) {
-                    Ok(()) => {
-                        info!("Hotkey re-registered: {}", new_settings.hotkey);
-                        health.record(&new_settings.hotkey, None)
-                    }
-                    Err(e) => {
-                        error!("Failed to register new hotkey '{}': {e}", new_settings.hotkey);
-                        // Re-register the old one as fallback so the app doesn't
-                        // end up with no hotkey bound at all. Either way the
-                        // SAVED shortcut is not registered — health must report
-                        // the saved shortcut's failure, not a false-normal for
-                        // the operational fallback.
-                        match app.global_shortcut().register(old_settings.hotkey.as_str()) {
-                            Ok(()) => {
-                                info!("Re-registered old hotkey '{}' as fallback", old_settings.hotkey);
-                                health.record(
+                let change = if let Some(e) = unregister_error {
+                    // The OS registration is now unknown. Do not risk adding a
+                    // second active shortcut after a failed unregister.
+                    health.record(
+                        &new_settings.hotkey,
+                        Some(format!(
+                            "failed to replace previous hotkey because it could not be unregistered: {e}"
+                        )),
+                        hotkey::OperationalHotkey::Unknown,
+                    )
+                } else {
+                    match app.global_shortcut().register(new_settings.hotkey.as_str()) {
+                        Ok(()) => {
+                            info!("Hotkey re-registered: {}", new_settings.hotkey);
+                            health.record(
+                                &new_settings.hotkey,
+                                None,
+                                hotkey::OperationalHotkey::registered(&new_settings.hotkey),
+                            )
+                        }
+                        Err(e) => {
+                            error!("Failed to register new hotkey '{}': {e}", new_settings.hotkey);
+                            // Re-register the old one as fallback so the app doesn't
+                            // end up with no hotkey bound at all. Either way the
+                            // SAVED shortcut is not registered — health must report
+                            // the saved shortcut's failure, not a false-normal for
+                            // the operational fallback.
+                            match &old_operational {
+                                hotkey::OperationalHotkey::Registered(old_shortcut) => {
+                                    match app.global_shortcut().register(old_shortcut.as_str()) {
+                                        Ok(()) => {
+                                            info!(
+                                                "Re-registered old hotkey '{old_shortcut}' as fallback"
+                                            );
+                                            health.record(
+                                                &new_settings.hotkey,
+                                                Some(format!(
+                                                    "failed to register: {e}; still using previous hotkey '{old_shortcut}'"
+                                                )),
+                                                hotkey::OperationalHotkey::Registered(
+                                                    old_shortcut.clone(),
+                                                ),
+                                            )
+                                        }
+                                        Err(e2) => {
+                                            error!("Failed to re-register old hotkey: {e2}");
+                                            health.record(
+                                                &new_settings.hotkey,
+                                                Some(format!(
+                                                    "failed to register: {e}; fallback to '{old_shortcut}' also failed: {e2}"
+                                                )),
+                                                hotkey::OperationalHotkey::Inactive,
+                                            )
+                                        }
+                                    }
+                                }
+                                hotkey::OperationalHotkey::Inactive => health.record(
                                     &new_settings.hotkey,
                                     Some(format!(
-                                        "failed to register: {e}; still using previous hotkey '{}'",
-                                        old_settings.hotkey
+                                        "failed to register: {e}; no previous hotkey was active"
                                     )),
-                                )
-                            }
-                            Err(e2) => {
-                                error!("Failed to re-register old hotkey: {e2}");
-                                health.record(
-                                    &new_settings.hotkey,
-                                    Some(format!(
-                                        "failed to register: {e}; fallback to '{}' also failed: {e2}",
-                                        old_settings.hotkey
-                                    )),
-                                )
+                                    hotkey::OperationalHotkey::Inactive,
+                                ),
+                                hotkey::OperationalHotkey::Unknown => {
+                                    unreachable!("unknown state handled before registration")
+                                }
                             }
                         }
                     }
@@ -915,6 +990,103 @@ fn start_settings_watcher(app: tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    fn wait_for_settings_event(
+        rx: &std::sync::mpsc::Receiver<notify::Result<notify::Event>>,
+        settings_path: &std::path::Path,
+    ) -> bool {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) {
+            match rx.recv_timeout(remaining) {
+                Ok(Ok(event)) if settings_event_may_affect(&event, settings_path) => {
+                    return true;
+                }
+                Ok(_) => continue,
+                Err(_) => return false,
+            }
+        }
+        false
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_settings_watcher_survives_repeated_atomic_replacements() {
+        use notify::{Config, PollWatcher, RecursiveMode, Watcher};
+
+        let dir = std::env::temp_dir().join(format!(
+            "sagascript-settings-watcher-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings_path = dir.join("sagascript-settings.json");
+        std::fs::write(&settings_path, b"{}\n").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher = PollWatcher::new(
+            tx,
+            Config::default()
+                .with_poll_interval(Duration::from_millis(100))
+                .with_compare_contents(true),
+        )
+        .unwrap();
+        watcher
+            .watch(&dir, RecursiveMode::NonRecursive)
+            .unwrap();
+
+        for value in [1, 2, 3, 4, 5] {
+            let temporary = dir.join(format!("settings-{value}.tmp"));
+            std::fs::write(&temporary, format!("{{\"value\":{value}}}\n")).unwrap();
+            std::fs::rename(&temporary, &settings_path).unwrap();
+            assert!(
+                wait_for_settings_event(&rx, &settings_path),
+                "watcher stopped reporting the settings path after atomic replacement {value}"
+            );
+        }
+
+        drop(watcher);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn settings_event_filter_accepts_target_create_and_modify_events() {
+        use notify::event::{CreateKind, ModifyKind};
+        use notify::{Event, EventKind};
+
+        let watch_dir = std::path::Path::new("/tmp/sagascript");
+        let settings_path = watch_dir.join("sagascript-settings.json");
+
+        for kind in [
+            EventKind::Create(CreateKind::Any),
+            EventKind::Modify(ModifyKind::Any),
+        ] {
+            let target_event = Event::new(kind).add_path(settings_path.clone());
+            assert!(settings_event_may_affect(&target_event, &settings_path));
+        }
+    }
+
+    #[test]
+    fn settings_event_filter_rejects_unrelated_and_non_mutating_events() {
+        use notify::event::{AccessKind, ModifyKind, RemoveKind};
+        use notify::{Event, EventKind};
+
+        let watch_dir = std::path::Path::new("/tmp/sagascript");
+        let settings_path = watch_dir.join("sagascript-settings.json");
+        let unrelated = Event::new(EventKind::Modify(ModifyKind::Any))
+            .add_path(watch_dir.join("settings.tmp"));
+        assert!(!settings_event_may_affect(&unrelated, &settings_path));
+
+        let remove = Event::new(EventKind::Remove(RemoveKind::Any))
+            .add_path(settings_path.clone());
+        assert!(!settings_event_may_affect(&remove, &settings_path));
+
+        let access = Event::new(EventKind::Access(AccessKind::Any))
+            .add_path(settings_path.clone());
+        assert!(!settings_event_may_affect(&access, &settings_path));
+
+        let other = Event::new(EventKind::Other).add_path(settings_path.clone());
+        assert!(!settings_event_may_affect(&other, &settings_path));
+    }
 
     #[test]
     fn auto_paste_requires_runtime_accessibility_approval() {

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::process::{Command, ExitStatus};
 
 const ACCESSIBILITY_SETTINGS_URL: &str =
-    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+    "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_Accessibility";
 
 extern "C" {
     fn AXIsProcessTrusted() -> bool;


### PR DESCRIPTION
## What changed

- replace notify's crashing macOS kqueue settings watcher with a one-second, content-comparing poll watcher for the tiny app-data directory
- add native regression coverage for repeated atomic settings-file replacements and exact event filtering
- track requested, registered, inactive, and unknown hotkey state separately
- serialize GUI and CLI/watcher hotkey transitions, preserve a valid fallback, and stop safely if unregister state becomes unknown
- use the macOS 26 Privacy & Security extension identifier so Accessibility onboarding navigates an already-open Settings window to the correct pane

## Why

Signed-app launch validation reproduced a `kqueue` panic after onboarding atomically replaced `sagascript-settings.json`. The watcher thread then died and later `sagascript config set` changes silently stopped reaching the GUI. The same runtime smoke exposed stale/duplicate hotkey risks after a failed external shortcut registration. Finally, the closed #99 fix launched System Settings on macOS 26.5 but left it on General.

## Validation

- `cargo test --workspace` — 413 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run test:frontend` — 9 passed
- `npm run check`
- signed debug `.app` and `.dmg` built with Developer ID and hardened runtime
- six repeated CLI atomic settings mutations hot-reloaded without watcher panic
- invalid `Control+ScrollLock` fell back to the previous working shortcut; a later valid shortcut recovered cleanly
- ~3 minute live recording with KB-Whisper Large, beam 5, VAD off hit the 60-second abort; an immediate five-second recording then transcribed successfully with no `ModelBusy`
- macOS 26 pane URL moved an already-open System Settings window from General to Privacy & Security → Accessibility

Closes #99.
Closes #101.
Addresses #78.
