### PR TITLE
Refresh notices and prepare v1.0.4

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -566,7 +566,6 @@ link; the upstream repository is authoritative for its license terms.
 | @tauri-apps/cli-win32-x64-msvc | 2.10.0 | Apache-2.0 OR MIT | [upstream](https://www.npmjs.com/package/@tauri-apps/cli-win32-x64-msvc/v/2.10.0) |
 | @tauri-apps/plugin-autostart | 2.5.1 | MIT OR Apache-2.0 | [upstream](https://www.npmjs.com/package/@tauri-apps/plugin-autostart/v/2.5.1) |
 | @tauri-apps/plugin-dialog | 2.6.0 | MIT OR Apache-2.0 | [upstream](https://www.npmjs.com/package/@tauri-apps/plugin-dialog/v/2.6.0) |
-| @tauri-apps/plugin-global-shortcut | 2.3.1 | MIT OR Apache-2.0 | [upstream](https://www.npmjs.com/package/@tauri-apps/plugin-global-shortcut/v/2.3.1) |
 | @tsconfig/svelte | 5.0.8 | MIT | [upstream](https://www.npmjs.com/package/@tsconfig/svelte/v/5.0.8) |
 | @types/estree | 1.0.9 | MIT | [upstream](https://www.npmjs.com/package/@types/estree/v/1.0.9) |
 | @types/trusted-types | 2.0.7 | MIT | [upstream](https://www.npmjs.com/package/@types/trusted-types/v/2.0.7) |
@@ -19229,7 +19228,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 
 ### eb8a6c846304
 
-Components: Rust tauri-plugin-autostart@2.5.1, Rust tauri-plugin-dialog@2.6.0, Rust tauri-plugin-fs@2.4.5, Rust tauri-plugin-global-shortcut@2.3.1, npm @tauri-apps/plugin-autostart@2.5.1, npm @tauri-apps/plugin-dialog@2.6.0, npm @tauri-apps/plugin-global-shortcut@2.3.1
+Components: Rust tauri-plugin-autostart@2.5.1, Rust tauri-plugin-dialog@2.6.0, Rust tauri-plugin-fs@2.4.5, Rust tauri-plugin-global-shortcut@2.3.1, npm @tauri-apps/plugin-autostart@2.5.1, npm @tauri-apps/plugin-dialog@2.6.0
 
 Source filenames: LICENSE.spdx
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "arboard",
  "block",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "arboard",
  "clap",
@@ -4096,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- refresh generated third-party notices after removing the frontend global-shortcut package
- advance synchronized release metadata to v1.0.4
- preserve the already-pushed failed v1.0.3 tag instead of rewriting release history

## Verification

- npm run licenses:check
- RELEASE_TAG=v1.0.4 npm run release:check
- git diff --check

The v1.0.3 release workflow stopped at the notice gate before signing or publishing any artifact. This clean branch contains only the six release-metadata/notice files.