### PR TITLE
chore: release v1.0.1

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,7 +39,8 @@ keychain and set `APPLE_SIGNING_IDENTITY`. Set `APPLE_API_ISSUER`,
 ## Release procedure
 
 1. Update the version in `package.json`, `package-lock.json`,
-   `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
+   `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and
+   `src-tauri/tauri.conf.json`.
 2. Run `npm run release:check`, `npm run licenses:check`, `npm run check`,
    `cargo test --workspace`, and
    `cargo clippy --workspace --all-targets -- -D warnings`.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -209,8 +209,6 @@ link; the upstream repository is authoritative for its license terms.
 | jsonptr | 0.6.3 | MIT OR Apache-2.0 | [upstream](https://github.com/chanced/jsonptr) |
 | keyboard-types | 0.7.0 | MIT OR Apache-2.0 | [upstream](https://github.com/pyfisch/keyboard-types) |
 | kodama | 0.2.3 | MIT | [upstream](https://github.com/diffeo/kodama) |
-| kqueue | 1.1.1 | MIT | [upstream](https://gitlab.com/rust-kqueue/rust-kqueue) |
-| kqueue-sys | 1.0.4 | MIT | [upstream](https://gitlab.com/rust-kqueue/rust-kqueue-sys) |
 | kuchikiki | 0.8.8-speedreader | MIT | [upstream](https://github.com/brave/kuchikiki) |
 | lazy_static | 1.5.0 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang-nursery/lazy-static.rs) |
 | libc | 0.2.180 | MIT OR Apache-2.0 | [upstream](https://github.com/rust-lang/libc) |
@@ -2126,34 +2124,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-~~~~
-
-### 208693b9bfa9
-
-Components: Rust kqueue-sys@1.0.4, Rust kqueue@1.1.1
-
-Source filenames: LICENSE
-
-~~~~text
-Copyright (c) 2016 William Orr <will@worrbase.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 ~~~~
 
 ### 23c3dce12b90

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arboard",
  "block",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arboard",
  "clap",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump all application and workspace version metadata from 1.0.0 to 1.0.1
- refresh Cargo and npm lockfile package versions
- regenerate third-party notices after the macOS watcher fix removed the unused kqueue crates
- clarify that `src-tauri/Cargo.lock` is part of the documented release-version update

## Why

This publishes the post-launch fixes merged in #102, including reliable macOS settings reload, fail-closed hotkey recovery, and the corrected Accessibility settings deep link.

## Validation

- `RELEASE_TAG=v1.0.1 npm run release:check`
- `npm run licenses:check`
- `npm run test:frontend`
- `npm run check`
- `npm run build`
- `cargo test --workspace` — 413 tests passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- signed macOS app and ARM64 DMG verified with Developer ID Team `7C6WF6GFZ4`
- hardened runtime, `ai.gille.sagascript` version/build 1.0.1, and audio-input entitlement verified
- signed-candidate settings watcher and hotkey re-registration smoke passed

Fable review is waived for this release as explicitly approved by Magnus. Native Codex review remains required before merge.