### PR TITLE
fix(cli): bound native diagnostics for JSON output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,11 @@ jobs:
       - name: Smoke test — transcribe with JSON output
         run: |
           BINARY=src-tauri/target/release/sagascript
-          RESULT=$($BINARY transcribe --json --language no --model nb-whisper-tiny test-audio/norwegian-short-3s.mp3)
-          echo "JSON: $RESULT"
-          echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['text']; assert d['language']=='no'; assert d['duration_seconds']>0"
+          STDOUT="$RUNNER_TEMP/transcription-smoke.json"
+          STDERR="$RUNNER_TEMP/transcription-smoke.stderr"
+          $BINARY transcribe --json --language no --model nb-whisper-tiny \
+            test-audio/norwegian-short-3s.mp3 > "$STDOUT" 2> "$STDERR"
+          python3 scripts/verify-json-cli-streams.py "$STDOUT" "$STDERR"
 
   check-linux:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,17 @@ jobs:
       - name: Gate real transcription
         run: |
           binary=src-tauri/target/release/sagascript
+          stdout="$RUNNER_TEMP/transcription-smoke.json"
+          stderr="$RUNNER_TEMP/transcription-smoke.stderr"
           "$binary" download-model nb-whisper-tiny
           "$binary" transcribe \
             --language no \
             --model nb-whisper-tiny \
             --beam 0 \
             --json \
-            test-audio/norwegian-short-3s.mp3 > "$RUNNER_TEMP/transcription-smoke.json"
-          python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert "storting" in d["text"].lower(); assert d["language"] == "no"; assert d["segments"]' "$RUNNER_TEMP/transcription-smoke.json"
+            test-audio/norwegian-short-3s.mp3 > "$stdout" 2> "$stderr"
+          python3 scripts/verify-json-cli-streams.py "$stdout" "$stderr"
+          python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert "storting" in d["text"].lower(); assert d["language"] == "no"; assert d["segments"]' "$stdout"
 
       - name: Gate real two-speaker diarization
         run: |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ sagascript manpages --dir /usr/local/share/man/man1
 
 Run `sagascript --help` for the full list of commands.
 
+Default CLI diagnostics retain Sagascript warnings and errors while suppressing
+routine native Whisper/GGML chatter, so machine-readable stdout (including
+`--json`) remains safe to capture. To opt in to verbose native diagnostics for
+troubleshooting, set an explicit filter, for example
+`RUST_LOG=whisper_rs=info sagascript transcribe recording.mp3`.
+
 ## Permissions
 
 ### macOS

--- a/scripts/verify-json-cli-streams.py
+++ b/scripts/verify-json-cli-streams.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Verify the default machine-readable CLI stream contract."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+MAX_STDERR_BYTES = 64 * 1024
+NATIVE_TRACE_PATTERNS = (
+    re.compile(r"\b0x[0-9a-fA-F]{6,}\b"),
+    re.compile(r"\bggml_metal_(?:init|free)\b"),
+    re.compile(r"\bwhisper_model_load\b"),
+    re.compile(r"\btoken\s*=\s*\d+\b", re.IGNORECASE),
+)
+
+
+def decode_utf8(path: Path) -> tuple[bytes, str]:
+    raw = path.read_bytes()
+    try:
+        return raw, raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise AssertionError(f"{path.name} is not valid UTF-8: {error}") from error
+
+
+def verify(stdout_path: Path, stderr_path: Path) -> None:
+    _, stdout = decode_utf8(stdout_path)
+    stderr_bytes, stderr = decode_utf8(stderr_path)
+
+    result = json.loads(stdout)
+    if not isinstance(result, dict):
+        raise AssertionError("stdout must contain exactly one JSON object")
+    if not result.get("text"):
+        raise AssertionError("JSON result has no transcript text")
+
+    if len(stderr_bytes) >= MAX_STDERR_BYTES:
+        raise AssertionError(
+            f"default stderr is unbounded: {len(stderr_bytes)} bytes "
+            f"(limit {MAX_STDERR_BYTES})"
+        )
+    for pattern in NATIVE_TRACE_PATTERNS:
+        if pattern.search(stderr):
+            raise AssertionError(
+                f"default stderr contains native trace output matching {pattern.pattern!r}"
+            )
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: verify-json-cli-streams.py STDOUT STDERR")
+    verify(Path(sys.argv[1]), Path(sys.argv[2]))
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6180,6 +6180,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
 dependencies = [
+ "tracing",
  "whisper-rs-sys",
 ]
 

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -11,6 +11,28 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser, Subcommand};
+
+/// Default CLI logging keeps application warnings/errors but suppresses native
+/// Whisper/GGML messages below error. Those libraries classify routine Metal
+/// capability probes as warnings, so a plain `warn` filter still produces
+/// thousands of non-actionable lines on long machine-readable runs.
+pub const NATIVE_LOG_SUPPRESSION: &str =
+    "whisper_rs::whisper_logging_hook=error,whisper_rs::ggml_logging_hook=error";
+pub const DEFAULT_CLI_LOG_FILTER: &str =
+    "warn,whisper_rs::whisper_logging_hook=error,whisper_rs::ggml_logging_hook=error";
+
+/// Preserve an application's requested log level without accidentally opting
+/// into noisy native Whisper/GGML diagnostics. Native logging is enabled only
+/// when the filter names `whisper_rs` explicitly.
+pub fn effective_log_filter(configured: Option<&str>, default_level: &str) -> String {
+    let configured = configured.map(str::trim).filter(|value| !value.is_empty());
+    match configured {
+        Some(filter) if filter.contains("whisper_rs") => filter.to_owned(),
+        Some(filter) => format!("{filter},{NATIVE_LOG_SUPPRESSION}"),
+        None if default_level == "warn" => DEFAULT_CLI_LOG_FILTER.to_owned(),
+        None => format!("{default_level},{NATIVE_LOG_SUPPRESSION}"),
+    }
+}
 use clap_complete::{Generator, Shell};
 
 pub(crate) fn set_transcription_progress(progress: &indicatif::ProgressBar, percentage: i32) {
@@ -508,6 +530,28 @@ fn render_manpage_tree(cmd: &clap::Command, dir: &PathBuf) -> Result<(), io::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn log_filter_suppresses_native_diagnostics_by_default() {
+        assert_eq!(effective_log_filter(None, "warn"), DEFAULT_CLI_LOG_FILTER);
+        assert_eq!(
+            effective_log_filter(Some("info"), "warn"),
+            format!("info,{NATIVE_LOG_SUPPRESSION}")
+        );
+        assert_eq!(
+            effective_log_filter(Some("  "), "info"),
+            format!("info,{NATIVE_LOG_SUPPRESSION}")
+        );
+    }
+
+    #[test]
+    fn log_filter_preserves_explicit_native_diagnostics_opt_in() {
+        let configured = "warn,whisper_rs=info";
+        assert_eq!(
+            effective_log_filter(Some(configured), "warn"),
+            configured
+        );
+    }
 
     #[test]
     fn transcription_progress_bar_never_renders_outside_zero_to_one_hundred() {

--- a/src-tauri/crates/sagascript-cli/src/main.rs
+++ b/src-tauri/crates/sagascript-cli/src/main.rs
@@ -7,10 +7,12 @@ use tracing_subscriber::EnvFilter;
 
 fn main() {
     // Warn-level logging to stderr keeps stdout clean for piped output.
+    let configured_filter = std::env::var("RUST_LOG").ok();
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
-        )
+        .with_env_filter(EnvFilter::new(sagascript_cli::effective_log_filter(
+            configured_filter.as_deref(),
+            "warn",
+        )))
         .with_writer(std::io::stderr)
         .init();
 

--- a/src-tauri/crates/sagascript-core/Cargo.toml
+++ b/src-tauri/crates/sagascript-core/Cargo.toml
@@ -34,13 +34,13 @@ ndarray = { version = "0.17", optional = true }
 # whisper-rs is declared per-target because macOS enables Metal/CoreML;
 # Windows and Linux use the CPU backend (Vulkan is a separate, currently-broken opt-in).
 [target.'cfg(target_os = "macos")'.dependencies]
-whisper-rs = { version = "0.15", features = ["coreml", "metal"] }
+whisper-rs = { version = "0.15", features = ["coreml", "metal", "tracing_backend"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-whisper-rs = { version = "0.15" }
+whisper-rs = { version = "0.15", features = ["tracing_backend"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-whisper-rs = { version = "0.15" }
+whisper-rs = { version = "0.15", features = ["tracing_backend"] }
 
 [features]
 default = []

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -204,6 +204,15 @@ impl Default for WhisperBackend {
 
 impl WhisperBackend {
     pub fn new() -> Self {
+        // whisper.cpp and GGML otherwise write their native diagnostics directly
+        // to stderr, bypassing Rust's UTF-8 and log-level guarantees. Route them
+        // through tracing before any context is created: the CLI suppresses
+        // routine native model/kernel/token chatter, while the hook's lossy
+        // C-string conversion preserves emitted errors as valid UTF-8. Application
+        // warnings remain visible. whisper-rs guards installation with `Once`, so
+        // concurrent backend construction remains safe.
+        whisper_rs::install_logging_hooks();
+
         Self {
             context: Mutex::new(None),
             state: Mutex::new(None),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -222,10 +222,12 @@ fn main() {
     // bare invocation.
     if let Some(parsed) = sagascript_cli::try_parse() {
         // CLI mode uses warn-level logging to keep stdout clean
+        let configured_filter = std::env::var("RUST_LOG").ok();
         tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
-            )
+            .with_env_filter(EnvFilter::new(sagascript_cli::effective_log_filter(
+                configured_filter.as_deref(),
+                "warn",
+            )))
             .with_writer(std::io::stderr)
             .init();
         sagascript_cli::run(parsed);
@@ -233,10 +235,12 @@ fn main() {
     }
 
     // GUI mode: initialize tracing (console logging)
+    let configured_filter = std::env::var("RUST_LOG").ok();
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
+        .with_env_filter(EnvFilter::new(sagascript_cli::effective_log_filter(
+            configured_filter.as_deref(),
+            "info",
+        )))
         .init();
 
     info!("Sagascript starting...");


### PR DESCRIPTION
Closes #125.

## What changed

- Routes whisper.cpp/GGML native logging through Rust tracing so both output streams remain valid UTF-8.
- Keeps Sagascript warnings/errors while suppressing routine native model, token, kernel, and address chatter unless `RUST_LOG` explicitly opts into `whisper_rs` diagnostics.
- Adds a reusable stream-contract verifier and runs it against real model transcription in CI and the release workflow.
- Documents the native verbose opt-in.

## Root cause

whisper.cpp wrote diagnostics directly to stderr, bypassing Rust's UTF-8 conversion and log filtering. A generic inherited `RUST_LOG=warn` also enabled thousands of routine native warning lines.

## Validation

- `cargo test -p sagascript-cli --no-default-features` — 89 passed
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Production frontend build
- Real Metal transcription: default stderr 720 bytes, valid UTF-8, one JSON object; explicit `RUST_LOG=whisper_rs=info` retained verbose native output and valid UTF-8
- `python3 -m py_compile scripts/verify-json-cli-streams.py`
