### PR TITLE
feat: warn on sustained auto-language shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ routine native Whisper/GGML chatter, so machine-readable stdout (including
 troubleshooting, set an explicit filter, for example
 `RUST_LOG=whisper_rs=info sagascript transcribe recording.mp3`.
 
+For files of at least one minute, `--language auto` samples up to 60
+speech-rich windows for sustained language changes. JSON includes
+`language_regions` with language probabilities and a `mixed_language_audio`
+warning when two supported languages remain stable across multiple windows.
+The v1 behavior warns instead of silently switching the decoder; split the
+recording or transcribe each part with an explicit language for best accuracy.
+Explicit `en`, `sv`, and `no` keep the single-language fast path. Future batch
+mode must run this detection independently for every source file.
+
 ## Permissions
 
 ### macOS

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -8,8 +8,9 @@ use sagascript_core::audio::decoder::decode_audio_file;
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{Language, WhisperModel};
 use sagascript_core::transcription::diagnostics::{
-    CoverageDiagnostics, LanguageDetection, TranscriptionWarning, analyze_coverage,
-    analyze_repetition, language_mismatch_warning,
+    CoverageDiagnostics, LanguageDetection, LanguageRegionDiagnostics, LanguageWindow,
+    TranscriptionWarning, analyze_coverage, analyze_language_windows, analyze_repetition,
+    language_mismatch_warning,
 };
 use sagascript_core::transcription::model;
 use sagascript_core::transcription::{
@@ -32,7 +33,8 @@ pub struct TranscribeArgs {
     /// Output result as JSON: text, language, model, duration, and a
     /// `segments` array with per-segment timing/confidence plus
     /// `coverage_ratio`, `uncovered_spans`, repetition quarantine spans,
-    /// detected language, and warnings. Raw segments include `quarantined`.
+    /// sampled language regions/probabilities, and warnings. Raw segments
+    /// include `quarantined`.
     #[arg(long)]
     pub json: bool,
 
@@ -154,6 +156,13 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             None
         }
     };
+    let language_regions = match detect_file_language_regions(&backend, &audio, language) {
+        Ok(diagnostics) => diagnostics,
+        Err(error) => {
+            eprintln!("Warning: language region detection was unavailable: {error}");
+            None
+        }
+    };
 
     // Diarization branch
     #[cfg(feature = "diarization")]
@@ -233,7 +242,10 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             })
             .collect();
         let coverage = analyze_coverage(&audio, &diagnostic_segments);
-        let warnings = combined_warnings(&coverage, language, detected_language.as_ref());
+        let mut warnings = combined_warnings(&coverage, language, detected_language.as_ref());
+        if let Some(diagnostics) = &language_regions {
+            warnings.extend(diagnostics.warnings.clone());
+        }
         emit_warnings(&warnings);
 
         if args.json {
@@ -251,6 +263,8 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
                 "coverage_ratio": coverage.coverage_ratio,
                 "uncovered_spans": coverage.uncovered_spans,
                 "detected_language": detected_language,
+                "language_redetection_enabled": language_regions.is_some(),
+                "language_regions": language_regions.as_ref().map(|diagnostics| &diagnostics.regions),
                 "warnings": warnings,
             });
             println!("{}", serde_json::to_string_pretty(&json).unwrap());
@@ -360,6 +374,9 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     let text = normalize_nonspeech_markers(&raw_text, language);
     let coverage = analyze_coverage(&audio, &trusted_segments);
     let mut warnings = combined_warnings(&coverage, language, detected_language.as_ref());
+    if let Some(diagnostics) = &language_regions {
+        warnings.extend(diagnostics.warnings.clone());
+    }
     warnings.extend(repetition.warnings.clone());
     emit_warnings(&warnings);
 
@@ -395,6 +412,8 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             "uncovered_spans": coverage.uncovered_spans,
             "repetition_spans": repetition.spans,
             "detected_language": detected_language,
+            "language_redetection_enabled": language_regions.is_some(),
+            "language_regions": language_regions.as_ref().map(|diagnostics| &diagnostics.regions),
             "warnings": warnings,
             "vocabulary_corrections": corrections,
         });
@@ -579,6 +598,107 @@ fn emit_warnings(warnings: &[TranscriptionWarning]) {
     for warning in warnings {
         eprintln!("Warning [{}]: {}", warning.code, warning.message);
     }
+}
+
+const LANGUAGE_WINDOW_SECONDS: usize = 20;
+const LANGUAGE_WINDOW_SAMPLES: usize = LANGUAGE_WINDOW_SECONDS * 16_000;
+const LANGUAGE_REDETECTION_MIN_SECONDS: usize = 60;
+const LANGUAGE_REDETECTION_MAX_WINDOWS: usize = 60;
+const LANGUAGE_WINDOW_MIN_RMS: f64 = 0.0015;
+
+/// Re-evaluate only long auto-language files. The sampling cap keeps detection
+/// bounded for multi-hour sources; this function is called independently for
+/// each source when native batch mode invokes the single-file pipeline.
+fn detect_file_language_regions(
+    backend: &WhisperBackend,
+    audio: &[f32],
+    configured_language: Language,
+) -> Result<Option<LanguageRegionDiagnostics>, DictationError> {
+    detect_language_regions_with(audio, configured_language, |window| {
+        backend.detect_language(window)
+    })
+}
+
+fn detect_language_regions_with(
+    audio: &[f32],
+    configured_language: Language,
+    mut detect: impl FnMut(&[f32]) -> Result<Option<LanguageDetection>, DictationError>,
+) -> Result<Option<LanguageRegionDiagnostics>, DictationError> {
+    let windows = language_window_plan(audio.len(), configured_language);
+    if windows.is_empty() {
+        return Ok(None);
+    }
+
+    eprintln!(
+        "Checking {} sampled window(s) for sustained language changes...",
+        windows.len()
+    );
+    let mut detections = Vec::new();
+    for window in windows {
+        let samples = &audio[window.start_sample..window.end_sample];
+        if samples.len() < LANGUAGE_WINDOW_SAMPLES / 2
+            || root_mean_square(samples) < LANGUAGE_WINDOW_MIN_RMS
+        {
+            continue;
+        }
+        let Some(detection) = detect(samples)? else {
+            continue;
+        };
+        detections.push(LanguageWindow {
+            sequence: window.sequence,
+            start: window.start_sample as f64 / 16_000.0,
+            end: window.end_sample as f64 / 16_000.0,
+            language: detection.language,
+            probability: detection.probability,
+        });
+    }
+
+    Ok(Some(analyze_language_windows(&detections)))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PlannedLanguageWindow {
+    sequence: usize,
+    start_sample: usize,
+    end_sample: usize,
+}
+
+fn language_window_plan(
+    audio_samples: usize,
+    configured_language: Language,
+) -> Vec<PlannedLanguageWindow> {
+    if configured_language != Language::Auto
+        || audio_samples < LANGUAGE_REDETECTION_MIN_SECONDS * 16_000
+    {
+        return Vec::new();
+    }
+
+    let total_windows = audio_samples.div_ceil(LANGUAGE_WINDOW_SAMPLES);
+    let step = total_windows.div_ceil(LANGUAGE_REDETECTION_MAX_WINDOWS);
+    (0..total_windows)
+        .step_by(step.max(1))
+        .enumerate()
+        .map(|(sequence, source_window)| {
+            let start_sample = source_window * LANGUAGE_WINDOW_SAMPLES;
+            PlannedLanguageWindow {
+                sequence,
+                start_sample,
+                end_sample: (start_sample + LANGUAGE_WINDOW_SAMPLES).min(audio_samples),
+            }
+        })
+        .collect()
+}
+
+fn root_mean_square(samples: &[f32]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    (samples
+        .iter()
+        .map(|&sample| f64::from(sample) * f64::from(sample))
+        .sum::<f64>()
+        / samples.len() as f64)
+        .sqrt()
 }
 
 fn detect_file_language(
@@ -829,6 +949,47 @@ pub fn copy_to_clipboard(text: &str) -> Result<(), DictationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_language_keeps_region_redetection_fast_path_disabled() {
+        let one_hour = 60 * 60 * 16_000;
+        for language in [Language::English, Language::Swedish, Language::Norwegian] {
+            assert!(language_window_plan(one_hour, language).is_empty());
+            let result = detect_language_regions_with(&vec![0.1; 60 * 16_000], language, |_| {
+                panic!("explicit language must not invoke region detection")
+            })
+            .unwrap();
+            assert!(result.is_none());
+        }
+    }
+
+    #[test]
+    fn auto_language_region_detection_is_bounded_and_skips_silence() {
+        let nine_hours = 9 * 60 * 60 * 16_000;
+        assert!(
+            language_window_plan(nine_hours, Language::Auto).len()
+                <= LANGUAGE_REDETECTION_MAX_WINDOWS
+        );
+
+        let mut audio = vec![0.05; 100 * 16_000];
+        audio[40 * 16_000..60 * 16_000].fill(0.0);
+        let detections = ["en", "en", "sv", "sv"];
+        let mut call_index = 0usize;
+        let diagnostics = detect_language_regions_with(&audio, Language::Auto, |_| {
+            let language = detections[call_index];
+            call_index += 1;
+            Ok(Some(LanguageDetection {
+                language: language.to_string(),
+                probability: 0.97,
+            }))
+        })
+        .unwrap()
+        .expect("long auto-language audio enables region detection");
+
+        assert_eq!(call_index, 4, "silent window must not be classified");
+        assert_eq!(diagnostics.regions.len(), 2);
+        assert_eq!(diagnostics.warnings[0].code, "mixed_language_audio");
+    }
 
     fn segment(text: &str, avg_logprob: Option<f32>, no_speech_prob: f32) -> TranscriptSegment {
         TranscriptSegment {

--- a/src-tauri/crates/sagascript-core/src/transcription/diagnostics.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/diagnostics.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::settings::Language;
 
@@ -18,6 +18,9 @@ const REPETITION_MIN_OCCURRENCES: usize = 8;
 const REPETITION_MIN_TOKENS: usize = 16;
 const REPETITION_MIN_DURATION_SECONDS: f64 = 20.0;
 const REPETITION_MAX_UNIQUE_TOKEN_RATIO: f64 = 0.25;
+const LANGUAGE_REGION_MIN_WINDOWS: usize = 2;
+const LANGUAGE_REGION_MIN_DURATION_SECONDS: f64 = 40.0;
+const LANGUAGE_REGION_MIN_PROBABILITY: f32 = 0.90;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UncoveredSpan {
@@ -77,6 +80,33 @@ impl RepetitionDiagnostics {
 pub struct LanguageDetection {
     pub language: String,
     pub probability: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LanguageWindow {
+    pub sequence: usize,
+    pub start: f64,
+    pub end: f64,
+    pub language: String,
+    pub probability: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LanguageRegion {
+    pub start: f64,
+    pub end: f64,
+    pub language: String,
+    pub probability: f32,
+    pub window_count: usize,
+    pub stable: bool,
+    pub first_sequence: usize,
+    pub last_sequence: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LanguageRegionDiagnostics {
+    pub regions: Vec<LanguageRegion>,
+    pub warnings: Vec<TranscriptionWarning>,
 }
 
 pub fn analyze_coverage(audio: &[f32], segments: &[TranscriptSegment]) -> CoverageDiagnostics {
@@ -300,6 +330,93 @@ pub fn analyze_repetition(segments: &[TranscriptSegment]) -> RepetitionDiagnosti
         .collect();
 
     RepetitionDiagnostics { spans, warnings }
+}
+
+/// Consolidate sampled language detections into conservative sustained regions.
+/// Missing sequence numbers (for example, a skipped silent window) break a
+/// region. A single foreign-language sample remains visible but unstable and
+/// cannot trigger a mixed-language warning.
+pub fn analyze_language_windows(windows: &[LanguageWindow]) -> LanguageRegionDiagnostics {
+    let mut sorted = windows.to_vec();
+    sorted.sort_by(|left, right| {
+        left.sequence
+            .cmp(&right.sequence)
+            .then_with(|| left.start.total_cmp(&right.start))
+    });
+
+    let mut regions: Vec<LanguageRegion> = Vec::new();
+    for window in sorted {
+        if !window.start.is_finite()
+            || !window.end.is_finite()
+            || window.end <= window.start
+            || !window.probability.is_finite()
+        {
+            continue;
+        }
+        if let Some(region) = regions.last_mut() {
+            if region.language.eq_ignore_ascii_case(&window.language)
+                && window.sequence == region.last_sequence + 1
+            {
+                let probability_sum = region.probability * region.window_count as f32;
+                region.end = region.end.max(window.end);
+                region.window_count += 1;
+                region.last_sequence = window.sequence;
+                region.probability =
+                    (probability_sum + window.probability) / region.window_count as f32;
+                continue;
+            }
+        }
+        regions.push(LanguageRegion {
+            start: window.start,
+            end: window.end,
+            language: window.language.to_lowercase(),
+            probability: window.probability,
+            window_count: 1,
+            stable: false,
+            first_sequence: window.sequence,
+            last_sequence: window.sequence,
+        });
+    }
+
+    for region in &mut regions {
+        region.stable = is_supported_language(&region.language)
+            && region.window_count >= LANGUAGE_REGION_MIN_WINDOWS
+            && region.end - region.start >= LANGUAGE_REGION_MIN_DURATION_SECONDS
+            && region.probability >= LANGUAGE_REGION_MIN_PROBABILITY;
+    }
+
+    let stable_regions: Vec<&LanguageRegion> =
+        regions.iter().filter(|region| region.stable).collect();
+    let warnings = stable_regions
+        .first()
+        .map(|initial| {
+            stable_regions
+                .iter()
+                .skip(1)
+                .filter(|region| !region.language.eq_ignore_ascii_case(&initial.language))
+                .map(|region| TranscriptionWarning {
+                    code: "mixed_language_audio".to_string(),
+                    message: format!(
+                        "Auto language detection found a sustained change from {} to {} between {:.2}s and {:.2}s (p={:.3}, {} windows). Mixed-language transcription uses one global decoder language; split the recording or transcribe each part with an explicit --language.",
+                        initial.language,
+                        region.language,
+                        region.start,
+                        region.end,
+                        region.probability,
+                        region.window_count
+                    ),
+                    start: Some(region.start),
+                    end: Some(region.end),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    LanguageRegionDiagnostics { regions, warnings }
+}
+
+fn is_supported_language(language: &str) -> bool {
+    matches!(language, "en" | "sv" | "no")
 }
 
 #[derive(Debug)]
@@ -617,5 +734,72 @@ mod tests {
 
         assert!(analyze_repetition(&[rhetorical]).spans.is_empty());
         assert!(analyze_repetition(&[fast_repetition]).spans.is_empty());
+    }
+
+    #[test]
+    fn warns_for_two_stable_languages_separated_by_silence() {
+        let windows: Vec<LanguageWindow> = serde_json::from_str(include_str!(
+            "../../tests/fixtures/mixed-language-windows.json"
+        ))
+        .expect("shareable mixed-language fixture should parse");
+
+        let diagnostics = analyze_language_windows(&windows);
+
+        assert_eq!(diagnostics.regions.len(), 2);
+        assert!(diagnostics.regions.iter().all(|region| region.stable));
+        assert_eq!(diagnostics.regions[0].language, "en");
+        assert_eq!(diagnostics.regions[1].language, "sv");
+        assert_eq!(diagnostics.warnings.len(), 1);
+        assert_eq!(diagnostics.warnings[0].code, "mixed_language_audio");
+        assert_eq!(
+            (diagnostics.warnings[0].start, diagnostics.warnings[0].end),
+            (Some(60.0), Some(100.0))
+        );
+    }
+
+    #[test]
+    fn isolated_foreign_window_does_not_flap_or_warn() {
+        let windows = vec![
+            language_window(0, 0.0, "en", 0.98),
+            language_window(1, 20.0, "en", 0.97),
+            language_window(2, 40.0, "sv", 0.99),
+            language_window(3, 60.0, "en", 0.96),
+            language_window(4, 80.0, "en", 0.95),
+        ];
+
+        let diagnostics = analyze_language_windows(&windows);
+
+        assert!(diagnostics.warnings.is_empty());
+        assert!(!diagnostics.regions[1].stable);
+    }
+
+    #[test]
+    fn language_diagnostics_are_independent_per_source_file() {
+        let english_source = vec![
+            language_window(0, 0.0, "en", 0.98),
+            language_window(1, 20.0, "en", 0.97),
+        ];
+        let swedish_source = vec![
+            language_window(0, 0.0, "sv", 0.98),
+            language_window(1, 20.0, "sv", 0.97),
+        ];
+
+        assert!(analyze_language_windows(&english_source).warnings.is_empty());
+        assert!(analyze_language_windows(&swedish_source).warnings.is_empty());
+    }
+
+    fn language_window(
+        sequence: usize,
+        start: f64,
+        language: &str,
+        probability: f32,
+    ) -> LanguageWindow {
+        LanguageWindow {
+            sequence,
+            start,
+            end: start + 20.0,
+            language: language.to_string(),
+            probability,
+        }
     }
 }

--- a/src-tauri/crates/sagascript-core/tests/fixtures/README.md
+++ b/src-tauri/crates/sagascript-core/tests/fixtures/README.md
@@ -8,3 +8,8 @@ failure shape without including private source audio or transcript content.
 The repetition diagnostic test loads this file directly. Keep its timestamps
 long enough to exercise the sustained-loop threshold; short rhetorical
 repetition belongs in the separate false-positive unit test.
+
+`mixed-language-windows.json` represents two sustained, high-confidence
+language regions separated by one omitted (silent) 20-second window. It is a
+detector-output fixture rather than private source audio, so it remains small,
+deterministic, and shareable across platforms.

--- a/src-tauri/crates/sagascript-core/tests/fixtures/mixed-language-windows.json
+++ b/src-tauri/crates/sagascript-core/tests/fixtures/mixed-language-windows.json
@@ -1,0 +1,6 @@
+[
+  {"sequence": 0, "start": 0.0, "end": 20.0, "language": "en", "probability": 0.98},
+  {"sequence": 1, "start": 20.0, "end": 40.0, "language": "en", "probability": 0.97},
+  {"sequence": 3, "start": 60.0, "end": 80.0, "language": "sv", "probability": 0.96},
+  {"sequence": 4, "start": 80.0, "end": 100.0, "language": "sv", "probability": 0.95}
+]


### PR DESCRIPTION
Closes #128.

## What changed

- Re-detects language only for auto-language files of at least one minute, sampling at most 60 speech-rich 20-second windows so multi-hour files stay bounded.
- Consolidates consecutive supported-language samples into regions and requires at least two windows, 40 seconds, and p>=0.90 before a region is stable.
- Emits a timed, actionable `mixed_language_audio` warning when stable supported-language regions disagree.
- Exposes `language_redetection_enabled` and `language_regions` (language, probability, span, sample count, and stability) in JSON.
- Keeps explicit `en`, `sv`, and `no` on the current zero-extra-work fast path.
- Documents that future native batch mode must run detection independently per source.
- Adds a shareable mixed-language detector fixture with a silent gap plus no-flapping and per-source isolation tests.

## Root cause

One global auto-language decision cannot describe long recordings that switch language. Later speech could degrade without any region-level evidence or structured warning.

## Validation

- Red/green regression tests for sustained mixed regions, isolated foreign content, and per-source independence
- `cargo test -p sagascript-core --no-default-features` — 163 passed
- `cargo test -p sagascript-cli --no-default-features` — 91 passed
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Production frontend build
- Independent private M5 full-diff review by qwen36-a3b — PASS
