### PR TITLE
fix file transcription coverage diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arboard",
  "block",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arboard",
  "clap",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -7,10 +7,16 @@ use indicatif::{ProgressBar, ProgressStyle};
 use sagascript_core::audio::decoder::decode_audio_file;
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{Language, WhisperModel};
+use sagascript_core::transcription::diagnostics::{
+    CoverageDiagnostics, LanguageDetection, TranscriptionWarning, analyze_coverage,
+    language_mismatch_warning,
+};
 use sagascript_core::transcription::model;
 use sagascript_core::transcription::{
     TranscribeOptions, WhisperBackend, normalize_nonspeech_markers,
 };
+#[cfg(feature = "diarization")]
+use sagascript_core::transcription::TranscriptSegment;
 
 #[derive(Args)]
 pub struct TranscribeArgs {
@@ -26,8 +32,8 @@ pub struct TranscribeArgs {
     pub model: Option<String>,
 
     /// Output result as JSON: text, language, model, duration, and a
-    /// `segments` array with per-segment timing and confidence
-    /// (avg_logprob, no_speech_prob) for flagging low-confidence spans.
+    /// `segments` array with per-segment timing/confidence plus
+    /// `coverage_ratio`, `uncovered_spans`, detected language, and warnings.
     #[arg(long)]
     pub json: bool,
 
@@ -110,6 +116,13 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     eprintln!("Loading model: {}...", model.display_name());
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
+    let detected_language = match detect_file_language(&backend, &audio, model) {
+        Ok(detection) => detection,
+        Err(error) => {
+            eprintln!("Warning: local language detection was unavailable: {error}");
+            None
+        }
+    };
 
     // Effective hint/prompt: --prompt-file, else --hint/--prompt, else the saved
     // initial_prompt. Used by both the diarized and standard paths.
@@ -180,6 +193,19 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         for segment in &mut consolidated {
             segment.text = normalize_nonspeech_markers(&segment.text, language);
         }
+        let diagnostic_segments: Vec<TranscriptSegment> = consolidated
+            .iter()
+            .map(|segment| TranscriptSegment {
+                start: segment.start,
+                end: segment.end,
+                text: segment.text.clone(),
+                avg_logprob: None,
+                no_speech_prob: 0.0,
+            })
+            .collect();
+        let coverage = analyze_coverage(&audio, &diagnostic_segments);
+        let warnings = combined_warnings(&coverage, language, detected_language.as_ref());
+        emit_warnings(&warnings);
 
         if args.json {
             let speakers: Vec<String> = {
@@ -193,6 +219,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
                 "model": model_id_string(model),
                 "file": args.file.display().to_string(),
                 "duration_seconds": duration,
+                "coverage_ratio": coverage.coverage_ratio,
+                "uncovered_spans": coverage.uncovered_spans,
+                "detected_language": detected_language,
+                "warnings": warnings,
             });
             println!("{}", serde_json::to_string_pretty(&json).unwrap());
         } else {
@@ -244,7 +274,9 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         }),
         temperature_fallback: stored.temperature_fallback,
         vad_model_path,
-        segment_timestamps: args.json,
+        // Coverage diagnostics need real segment bounds for both human and
+        // JSON output. Text decoding remains in no-timestamps mode.
+        segment_timestamps: true,
     };
     if opts.beam_size >= 2 {
         eprintln!("Beam search: width {}", opts.beam_size);
@@ -282,6 +314,9 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         .trim()
         .to_string();
     let text = normalize_nonspeech_markers(&raw_text, language);
+    let coverage = analyze_coverage(&audio, &segments);
+    let warnings = combined_warnings(&coverage, language, detected_language.as_ref());
+    emit_warnings(&warnings);
 
     // Output
     if args.json {
@@ -309,6 +344,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             "model": model_id_string(model),
             "file": args.file.display().to_string(),
             "duration_seconds": duration,
+            "coverage_ratio": coverage.coverage_ratio,
+            "uncovered_spans": coverage.uncovered_spans,
+            "detected_language": detected_language,
+            "warnings": warnings,
         });
         println!("{}", serde_json::to_string_pretty(&json).unwrap());
     } else {
@@ -322,6 +361,109 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     }
 
     Ok(())
+}
+
+fn combined_warnings(
+    coverage: &CoverageDiagnostics,
+    configured_language: Language,
+    detected_language: Option<&LanguageDetection>,
+) -> Vec<TranscriptionWarning> {
+    let mut warnings = coverage.warnings.clone();
+    if let Some(detected) = detected_language {
+        if let Some(warning) = language_mismatch_warning(configured_language, detected) {
+            warnings.push(warning);
+        }
+    }
+    warnings
+}
+
+fn emit_warnings(warnings: &[TranscriptionWarning]) {
+    for warning in warnings {
+        eprintln!("Warning [{}]: {}", warning.code, warning.message);
+    }
+}
+
+fn detect_file_language(
+    transcription_backend: &WhisperBackend,
+    audio: &[f32],
+    transcription_model: WhisperModel,
+) -> Result<Option<LanguageDetection>, DictationError> {
+    if transcription_model.is_english_only() {
+        return Ok(None);
+    }
+    if !transcription_model.is_language_optimized() {
+        return transcription_backend.detect_language(audio);
+    }
+
+    let Some(detection_model) = neutral_language_detection_model(model::is_model_downloaded)
+    else {
+        eprintln!(
+            "Warning: language mismatch check skipped because no neutral multilingual model is downloaded."
+        );
+        return Ok(None);
+    };
+    eprintln!(
+        "Checking language with neutral model: {}...",
+        detection_model.display_name()
+    );
+    let detection_backend = WhisperBackend::new();
+    detection_backend.load_model(detection_model)?;
+    let initial_detection = detection_backend.detect_language(audio)?;
+    let Some(initial) = initial_detection else {
+        return Ok(None);
+    };
+    if initial.probability >= 0.90 {
+        return Ok(Some(initial));
+    }
+
+    // Release the cheap detector before loading the larger fallback. The
+    // transcription backend is still resident, so keeping both detection
+    // contexts alive here would needlessly increase peak memory.
+    drop(detection_backend);
+
+    let Some(accurate_model) =
+        accurate_language_detection_model(model::is_model_downloaded, detection_model)
+    else {
+        return Ok(Some(initial));
+    };
+    eprintln!(
+        "Language check was uncertain ({} p={:.3}); verifying with {}...",
+        initial.language,
+        initial.probability,
+        accurate_model.display_name()
+    );
+    let accurate_backend = WhisperBackend::new();
+    accurate_backend.load_model(accurate_model)?;
+    accurate_backend.detect_language(audio)
+}
+
+fn neutral_language_detection_model(
+    is_downloaded: impl Fn(WhisperModel) -> bool,
+) -> Option<WhisperModel> {
+    // Start with a small neutral model so the common, confident case stays
+    // cheap. An uncertain result is escalated below.
+    [
+        WhisperModel::Base,
+        WhisperModel::Tiny,
+        WhisperModel::Small,
+        WhisperModel::Medium,
+        WhisperModel::LargeV3TurboQ8,
+        WhisperModel::LargeV3Turbo,
+    ]
+    .into_iter()
+    .find(|&candidate| is_downloaded(candidate))
+}
+
+fn accurate_language_detection_model(
+    is_downloaded: impl Fn(WhisperModel) -> bool,
+    exclude: WhisperModel,
+) -> Option<WhisperModel> {
+    // Older Whisper language classifiers can confuse accented English with
+    // Swedish. Large v3 Turbo is used only when the cheap detector is below
+    // the strong-confidence threshold.
+    [WhisperModel::LargeV3TurboQ8, WhisperModel::LargeV3Turbo]
+        .into_iter()
+        .find(|&candidate| candidate != exclude && is_downloaded(candidate))
 }
 
 /// Validates a `--diarize-threshold` value: must parse as a finite f32 in the
@@ -732,6 +874,38 @@ mod tests {
         assert!(
             resolve_effective_model(Some("bogus"), Language::Auto, true, WhisperModel::Base)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn neutral_language_detector_prefers_downloaded_base() {
+        let selected = neutral_language_detection_model(|model| {
+            matches!(model, WhisperModel::Base | WhisperModel::Tiny)
+        });
+        assert_eq!(selected, Some(WhisperModel::Base));
+    }
+
+    #[test]
+    fn neutral_language_detector_falls_back_and_can_be_unavailable() {
+        let selected =
+            neutral_language_detection_model(|model| model == WhisperModel::LargeV3Turbo);
+        assert_eq!(selected, Some(WhisperModel::LargeV3Turbo));
+        assert_eq!(neutral_language_detection_model(|_| false), None);
+    }
+
+    #[test]
+    fn uncertain_language_detector_escalates_to_downloaded_turbo() {
+        let selected = accurate_language_detection_model(
+            |model| matches!(model, WhisperModel::LargeV3TurboQ8 | WhisperModel::LargeV3Turbo),
+            WhisperModel::Base,
+        );
+        assert_eq!(selected, Some(WhisperModel::LargeV3TurboQ8));
+        assert_eq!(
+            accurate_language_detection_model(
+                |model| model == WhisperModel::LargeV3Turbo,
+                WhisperModel::LargeV3Turbo,
+            ),
+            None
         );
     }
 }

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -198,6 +198,14 @@ impl WhisperModel {
         )
     }
 
+    /// Fine-tuned language-specific models are intentionally biased toward
+    /// their target language, so they must not be used to independently check
+    /// whether the configured language matches an input file.
+    #[allow(dead_code)]
+    pub fn is_language_optimized(&self) -> bool {
+        self.is_swedish_optimized() || self.is_norwegian_optimized()
+    }
+
     /// GGML model filename
     pub fn ggml_filename(&self) -> &'static str {
         match self {
@@ -575,6 +583,14 @@ mod tests {
         assert!(!WhisperModel::LargeV3Turbo.is_english_only());
         assert!(!WhisperModel::KbWhisperTiny.is_english_only());
         assert!(!WhisperModel::NbWhisperBase.is_english_only());
+    }
+
+    #[test]
+    fn language_optimized_models_are_not_neutral_detectors() {
+        assert!(WhisperModel::KbWhisperSmall.is_language_optimized());
+        assert!(WhisperModel::NbWhisperBase.is_language_optimized());
+        assert!(!WhisperModel::Base.is_language_optimized());
+        assert!(!WhisperModel::MediumEn.is_language_optimized());
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/crates/sagascript-core/src/transcription/diagnostics.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/diagnostics.rs
@@ -1,0 +1,363 @@
+use serde::Serialize;
+
+use crate::settings::Language;
+
+use super::TranscriptSegment;
+
+pub const MATERIAL_GAP_SECONDS: f64 = 5.0;
+const SAMPLE_RATE_HZ: f64 = 16_000.0;
+const FRAME_SAMPLES: usize = 320;
+const MIN_SPEECH_RMS: f64 = 0.0015;
+const MIN_UNCOVERED_SPEECH_SECONDS: f64 = 1.0;
+const MIN_UNCOVERED_SPEECH_RATIO: f64 = 0.10;
+const STRONG_LANGUAGE_PROBABILITY: f32 = 0.90;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct UncoveredSpan {
+    pub start: f64,
+    pub end: f64,
+    pub duration: f64,
+    pub speech_seconds: f64,
+    pub speech_ratio: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TranscriptionWarning {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CoverageDiagnostics {
+    pub coverage_ratio: f64,
+    pub uncovered_spans: Vec<UncoveredSpan>,
+    pub warnings: Vec<TranscriptionWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LanguageDetection {
+    pub language: String,
+    pub probability: f32,
+}
+
+pub fn analyze_coverage(audio: &[f32], segments: &[TranscriptSegment]) -> CoverageDiagnostics {
+    let duration = audio.len() as f64 / SAMPLE_RATE_HZ;
+    let speech_frames = detect_speech_frames(audio);
+    let intervals = merged_segment_intervals(segments, duration);
+
+    let mut total_speech_frames = 0usize;
+    let mut covered_speech_frames = 0usize;
+    for (index, &is_speech) in speech_frames.iter().enumerate() {
+        if !is_speech {
+            continue;
+        }
+        total_speech_frames += 1;
+        let midpoint = (index * FRAME_SAMPLES + FRAME_SAMPLES / 2) as f64 / SAMPLE_RATE_HZ;
+        if intervals
+            .iter()
+            .any(|&(start, end)| midpoint >= start && midpoint < end)
+        {
+            covered_speech_frames += 1;
+        }
+    }
+
+    let coverage_ratio = if total_speech_frames == 0 {
+        1.0
+    } else {
+        covered_speech_frames as f64 / total_speech_frames as f64
+    };
+
+    let mut uncovered_spans = Vec::new();
+    for (start, end) in uncovered_intervals(&intervals, duration) {
+        let gap_duration = end - start;
+        if gap_duration < MATERIAL_GAP_SECONDS {
+            continue;
+        }
+        let speech_frame_count = speech_frames
+            .iter()
+            .enumerate()
+            .filter(|&(index, is_speech)| {
+                if !*is_speech {
+                    return false;
+                }
+                let midpoint = (index * FRAME_SAMPLES + FRAME_SAMPLES / 2) as f64 / SAMPLE_RATE_HZ;
+                midpoint >= start && midpoint < end
+            })
+            .count();
+        let speech_seconds = (speech_frame_count * FRAME_SAMPLES) as f64 / SAMPLE_RATE_HZ;
+        let speech_ratio = if gap_duration > 0.0 {
+            (speech_seconds / gap_duration).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        if speech_seconds >= MIN_UNCOVERED_SPEECH_SECONDS
+            && speech_ratio >= MIN_UNCOVERED_SPEECH_RATIO
+        {
+            uncovered_spans.push(UncoveredSpan {
+                start,
+                end,
+                duration: gap_duration,
+                speech_seconds,
+                speech_ratio,
+            });
+        }
+    }
+
+    let warnings = uncovered_spans
+        .iter()
+        .map(|span| TranscriptionWarning {
+            code: "uncovered_speech".to_string(),
+            message: format!(
+                "Transcript has no segment from {:.2}s to {:.2}s ({:.2}s), but {:.2}s of that span appears to contain speech.",
+                span.start, span.end, span.duration, span.speech_seconds
+            ),
+            start: Some(span.start),
+            end: Some(span.end),
+        })
+        .collect();
+
+    CoverageDiagnostics {
+        coverage_ratio,
+        uncovered_spans,
+        warnings,
+    }
+}
+
+pub fn language_mismatch_warning(
+    configured: Language,
+    detected: &LanguageDetection,
+) -> Option<TranscriptionWarning> {
+    let configured_code = configured.whisper_code()?;
+    if detected.probability < STRONG_LANGUAGE_PROBABILITY
+        || detected.language.eq_ignore_ascii_case(configured_code)
+    {
+        return None;
+    }
+
+    let detected_name = language_name(&detected.language);
+    let recommendation = match detected.language.as_str() {
+        "en" | "sv" | "no" => format!("--language {}", detected.language),
+        _ => "--language auto".to_string(),
+    };
+    Some(TranscriptionWarning {
+        code: "language_mismatch".to_string(),
+        message: format!(
+            "Configured language is {} (`{configured_code}`), but the audio strongly appears to be {detected_name} (`{}`, p={:.3}). Re-run with `{recommendation}`; the saved setting was not changed.",
+            configured.display_name(),
+            detected.language,
+            detected.probability
+        ),
+        start: None,
+        end: None,
+    })
+}
+
+fn detect_speech_frames(audio: &[f32]) -> Vec<bool> {
+    let rms_values: Vec<f64> = audio
+        .chunks(FRAME_SAMPLES)
+        .map(|frame| {
+            let mean_square = frame
+                .iter()
+                .map(|&sample| f64::from(sample) * f64::from(sample))
+                .sum::<f64>()
+                / frame.len().max(1) as f64;
+            mean_square.sqrt()
+        })
+        .collect();
+    if rms_values.is_empty() {
+        return Vec::new();
+    }
+
+    let mut sorted = rms_values.clone();
+    sorted.sort_by(f64::total_cmp);
+    let low = percentile(&sorted, 0.10);
+    let high = percentile(&sorted, 0.90);
+    if high < MIN_SPEECH_RMS {
+        return vec![false; rms_values.len()];
+    }
+
+    let dynamic_range = (high - low).max(0.0);
+    let threshold = if dynamic_range >= MIN_SPEECH_RMS {
+        low + dynamic_range * 0.25
+    } else {
+        high * 0.5
+    }
+    .max(high * 0.15)
+    .max(MIN_SPEECH_RMS);
+
+    rms_values.into_iter().map(|rms| rms >= threshold).collect()
+}
+
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    let index = ((sorted.len() - 1) as f64 * fraction).round() as usize;
+    sorted[index]
+}
+
+fn merged_segment_intervals(segments: &[TranscriptSegment], duration: f64) -> Vec<(f64, f64)> {
+    let mut intervals: Vec<(f64, f64)> = segments
+        .iter()
+        .filter_map(|segment| {
+            if !segment.start.is_finite() || !segment.end.is_finite() {
+                return None;
+            }
+            let start = segment.start.clamp(0.0, duration);
+            let end = segment.end.clamp(start, duration);
+            (end > start).then_some((start, end))
+        })
+        .collect();
+    intervals.sort_by(|left, right| left.0.total_cmp(&right.0));
+
+    let mut merged: Vec<(f64, f64)> = Vec::with_capacity(intervals.len());
+    for (start, end) in intervals {
+        if let Some(last) = merged.last_mut() {
+            if start <= last.1 {
+                last.1 = last.1.max(end);
+                continue;
+            }
+        }
+        merged.push((start, end));
+    }
+    merged
+}
+
+fn uncovered_intervals(intervals: &[(f64, f64)], duration: f64) -> Vec<(f64, f64)> {
+    let mut gaps = Vec::new();
+    let mut cursor = 0.0;
+    for &(start, end) in intervals {
+        if start > cursor {
+            gaps.push((cursor, start));
+        }
+        cursor = cursor.max(end);
+    }
+    if cursor < duration {
+        gaps.push((cursor, duration));
+    }
+    gaps
+}
+
+fn language_name(code: &str) -> &str {
+    match code {
+        "en" => "English",
+        "sv" => "Swedish",
+        "no" => "Norwegian",
+        _ => code,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_RATE: usize = 16_000;
+
+    fn segment(start: f64, end: f64) -> TranscriptSegment {
+        TranscriptSegment {
+            start,
+            end,
+            text: " speech".to_string(),
+            avg_logprob: Some(-0.1),
+            no_speech_prob: 0.0,
+        }
+    }
+
+    fn voiced_audio(duration: f64, voiced_spans: &[(f64, f64)]) -> Vec<f32> {
+        let sample_count = (duration * SAMPLE_RATE as f64) as usize;
+        (0..sample_count)
+            .map(|index| {
+                let seconds = index as f64 / SAMPLE_RATE as f64;
+                if voiced_spans
+                    .iter()
+                    .any(|&(start, end)| seconds >= start && seconds < end)
+                {
+                    let phase = seconds * 220.0 * std::f64::consts::TAU;
+                    (phase.sin() * 0.1) as f32
+                } else {
+                    0.0
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn reports_material_uncovered_speech_across_whisper_windows() {
+        let audio = voiced_audio(70.0, &[(0.0, 70.0)]);
+        let diagnostics = analyze_coverage(&audio, &[segment(0.0, 25.0), segment(55.0, 70.0)]);
+
+        assert_eq!(diagnostics.uncovered_spans.len(), 1);
+        let gap = &diagnostics.uncovered_spans[0];
+        assert_eq!((gap.start, gap.end, gap.duration), (25.0, 55.0, 30.0));
+        assert!(gap.speech_ratio > 0.9);
+        assert!(diagnostics.coverage_ratio < 0.6);
+        assert_eq!(diagnostics.warnings[0].code, "uncovered_speech");
+    }
+
+    #[test]
+    fn ignores_material_timestamp_gap_that_is_silent() {
+        let audio = voiced_audio(20.0, &[(0.0, 6.0), (14.0, 20.0)]);
+        let diagnostics = analyze_coverage(&audio, &[segment(0.0, 6.0), segment(14.0, 20.0)]);
+
+        assert!(diagnostics.uncovered_spans.is_empty());
+        assert!(diagnostics.warnings.is_empty());
+        assert!(diagnostics.coverage_ratio > 0.99);
+    }
+
+    #[test]
+    fn does_not_warn_for_short_uncovered_speech() {
+        let audio = voiced_audio(12.0, &[(0.0, 12.0)]);
+        let diagnostics = analyze_coverage(&audio, &[segment(0.0, 4.0), segment(7.0, 12.0)]);
+
+        assert!(diagnostics.uncovered_spans.is_empty());
+        assert!(diagnostics.warnings.is_empty());
+        assert!(diagnostics.coverage_ratio < 0.8);
+    }
+
+    #[test]
+    fn reports_all_speech_missing_when_no_segments_exist() {
+        let audio = voiced_audio(8.0, &[(0.0, 8.0)]);
+        let diagnostics = analyze_coverage(&audio, &[]);
+
+        assert_eq!(diagnostics.uncovered_spans.len(), 1);
+        assert_eq!(diagnostics.uncovered_spans[0].duration, 8.0);
+        assert_eq!(diagnostics.coverage_ratio, 0.0);
+    }
+
+    #[test]
+    fn strong_supported_language_mismatch_is_actionable() {
+        let warning = language_mismatch_warning(
+            Language::Swedish,
+            &LanguageDetection {
+                language: "en".to_string(),
+                probability: 0.995,
+            },
+        )
+        .expect("strong mismatch should warn");
+
+        assert_eq!(warning.code, "language_mismatch");
+        assert!(warning.message.contains("--language en"));
+        assert!(warning.message.contains("Swedish"));
+    }
+
+    #[test]
+    fn weak_or_matching_language_detection_does_not_warn() {
+        assert!(language_mismatch_warning(
+            Language::Swedish,
+            &LanguageDetection {
+                language: "en".to_string(),
+                probability: 0.70,
+            },
+        )
+        .is_none());
+        assert!(language_mismatch_warning(
+            Language::English,
+            &LanguageDetection {
+                language: "en".to_string(),
+                probability: 0.999,
+            },
+        )
+        .is_none());
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/transcription/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/mod.rs
@@ -1,3 +1,4 @@
+pub mod diagnostics;
 pub mod model;
 mod postprocess;
 pub mod whisper_backend;

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -6,13 +6,14 @@ use std::time::{Duration, Instant};
 use tracing::{info, warn};
 use whisper_rs::{
     FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
-    WhisperVadParams,
+    WhisperVadParams, get_lang_str,
 };
 #[cfg(feature = "diarization")]
 use whisper_rs::{DtwMode, DtwParameters};
 
 use crate::error::DictationError;
 use crate::settings::{Language, WhisperModel};
+use crate::transcription::diagnostics::LanguageDetection;
 use crate::transcription::model;
 
 /// Default beam width for file (non-live) transcription. File transcription
@@ -174,6 +175,62 @@ impl WhisperBackend {
             abort_flag: Arc::new(AtomicBool::new(false)),
             load_lock: Mutex::new(()),
         }
+    }
+
+    /// Run Whisper's local language classifier on a bounded, speech-rich
+    /// preview of the decoded audio. English-only models cannot classify
+    /// languages and return `Ok(None)`.
+    ///
+    /// The preview is capped at 30 seconds and chosen from the first five
+    /// minutes by RMS energy. This keeps the check cheap while avoiding a
+    /// silent intro when the recording starts later.
+    pub fn detect_language(
+        &self,
+        audio: &[f32],
+    ) -> Result<Option<LanguageDetection>, DictationError> {
+        if audio.is_empty() {
+            return Err(DictationError::NoAudioCaptured);
+        }
+
+        let is_multilingual = {
+            let guard = self.context.lock().unwrap();
+            guard
+                .as_ref()
+                .ok_or(DictationError::ModelNotLoaded)?
+                .is_multilingual()
+        };
+        if !is_multilingual {
+            return Ok(None);
+        }
+
+        let preview = language_detection_preview(audio);
+        let n_threads = whisper_threads().max(1) as usize;
+        self.with_warm_state(|state| {
+            state.pcm_to_mel(preview, n_threads).map_err(|error| {
+                DictationError::TranscriptionFailed(format!(
+                    "Language detection spectrogram failed: {error}"
+                ))
+            })?;
+            let (language_id, probabilities) =
+                state.lang_detect(0, n_threads).map_err(|error| {
+                    DictationError::TranscriptionFailed(format!(
+                        "Language detection failed: {error}"
+                    ))
+                })?;
+            let language = get_lang_str(language_id).ok_or_else(|| {
+                DictationError::TranscriptionFailed(format!(
+                    "Language detection returned unknown language id {language_id}"
+                ))
+            })?;
+            let probability = probabilities
+                .get(language_id as usize)
+                .copied()
+                .unwrap_or_default();
+            Ok(Some(LanguageDetection {
+                language: language.to_string(),
+                probability,
+            }))
+        })
     }
 
     /// Signal any in-progress inference to abort at the next whisper.cpp compute
@@ -891,6 +948,61 @@ impl WhisperBackend {
 
             Ok(results)
         })
+    }
+}
+
+/// Choose at most 30 seconds from the first five minutes for language
+/// detection, preferring the non-overlapping window with the highest RMS
+/// energy. Scanning non-overlapping windows keeps this linear in the bounded
+/// prefix and is sufficient to skip long silent intros.
+fn language_detection_preview(audio: &[f32]) -> &[f32] {
+    const PREVIEW_SAMPLES: usize = 30 * 16_000;
+    const SCAN_SAMPLES: usize = 5 * 60 * 16_000;
+
+    if audio.len() <= PREVIEW_SAMPLES {
+        return audio;
+    }
+
+    let scan_end = audio.len().min(SCAN_SAMPLES);
+    let mut best_start = 0usize;
+    let mut best_mean_square = f64::NEG_INFINITY;
+    for start in (0..scan_end).step_by(PREVIEW_SAMPLES) {
+        let end = (start + PREVIEW_SAMPLES).min(scan_end);
+        let window = &audio[start..end];
+        let mean_square = window
+            .iter()
+            .map(|&sample| f64::from(sample) * f64::from(sample))
+            .sum::<f64>()
+            / window.len().max(1) as f64;
+        if mean_square > best_mean_square {
+            best_mean_square = mean_square;
+            best_start = start;
+        }
+    }
+    let best_end = (best_start + PREVIEW_SAMPLES).min(audio.len());
+    &audio[best_start..best_end]
+}
+
+#[cfg(test)]
+mod language_detection_preview_tests {
+    use super::language_detection_preview;
+
+    #[test]
+    fn keeps_short_audio_intact() {
+        let audio = vec![0.1; 16_000];
+        assert_eq!(language_detection_preview(&audio).len(), audio.len());
+    }
+
+    #[test]
+    fn chooses_loudest_thirty_second_window() {
+        let window = 30 * 16_000;
+        let mut audio = vec![0.001; window * 3];
+        audio[window..window * 2].fill(0.1);
+
+        let preview = language_detection_preview(&audio);
+
+        assert_eq!(preview.len(), window);
+        assert!(preview.iter().all(|&sample| sample == 0.1));
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- detect material timestamp gaps that contain likely speech and expose structured local diagnostics in CLI JSON
- distinguish speech-bearing omissions from genuine silence with an adaptive 20 ms RMS analysis
- detect strong configured/detected language mismatches locally and print an actionable override without changing saved settings
- keep the existing transcript/segment JSON contract while adding `coverage_ratio`, `uncovered_spans`, `detected_language`, and `warnings`
- bump the patch release to 1.0.2

## Private regression fixture

Validated against the 4m46 English Voice Memo supplied for #105 without playing it and without committing its audio or transcript:

- `large-v3-turbo` reports the exact uncovered span `123.16–164.92s` (41.76s), with 24.00s classified as likely speech
- the saved Swedish configuration is identified as an English mismatch at p=0.999 and recommends `--language en`
- `medium.en` remains warning-free with coverage 0.9773
- the patched `medium.en` top-level transcript is byte-for-byte identical to v1.0.1

## Verification

- `cargo test --workspace` — 425 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build -p sagascript-cli --no-default-features`
- `cargo clippy -p sagascript-cli --no-default-features --all-targets -- -D warnings`
- `npx svelte-check --tsconfig ./tsconfig.json`
- `npm run build`
- `npm run test:frontend` — 9 passed
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm run licenses:check`
- `npm run release:check`
- independent M5 review (`qwen3-coder-next-80b`); one validated peak-memory finding fixed and rechecked

Closes #105