### PR TITLE
fix: reject Command-X as a macOS hotkey

### DIFF
--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -425,6 +425,18 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn validate_hotkey_rejects_macos_cut_shortcut_before_settings_mutation() {
+        let mut settings = Settings::default();
+        let original = settings.hotkey.clone();
+
+        let error = apply_setting_value(&mut settings, "hotkey", "Super+X").unwrap_err();
+
+        assert!(error.to_string().contains("reserved for Cut on macOS"));
+        assert_eq!(settings.hotkey, original);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn reserved_hotkey_is_rejected_before_settings_mutation() {
         let mut settings = Settings::default();
         let original = settings.hotkey.clone();

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -388,7 +388,7 @@ mod tests {
             "Command+A",
             "CmdOrCtrl+Space",
             "Ctrl+Shift+Alt+F1",
-            "Super+KeyX",
+            "Super+Shift+KeyX",
             "Shift+Enter",
             "Control+Tab",
             "CommandOrControl+Z",

--- a/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
@@ -307,10 +307,16 @@ fn validate_hotkey_for_platform(value: &str, platform: HotkeyPlatform) -> Result
         )
     });
 
-    if platform == HotkeyPlatform::MacOS && uses_command {
+    if platform == HotkeyPlatform::MacOS {
         let reserved_shortcut = match key.as_str() {
-            "q" | "keyq" => Some(("Q", "Quit")),
-            "x" | "keyx" => Some(("X", "Cut")),
+            // Keep the existing stricter Quit guard: any shortcut containing a
+            // Command alias and Q is unsafe to expose as a global hotkey.
+            "q" | "keyq" if uses_command => Some(("Q", "Quit")),
+            // Cut is only Command+X itself. Modified variants such as
+            // Command+Shift+X are distinct macOS shortcuts and remain valid.
+            "x" | "keyx" if uses_command && modifier_tokens.len() == 1 => {
+                Some(("X", "Cut"))
+            }
             _ => None,
         };
         if let Some((key, action)) = reserved_shortcut {
@@ -355,7 +361,6 @@ mod tests {
             "Super+X",
             "CmdOrCtrl+X",
             "CommandOrControl+x",
-            "Control+Super+X",
             "  cOmMaNd + keyX  ",
         ] {
             let error = validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).unwrap_err();
@@ -374,6 +379,7 @@ mod tests {
             "Command+A",
             "Super+Shift+X",
             "Command+Shift+X",
+            "Control+Super+X",
         ] {
             assert!(
                 validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).is_ok(),

--- a/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
@@ -294,25 +294,31 @@ fn validate_hotkey_for_platform(value: &str, platform: HotkeyPlatform) -> Result
         ));
     }
 
-    if platform == HotkeyPlatform::MacOS
-        && matches!(key.as_str(), "q" | "keyq")
-        && modifier_tokens.iter().any(|token| {
-            matches!(
-                token.to_lowercase().as_str(),
-                "super"
-                    | "command"
-                    | "cmd"
-                    | "commandorcontrol"
-                    | "commandorctrl"
-                    | "cmdorctrl"
-                    | "cmdorcontrol"
-            )
-        })
-    {
-        return Err(format!(
-            "Invalid hotkey '{value}': Command+Q is reserved for Quit on macOS. \
-             Choose a different shortcut, such as 'Control+Shift+Space'."
-        ));
+    let uses_command = modifier_tokens.iter().any(|token| {
+        matches!(
+            token.to_lowercase().as_str(),
+            "super"
+                | "command"
+                | "cmd"
+                | "commandorcontrol"
+                | "commandorctrl"
+                | "cmdorctrl"
+                | "cmdorcontrol"
+        )
+    });
+
+    if platform == HotkeyPlatform::MacOS && uses_command {
+        let reserved_shortcut = match key.as_str() {
+            "q" | "keyq" => Some(("Q", "Quit")),
+            "x" | "keyx" => Some(("X", "Cut")),
+            _ => None,
+        };
+        if let Some((key, action)) = reserved_shortcut {
+            return Err(format!(
+                "Invalid hotkey '{value}': Command+{key} is reserved for {action} on macOS. \
+                 Choose a different shortcut, such as 'Control+Shift+Space'."
+            ));
+        }
     }
 
     Ok(())
@@ -342,8 +348,33 @@ mod tests {
     }
 
     #[test]
+    fn macos_cut_shortcut_is_reserved_for_every_command_alias() {
+        for shortcut in [
+            "Command+X",
+            "Cmd+KeyX",
+            "Super+X",
+            "CmdOrCtrl+X",
+            "CommandOrControl+x",
+            "Control+Super+X",
+            "  cOmMaNd + keyX  ",
+        ] {
+            let error = validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).unwrap_err();
+            assert!(
+                error.contains("reserved for Cut on macOS"),
+                "unexpected error for {shortcut}: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn macos_non_quit_shortcuts_remain_valid() {
-        for shortcut in ["Control+Q", "Shift+Q", "Command+A", "Super+Shift+X"] {
+        for shortcut in [
+            "Control+Q",
+            "Shift+Q",
+            "Command+A",
+            "Super+Shift+X",
+            "Command+Shift+X",
+        ] {
             assert!(
                 validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).is_ok(),
                 "should remain valid: {shortcut}"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1301,6 +1301,17 @@ mod tests {
             .is_some_and(|message| message.contains("reserved for Quit on macOS")));
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn startup_replaces_saved_cut_hotkey_with_safe_operational_fallback() {
+        let (candidate, error) = startup_hotkey_candidate("Super+X");
+
+        assert_eq!(candidate, sagascript_core::settings::Settings::default().hotkey);
+        assert!(error
+            .as_deref()
+            .is_some_and(|message| message.contains("reserved for Cut on macOS")));
+    }
+
     // -- tray_label --
 
     #[test]


### PR DESCRIPTION
## Summary

Rejects Command-X as a global dictation hotkey on macOS, preserving the platform Cut shortcut.

## Root cause

The shared validator reserved only Command-Q. It accepted Command/Super aliases paired with X, allowing a global hotkey to conflict with Cut in other applications.

## Changes

- Extend the shared macOS reserved-shortcut policy to exact Command-X aliases.
- Keep modified shortcuts such as Command-Shift-X valid.
- Verify the CLI rejects the invalid value before mutating settings.
- Verify startup falls back safely when an old saved Super-X setting is encountered.

## Verification

- Core validator regression test passes.
- CLI settings regression test passes.
- Native Codex review and independent Qwen review found no blockers.
- The local Tauri binary test target requires a generated `dist` directory, which is absent in this worktree; GitHub's macOS CI remains the integration check.

Closes #111
