### PR TITLE
ci: speed up native PR feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,18 @@ jobs:
       - name: Svelte check
         run: npx svelte-check --tsconfig ./tsconfig.json
 
-      - name: Build Tauri app
-        run: npx tauri build
+      # PR validation needs the native release binary for the smoke tests, not
+      # an installer. Full packaging, signing and notarization remain gated in
+      # release.yml, so skipping bundling here removes duplicate work without
+      # weakening native macOS coverage.
+      - name: Build native release binary (no installer)
+        run: npx tauri build --no-bundle
+
+      - name: Verify native release binary
+        run: |
+          BINARY=src-tauri/target/release/sagascript
+          [[ -x "$BINARY" ]]
+          file "$BINARY"
 
       # --- Tier 1: CLI smoke tests (no model needed) ---
 
@@ -331,8 +341,19 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
 
-      - name: Build Tauri app
-        run: npx tauri build
+      # PR validation needs the native release binary for the smoke tests, not
+      # an installer. Full packaging, signing and notarization remain gated in
+      # release.yml, so skipping bundling here removes duplicate work without
+      # weakening native Windows coverage.
+      - name: Build native release binary (no installer)
+        run: npx tauri build --no-bundle
+
+      - name: Verify native release binary
+        run: |
+          $binary = "src-tauri\target\release\sagascript.exe"
+          if (-not (Test-Path -PathType Leaf $binary)) {
+            throw "Missing native release binary: $binary"
+          }
 
       # --- CLI smoke tests (Windows / PowerShell) ---
 

--- a/docs/ci-performance.md
+++ b/docs/ci-performance.md
@@ -1,0 +1,33 @@
+# Native CI performance
+
+PR CI builds the native Tauri release binary on macOS and Windows, then runs
+platform-native CLI smoke tests against it. It intentionally does **not**
+produce installers on pull requests: bundling, signing, notarization, and
+artifact verification belong to the tagged release workflow.
+
+## Baseline and target
+
+The fully green run for PR #121 (2026-08-12) established this baseline:
+
+| Platform | Total | Cargo cache restore | Tauri build + bundle |
+| --- | ---: | ---: | ---: |
+| macOS | 4m 41s | 50s | 2m 12s |
+| Windows | 9m 30s | 1m 47s | 5m 08s |
+
+The dominant repeatable cost was installer bundling in PR CI. `npx tauri build
+--no-bundle` retains the native release binary while omitting that release-only
+work. The next green PR run is the after measurement; GitHub Actions exposes
+the step durations directly.
+
+## Coverage map
+
+| Check | macOS PR CI | Windows PR CI | Tagged release workflow |
+| --- | --- | --- | --- |
+| Native release binary | yes | yes | yes |
+| Native CLI smoke tests | yes | yes | macOS installed-app smoke |
+| Model-backed transcription smoke | yes | best-effort | yes |
+| Installer/app bundle | no | no | macOS app + DMG |
+| Signing/notarization/artifact verification | no | no | yes |
+
+This split keeps fast feedback focused on code and platform behavior while the
+release workflow remains the sole authority for distributable artifacts.


### PR DESCRIPTION
Closes #122

## Why

The fully green run for PR #121 took 4m 41s on macOS and 9m 30s on Windows.
The dominant repeatable cost was installer bundling: 2m 12s on macOS and 5m 08s
on Windows. PR validation only consumes the native release executable, while
the tagged release workflow owns installer generation, signing, notarization,
and artifact verification.

## Change

- Run `npx tauri build --no-bundle` in the macOS and Windows PR jobs.
- Assert that the expected native release executable was produced before the
  platform smoke tests run.
- Document the baseline, intended measurement method, and coverage split in
  `docs/ci-performance.md`.

## Coverage retained

- Native release binaries and existing platform smoke tests remain in PR CI.
- macOS model-backed transcription smoke remains mandatory.
- Release builds retain full bundles, signing, notarization, and artifact
  verification.

## Verification

- Parsed both GitHub workflow YAML files.
- Checked the PR workflow uses `--no-bundle` for both native jobs and that the
  release workflow still uses its full bundle build.
- Ran `git diff --check`.
- Independent M5 review: approved.
