### PR TITLE
feat: add per-hotkey language profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ speech or diarization model.
 - **Privacy by default** -- no telemetry, cloud transcription, or transcript upload; network access is limited to model downloads you initiate
 - **No telemetry or tracking** -- no analytics, no usage sharing, no data collection of any kind
 - **Multi-language** -- English, Swedish, and Norwegian with dedicated models; additional languages supported via generic Whisper models
+- **Language shortcuts** -- assign different global hotkeys to different languages and switch without opening Settings
 - **CLI + GUI** -- full CLI for scripting and automation, menu bar app for everyday use
 - **File transcription** -- transcribe audio and video files (MP3, WAV, M4A, FLAC, MP4, MKV, OGG, and more)
 - **Configurable** -- choose your model, language, hotkey, and output behavior
@@ -79,6 +80,10 @@ sagascript download-model ggml-base.en
 sagascript config list
 sagascript config set language sv
 sagascript config get hotkey
+
+# Use one shortcut for English and another for Swedish
+sagascript config profiles create swedish --name Swedish --hotkey 'Option+Space' --language sv
+sagascript config profiles list
 
 # Generate shell completions
 sagascript completions zsh > ~/.zfunc/_sagascript

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{
-    self, validate_hotkey, HotkeyMode, Language, Settings, WhisperModel,
+    self, validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
 };
 
 #[derive(Args)]
@@ -101,6 +101,40 @@ EXAMPLES:
 Print the absolute path to the settings JSON file. Useful for manual \
 editing or backup.")]
     Path,
+
+    /// Manage per-shortcut dictation language profiles
+    Profiles {
+        #[command(subcommand)]
+        action: ProfileAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ProfileAction {
+    /// List all dictation profiles
+    List,
+    /// Create a dictation profile
+    Create {
+        id: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        hotkey: String,
+        #[arg(long)]
+        language: String,
+    },
+    /// Update a dictation profile
+    Update {
+        id: String,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        hotkey: Option<String>,
+        #[arg(long)]
+        language: Option<String>,
+    },
+    /// Remove a dictation profile (at least one must remain)
+    Remove { id: String },
 }
 
 const VALID_KEYS: &[&str] = &[
@@ -124,7 +158,66 @@ pub fn run(args: ConfigArgs) -> Result<(), DictationError> {
         ConfigAction::Set { key, value } => cmd_set(&key, &value),
         ConfigAction::Reset { key } => cmd_reset(key.as_deref()),
         ConfigAction::Path => cmd_path(),
+        ConfigAction::Profiles { action } => cmd_profiles(action),
     }
+}
+
+fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
+    match action {
+        ProfileAction::List => {
+            println!("{:<16} {:<20} {:<28} LANGUAGE", "ID", "NAME", "HOTKEY");
+            for profile in settings::store::load().resolved_hotkey_profiles() {
+                println!("{:<16} {:<20} {:<28} {}", profile.id, profile.name, profile.shortcut, format_language(profile.language));
+            }
+            Ok(())
+        }
+        ProfileAction::Create { id, name, hotkey, language } => {
+            let language = parse_enum_value::<Language>(&language, "language")?;
+            let mut profiles = settings::store::load().resolved_hotkey_profiles();
+            if profiles.iter().any(|profile| profile.id == id) {
+                return Err(DictationError::SettingsError(format!("Profile '{id}' already exists")));
+            }
+            profiles.push(HotkeyProfile { id: id.clone(), name, shortcut: hotkey, language });
+            persist_profiles(profiles)?;
+            eprintln!("Created profile {id}");
+            Ok(())
+        }
+        ProfileAction::Update { id, name, hotkey, language } => {
+            if name.is_none() && hotkey.is_none() && language.is_none() {
+                return Err(DictationError::SettingsError("Specify at least one of --name, --hotkey, or --language".to_string()));
+            }
+            let language = language.as_deref().map(|value| parse_enum_value::<Language>(value, "language")).transpose()?;
+            let mut profiles = settings::store::load().resolved_hotkey_profiles();
+            let profile = profiles.iter_mut().find(|profile| profile.id == id).ok_or_else(|| DictationError::SettingsError(format!("Unknown profile '{id}'")))?;
+            if let Some(name) = name { profile.name = name; }
+            if let Some(hotkey) = hotkey { profile.shortcut = hotkey; }
+            if let Some(language) = language { profile.language = language; }
+            persist_profiles(profiles)?;
+            eprintln!("Updated profile {id}");
+            Ok(())
+        }
+        ProfileAction::Remove { id } => {
+            let mut profiles = settings::store::load().resolved_hotkey_profiles();
+            let original_len = profiles.len();
+            profiles.retain(|profile| profile.id != id);
+            if profiles.len() == original_len {
+                return Err(DictationError::SettingsError(format!("Unknown profile '{id}'")));
+            }
+            persist_profiles(profiles)?;
+            eprintln!("Removed profile {id}");
+            Ok(())
+        }
+    }
+}
+
+fn persist_profiles(profiles: Vec<HotkeyProfile>) -> Result<(), DictationError> {
+    Settings::validate_hotkey_profiles(&profiles).map_err(DictationError::SettingsError)?;
+    settings::store::try_update(|settings| {
+        settings.replace_hotkey_profiles(profiles)?;
+        Ok(())
+    })
+    .map_err(DictationError::SettingsError)?;
+    Ok(())
 }
 
 fn cmd_list() -> Result<(), DictationError> {
@@ -203,11 +296,18 @@ fn cmd_get(key: &str) -> Result<(), DictationError> {
 fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
     validate_key(key)?;
     // Parse before acquiring the settings lock so invalid input never writes.
-    let mut validation_target = Settings::default();
+    let mut validation_target = settings::store::load();
     apply_setting_value(&mut validation_target, key, value)?;
-    let settings = settings::store::update(|settings| {
-        apply_setting_value(settings, key, value)
-            .expect("setting value was validated before acquiring the lock");
+    if key == "hotkey" {
+        Settings::validate_hotkey_profiles(&validation_target.resolved_hotkey_profiles())
+            .map_err(DictationError::SettingsError)?;
+    }
+    let settings = settings::store::try_update(|settings| {
+        apply_setting_value(settings, key, value).map_err(|error| error.to_string())?;
+        if key == "hotkey" {
+            Settings::validate_hotkey_profiles(&settings.resolved_hotkey_profiles())?;
+        }
+        Ok(())
     })
     .map_err(DictationError::SettingsError)?;
 
@@ -232,7 +332,7 @@ fn apply_setting_value(
 ) -> Result<(), DictationError> {
     match key {
         "language" => {
-            settings.language = parse_enum_value::<Language>(value, "language")?;
+            settings.set_legacy_language(parse_enum_value::<Language>(value, "language")?);
         }
         "whisper_model" => {
             settings.whisper_model = parse_enum_value::<WhisperModel>(value, "whisper_model")?;
@@ -251,7 +351,7 @@ fn apply_setting_value(
         }
         "hotkey" => {
             validate_hotkey(value).map_err(DictationError::SettingsError)?;
-            settings.hotkey = value.to_string();
+            settings.set_legacy_hotkey(value.to_string());
         }
         "initial_prompt" => settings.initial_prompt = value.to_string(),
         "beam_size" => {
@@ -276,14 +376,22 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
     if let Some(key) = key {
         validate_key(key)?;
         let defaults = Settings::default();
+        if key == "hotkey" {
+            let mut profiles = settings::store::load().resolved_hotkey_profiles();
+            let index = profiles.iter().position(|profile| profile.id == "default").unwrap_or(0);
+            profiles[index].shortcut = defaults.hotkey;
+            persist_profiles(profiles)?;
+            eprintln!("Reset hotkey to {}", settings::store::load().hotkey);
+            return Ok(());
+        }
         let settings = settings::store::update(|settings| match key {
-            "language" => settings.language = defaults.language,
+            "language" => settings.set_legacy_language(defaults.language),
             "whisper_model" => settings.whisper_model = defaults.whisper_model,
             "hotkey_mode" => settings.hotkey_mode = defaults.hotkey_mode,
             "show_overlay" => settings.show_overlay = defaults.show_overlay,
             "auto_paste" => settings.auto_paste = defaults.auto_paste,
             "auto_select_model" => settings.auto_select_model = defaults.auto_select_model,
-            "hotkey" => settings.hotkey = defaults.hotkey,
+            "hotkey" => unreachable!("hotkey reset handled transactionally above"),
             "initial_prompt" => settings.initial_prompt = defaults.initial_prompt,
             "beam_size" => settings.beam_size = defaults.beam_size,
             "temperature_fallback" => settings.temperature_fallback = defaults.temperature_fallback,
@@ -525,7 +633,7 @@ mod tests {
     fn valid_keys_count_matches_settings_struct() {
         // Internal fields that are serialized but not user-configurable via `config`.
         // These have dedicated CLI commands instead (e.g. `reset-onboarding`).
-        const INTERNAL_FIELDS: &[&str] = &["has_completed_onboarding"];
+        const INTERNAL_FIELDS: &[&str] = &["has_completed_onboarding", "hotkey_profiles"];
 
         let settings = Settings::default();
         let json = serde_json::to_value(&settings).unwrap();

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -1007,6 +1007,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_config_profile_create() {
+        let cli = Cli::try_parse_from([
+            "sagascript", "config", "profiles", "create", "swedish",
+            "--name", "Swedish", "--hotkey", "Option+Space", "--language", "sv",
+        ]).unwrap();
+        match cli.command.unwrap() {
+            Command::Config(args) => match args.action {
+                config::ConfigAction::Profiles { action: config::ProfileAction::Create { id, name, hotkey, language } } => {
+                    assert_eq!(id, "swedish");
+                    assert_eq!(name, "Swedish");
+                    assert_eq!(hotkey, "Option+Space");
+                    assert_eq!(language, "sv");
+                }
+                _ => panic!("expected profile create"),
+            },
+            _ => panic!("expected Config"),
+        }
+    }
+
+    #[test]
     fn parse_completions() {
         let cli = Cli::try_parse_from(["sagascript", "completions", "zsh"]).unwrap();
         match cli.command.unwrap() {

--- a/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
@@ -6,6 +6,15 @@ pub fn validate_hotkey(value: &str) -> Result<(), String> {
     validate_hotkey_for_platform(value, CURRENT_PLATFORM)
 }
 
+/// Canonical representation used for equality and duplicate detection.
+/// Tauri accepts several aliases for the same physical shortcut; storing the
+/// user's spelling is useful for display, but comparisons must collapse those
+/// aliases so two profiles cannot claim the same key combination.
+pub fn canonical_hotkey(value: &str) -> Result<String, String> {
+    validate_hotkey(value)?;
+    Ok(canonical_hotkey_for_platform(value, CURRENT_PLATFORM))
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum HotkeyPlatform {
     MacOS,
@@ -17,6 +26,48 @@ const CURRENT_PLATFORM: HotkeyPlatform = if cfg!(target_os = "macos") {
 } else {
     HotkeyPlatform::Other
 };
+
+fn canonical_hotkey_for_platform(value: &str, platform: HotkeyPlatform) -> String {
+    let tokens: Vec<String> = value
+        .split('+')
+        .map(|token| token.trim().to_ascii_lowercase())
+        .collect();
+    let (modifiers, key) = tokens.split_at(tokens.len() - 1);
+    let mut modifiers: Vec<&str> = modifiers
+        .iter()
+        .map(|modifier| match modifier.as_str() {
+            "control" | "ctrl" => "control",
+            "alt" | "option" => "alt",
+            "super" | "command" | "cmd" => "super",
+            "commandorcontrol" | "commandorctrl" | "cmdorctrl" | "cmdorcontrol" => {
+                if platform == HotkeyPlatform::MacOS { "super" } else { "control" }
+            }
+            "shift" => "shift",
+            _ => unreachable!("validated modifier"),
+        })
+        .collect();
+    modifiers.sort_unstable();
+    modifiers.dedup();
+
+    let raw_key = key[0].as_str();
+    let key = match raw_key {
+        "up" => "arrowup".to_string(),
+        "down" => "arrowdown".to_string(),
+        "left" => "arrowleft".to_string(),
+        "right" => "arrowright".to_string(),
+        "esc" => "escape".to_string(),
+        other if other.len() == 1 && other.as_bytes()[0].is_ascii_lowercase() => {
+            format!("key{other}")
+        }
+        other if other.len() == 1 && other.as_bytes()[0].is_ascii_digit() => {
+            format!("digit{other}")
+        }
+        other => other.to_string(),
+    };
+    let mut parts: Vec<String> = modifiers.into_iter().map(str::to_string).collect();
+    parts.push(key);
+    parts.join("+")
+}
 
 fn validate_hotkey_for_platform(value: &str, platform: HotkeyPlatform) -> Result<(), String> {
     const MODIFIERS: &[&str] = &[
@@ -391,5 +442,17 @@ mod tests {
     #[test]
     fn command_q_policy_is_platform_specific() {
         assert!(validate_hotkey_for_platform("Command+Q", HotkeyPlatform::Other).is_ok());
+    }
+
+    #[test]
+    fn canonical_hotkey_collapses_aliases_order_case_and_key_names() {
+        assert_eq!(
+            canonical_hotkey_for_platform("Shift+OPTION+A", HotkeyPlatform::MacOS),
+            canonical_hotkey_for_platform("Alt + Shift + KeyA", HotkeyPlatform::MacOS)
+        );
+        assert_eq!(
+            canonical_hotkey_for_platform("CmdOrCtrl+Space", HotkeyPlatform::MacOS),
+            canonical_hotkey_for_platform("Command+Space", HotkeyPlatform::MacOS)
+        );
     }
 }

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -1,4 +1,8 @@
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
+
+use super::{canonical_hotkey, validate_hotkey};
 
 use crate::download::DownloadIntegrity;
 
@@ -452,6 +456,26 @@ impl HotkeyMode {
     }
 }
 
+/// One global shortcut and the transcription language selected when it fires.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HotkeyProfile {
+    pub id: String,
+    pub name: String,
+    pub shortcut: String,
+    pub language: Language,
+}
+
+impl HotkeyProfile {
+    pub fn legacy_default(shortcut: String, language: Language) -> Self {
+        Self {
+            id: "default".to_string(),
+            name: "Default".to_string(),
+            shortcut,
+            language,
+        }
+    }
+}
+
 /// All user-configurable settings, persisted as JSON
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -464,6 +488,9 @@ pub struct Settings {
     pub auto_select_model: bool,
     /// Hotkey shortcut string (e.g. "Control+Shift+Space")
     pub hotkey: String,
+    /// Explicit dictation profiles. Empty means a legacy settings file; callers
+    /// use `resolved_hotkey_profiles()` to synthesize its default profile.
+    pub hotkey_profiles: Vec<HotkeyProfile>,
     /// Optional initial prompt that primes the decoder with domain vocabulary
     /// (names, jargon, spellings) for more accurate transcription. Empty = none.
     pub initial_prompt: String,
@@ -491,6 +518,7 @@ impl Default for Settings {
             auto_paste: true,
             auto_select_model: true,
             hotkey: "Control+Shift+Space".to_string(),
+            hotkey_profiles: Vec::new(),
             initial_prompt: String::new(),
             beam_size: 0,
             temperature_fallback: true,
@@ -503,10 +531,80 @@ impl Default for Settings {
 impl Settings {
     /// Returns the effective model considering auto-selection
     pub fn effective_model(&self) -> WhisperModel {
-        if self.auto_select_model {
-            WhisperModel::recommended(self.language)
+        self.effective_model_for(self.language)
+    }
+
+    pub fn effective_model_for(&self, language: Language) -> WhisperModel {
+        if self.auto_select_model { WhisperModel::recommended(language) } else { self.whisper_model }
+    }
+
+    pub fn resolved_hotkey_profiles(&self) -> Vec<HotkeyProfile> {
+        if self.hotkey_profiles.is_empty() {
+            vec![HotkeyProfile::legacy_default(self.hotkey.clone(), self.language)]
         } else {
-            self.whisper_model
+            self.hotkey_profiles.clone()
+        }
+    }
+
+    pub fn validate_hotkey_profiles(profiles: &[HotkeyProfile]) -> Result<(), String> {
+        if profiles.is_empty() {
+            return Err("At least one hotkey profile is required".to_string());
+        }
+        let mut ids = HashSet::new();
+        let mut shortcuts = HashSet::new();
+        for profile in profiles {
+            if profile.id.is_empty()
+                || profile.id.len() > 32
+                || !profile.id.starts_with(|c: char| c.is_ascii_alphanumeric())
+                || !profile.id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+            {
+                return Err(format!("Invalid profile id '{}': use lowercase letters, numbers, '-' or '_'", profile.id));
+            }
+            if !ids.insert(profile.id.clone()) {
+                return Err(format!("Duplicate profile id '{}'", profile.id));
+            }
+            if profile.name.trim().is_empty() {
+                return Err(format!("Profile '{}' must have a name", profile.id));
+            }
+            if profile.name.chars().count() > 40 {
+                return Err(format!("Profile '{}' name must be 40 characters or fewer", profile.id));
+            }
+            validate_hotkey(&profile.shortcut)?;
+            let canonical = canonical_hotkey(&profile.shortcut)?;
+            if !shortcuts.insert(canonical) {
+                return Err(format!("Duplicate hotkey '{}'", profile.shortcut));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn replace_hotkey_profiles(&mut self, profiles: Vec<HotkeyProfile>) -> Result<(), String> {
+        Self::validate_hotkey_profiles(&profiles)?;
+        let legacy = profiles.iter().find(|profile| profile.id == "default").unwrap_or(&profiles[0]);
+        self.hotkey = legacy.shortcut.clone();
+        self.language = legacy.language;
+        self.hotkey_profiles = profiles;
+        Ok(())
+    }
+
+    pub fn hotkey_profile_for_shortcut(&self, shortcut: &str) -> Option<HotkeyProfile> {
+        let target = canonical_hotkey(shortcut).ok()?;
+        self.resolved_hotkey_profiles()
+            .into_iter()
+            .find(|profile| canonical_hotkey(&profile.shortcut).ok().as_deref() == Some(target.as_str()))
+    }
+
+    pub fn set_legacy_language(&mut self, language: Language) {
+        self.language = language;
+        if let Some(profile) = self.hotkey_profiles.iter_mut().find(|profile| profile.id == "default") {
+            profile.language = language;
+        }
+    }
+
+    pub fn set_legacy_hotkey(&mut self, shortcut: String) {
+        self.hotkey = shortcut.clone();
+        if let Some(profile) = self.hotkey_profiles.iter_mut().find(|profile| profile.id == "default") {
+            profile.shortcut = shortcut;
         }
     }
 }
@@ -926,6 +1024,89 @@ mod tests {
         let s = Settings { auto_select_model: false, whisper_model: WhisperModel::KbWhisperSmall, language: Language::English, ..Default::default() }; // language shouldn't matter
 
         assert_eq!(s.effective_model(), WhisperModel::KbWhisperSmall);
+    }
+
+    fn profile(id: &str, shortcut: &str, language: Language) -> HotkeyProfile {
+        HotkeyProfile {
+            id: id.to_string(),
+            name: id.to_string(),
+            shortcut: shortcut.to_string(),
+            language,
+        }
+    }
+
+    #[test]
+    fn legacy_settings_resolve_to_one_default_hotkey_profile() {
+        let settings: Settings = serde_json::from_str(
+            r#"{"language":"sv","hotkey":"Option+Space"}"#,
+        )
+        .unwrap();
+        let profiles = settings.resolved_hotkey_profiles();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].id, "default");
+        assert_eq!(profiles[0].shortcut, "Option+Space");
+        assert_eq!(profiles[0].language, Language::Swedish);
+    }
+
+    #[test]
+    fn hotkey_profiles_roundtrip_and_lookup_aliases() {
+        let mut settings = Settings::default();
+        settings
+            .replace_hotkey_profiles(vec![
+                profile("default", "Control+Shift+A", Language::English),
+                profile("swedish", "Option+Space", Language::Swedish),
+            ])
+            .unwrap();
+        let json = serde_json::to_string(&settings).unwrap();
+        let loaded: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.hotkey_profiles, settings.hotkey_profiles);
+        assert_eq!(
+            loaded.hotkey_profile_for_shortcut("Alt+Space").unwrap().id,
+            "swedish"
+        );
+    }
+
+    #[test]
+    fn replacing_profiles_syncs_legacy_fields_from_default() {
+        let mut settings = Settings::default();
+        settings
+            .replace_hotkey_profiles(vec![
+                profile("swedish", "Option+Space", Language::Swedish),
+                profile("default", "Control+Shift+E", Language::English),
+            ])
+            .unwrap();
+        assert_eq!(settings.hotkey, "Control+Shift+E");
+        assert_eq!(settings.language, Language::English);
+    }
+
+    #[test]
+    fn profile_validation_rejects_invalid_and_duplicate_values() {
+        assert!(Settings::validate_hotkey_profiles(&[]).is_err());
+        assert!(Settings::validate_hotkey_profiles(&[profile("Bad ID", "Option+A", Language::English)]).is_err());
+        assert!(Settings::validate_hotkey_profiles(&[profile("default", "Space", Language::English)]).is_err());
+
+        let mut blank = profile("default", "Option+A", Language::English);
+        blank.name = "  ".to_string();
+        assert!(Settings::validate_hotkey_profiles(&[blank]).is_err());
+
+        let duplicate_ids = vec![
+            profile("same", "Option+A", Language::English),
+            profile("same", "Option+B", Language::Swedish),
+        ];
+        assert!(Settings::validate_hotkey_profiles(&duplicate_ids).is_err());
+
+        let duplicate_aliases = vec![
+            profile("one", "Option+Shift+A", Language::English),
+            profile("two", "shift+alt+KeyA", Language::Swedish),
+        ];
+        assert!(Settings::validate_hotkey_profiles(&duplicate_aliases).is_err());
+    }
+
+    #[test]
+    fn effective_model_can_be_selected_for_profile_language() {
+        let settings = Settings { auto_select_model: true, ..Default::default() };
+        assert_eq!(settings.effective_model_for(Language::Swedish), WhisperModel::KbWhisperBase);
+        assert_eq!(settings.effective_model_for(Language::Norwegian), WhisperModel::NbWhisperBase);
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/settings/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/mod.rs
@@ -2,5 +2,5 @@ mod hotkey;
 pub mod manager;
 pub mod store;
 
-pub use hotkey::validate_hotkey;
+pub use hotkey::{canonical_hotkey, validate_hotkey};
 pub use manager::*;

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -179,6 +179,41 @@ where
     update_at_with_legacy_sources(&path, legacy_settings_paths(), mutate)
 }
 
+/// Like [`update`], but lets validation fail while the cross-process lock is
+/// held so read/validate/write profile mutations cannot race another writer.
+pub fn try_update<F>(mutate: F) -> Result<Settings, String>
+where
+    F: FnOnce(&mut Settings) -> Result<(), String>,
+{
+    let path = settings_path();
+    try_update_at_with_legacy_sources(&path, legacy_settings_paths(), mutate)
+}
+
+#[cfg(test)]
+fn try_update_at<F>(path: &Path, mutate: F) -> Result<Settings, String>
+where
+    F: FnOnce(&mut Settings) -> Result<(), String>,
+{
+    try_update_at_with_legacy_sources(path, std::iter::empty(), mutate)
+}
+
+fn try_update_at_with_legacy_sources<F>(
+    path: &Path,
+    sources: impl IntoIterator<Item = PathBuf>,
+    mutate: F,
+) -> Result<Settings, String>
+where
+    F: FnOnce(&mut Settings) -> Result<(), String>,
+{
+    with_settings_lock(path, || {
+        migrate_legacy_identifier_settings_locked(path, sources);
+        let mut settings = load_from(path);
+        mutate(&mut settings)?;
+        save_to(path, &settings)?;
+        Ok(settings)
+    })
+}
+
 #[cfg(test)]
 fn update_at<F>(path: &Path, mutate: F) -> Result<Settings, String>
 where
@@ -505,6 +540,19 @@ mod tests {
             assert_eq!(persisted.hotkey, "Super+Q");
             let reloaded = load_from(&path);
             assert_eq!(reloaded.hotkey, "Super+Q");
+        });
+    }
+
+    #[test]
+    fn fallible_update_does_not_persist_a_rejected_mutation() {
+        with_temp_settings(|path| {
+            save_to(&path, &Settings::default()).unwrap();
+            let result = try_update_at(&path, |settings| {
+                settings.hotkey = "invalid".to_string();
+                Err("rejected".to_string())
+            });
+            assert_eq!(result.unwrap_err(), "rejected");
+            assert_eq!(load_from(&path).hotkey, Settings::default().hotkey);
         });
     }
 

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -9,7 +9,7 @@ use crate::hotkey::HotkeyService;
 use crate::logging::LoggingService;
 use crate::logging::log_events;
 use crate::paste::PasteService;
-use sagascript_core::settings::{HotkeyMode, Settings};
+use sagascript_core::settings::{canonical_hotkey, HotkeyMode, HotkeyProfile, Settings};
 
 /// Result of handling a hotkey-down event
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,6 +74,7 @@ pub struct AppController {
     last_transcription: Option<String>,
     last_error: Option<String>,
     model_ready: bool,
+    active_hotkey_profile: Option<HotkeyProfile>,
 }
 
 impl AppController {
@@ -99,6 +100,7 @@ impl AppController {
             last_transcription: None,
             last_error: None,
             model_ready: false,
+            active_hotkey_profile: None,
         }
     }
 
@@ -131,11 +133,33 @@ impl AppController {
     }
 
     pub fn language(&self) -> sagascript_core::settings::Language {
-        self.settings.language
+        self.active_hotkey_profile
+            .as_ref()
+            .map(|profile| profile.language)
+            .unwrap_or(self.settings.language)
+    }
+
+    pub fn active_hotkey_profile(&self) -> Option<&HotkeyProfile> {
+        self.active_hotkey_profile.as_ref()
     }
 
     /// Handle hotkey down event
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn handle_hotkey_down(&mut self) -> Result<HotkeyDownResult, DictationError> {
+        let profile = self
+            .settings
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .find(|profile| profile.id == "default")
+            .or_else(|| self.settings.resolved_hotkey_profiles().into_iter().next())
+            .expect("resolved profiles always contains at least one profile");
+        self.handle_hotkey_down_for_profile(profile)
+    }
+
+    pub fn handle_hotkey_down_for_profile(
+        &mut self,
+        profile: HotkeyProfile,
+    ) -> Result<HotkeyDownResult, DictationError> {
         info!("Hotkey DOWN");
 
         match self.settings.hotkey_mode {
@@ -144,17 +168,23 @@ impl AppController {
                 // PTT while a prior utterance is still Transcribing must be a
                 // no-op — otherwise the overlay/tray shows a recording that
                 // never happened and never hides (finding 1).
-                if self.start_recording()? {
+                if self.start_recording_for_profile(profile)? {
                     Ok(HotkeyDownResult::StartedRecording)
                 } else {
                     Ok(HotkeyDownResult::NoOp)
                 }
             }
             HotkeyMode::Toggle => {
-                if self.state.is_recording() {
+                if self.state.is_recording()
+                    && self
+                        .active_hotkey_profile
+                        .as_ref()
+                        .map(|active| active.id == profile.id)
+                        .unwrap_or(true)
+                {
                     Ok(HotkeyDownResult::StopRecording)
                 } else if self.state == AppState::Idle {
-                    self.start_recording()?;
+                    self.start_recording_for_profile(profile)?;
                     Ok(HotkeyDownResult::StartedRecording)
                 } else {
                     Ok(HotkeyDownResult::NoOp)
@@ -168,6 +198,17 @@ impl AppController {
         self.settings.hotkey_mode == HotkeyMode::PushToTalk && self.state.is_recording()
     }
 
+    pub fn should_stop_profile_on_key_up(&self, shortcut: &str) -> bool {
+        self.should_stop_on_key_up()
+            && self
+                .active_hotkey_profile
+                .as_ref()
+                .and_then(|active| {
+                    Some(canonical_hotkey(&active.shortcut).ok()? == canonical_hotkey(shortcut).ok()?)
+                })
+                .unwrap_or(false)
+    }
+
     /// Start audio recording.
     ///
     /// Returns `Ok(true)` if recording actually started, `Ok(false)` if it was
@@ -175,6 +216,20 @@ impl AppController {
     /// still transcribing). Callers use this to avoid reporting a recording that
     /// never happened (finding 1).
     pub fn start_recording(&mut self) -> Result<bool, DictationError> {
+        let profile = self
+            .settings
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .find(|profile| profile.id == "default")
+            .or_else(|| self.settings.resolved_hotkey_profiles().into_iter().next())
+            .expect("resolved profiles always contains at least one profile");
+        self.start_recording_for_profile(profile)
+    }
+
+    pub fn start_recording_for_profile(
+        &mut self,
+        profile: HotkeyProfile,
+    ) -> Result<bool, DictationError> {
         if self.state != AppState::Idle {
             warn!("Cannot start recording: state is {:?}", self.state);
             return Ok(false);
@@ -189,6 +244,13 @@ impl AppController {
         );
 
         self.audio.start_capture()?;
+        info!(
+            profile_id = %profile.id,
+            profile_name = %profile.name,
+            language = %profile.language.display_name(),
+            "Recording profile selected"
+        );
+        self.active_hotkey_profile = Some(profile);
         self.state = AppState::Recording;
         self.recording_start = Some(Instant::now());
         self.last_error = None;
@@ -246,6 +308,7 @@ impl AppController {
         self.last_transcription = Some(text.to_string());
         self.audio.clear_last_captured();
         self.state = AppState::Idle;
+        self.active_hotkey_profile = None;
         self.logging.end_dictation_session();
     }
 
@@ -253,6 +316,7 @@ impl AppController {
     pub fn on_transcription_error(&mut self, error: &str) {
         self.last_error = Some(error.to_string());
         self.state = AppState::Idle;
+        self.active_hotkey_profile = None;
         self.logging.end_dictation_session();
     }
 
@@ -291,6 +355,7 @@ impl AppController {
         if self.state.is_recording() {
             let _ = self.audio.stop_capture();
             self.state = AppState::Idle;
+            self.active_hotkey_profile = None;
             self.logging.end_dictation_session();
             info!("Recording cancelled");
         }
@@ -506,6 +571,34 @@ mod tests {
         ctrl.settings_mut().hotkey_mode = HotkeyMode::Toggle;
         ctrl.state = AppState::Recording;
         assert!(!ctrl.should_stop_on_key_up());
+    }
+
+    #[test]
+    fn active_profile_freezes_language_and_release_identity() {
+        let mut ctrl = default_controller();
+        let profiles = vec![
+            HotkeyProfile { id: "default".into(), name: "English".into(), shortcut: "Control+Shift+E".into(), language: sagascript_core::settings::Language::English },
+            HotkeyProfile { id: "swedish".into(), name: "Swedish".into(), shortcut: "Option+Space".into(), language: sagascript_core::settings::Language::Swedish },
+        ];
+        ctrl.settings_mut().replace_hotkey_profiles(profiles.clone()).unwrap();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_profile = Some(profiles[1].clone());
+
+        assert_eq!(ctrl.language(), sagascript_core::settings::Language::Swedish);
+        assert!(ctrl.should_stop_profile_on_key_up("Alt+Space"));
+        assert!(!ctrl.should_stop_profile_on_key_up("Control+Shift+E"));
+    }
+
+    #[test]
+    fn toggle_press_from_different_profile_does_not_stop_active_recording() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Toggle;
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_profile = Some(HotkeyProfile { id: "english".into(), name: "English".into(), shortcut: "Control+Shift+E".into(), language: sagascript_core::settings::Language::English });
+        let swedish = HotkeyProfile { id: "swedish".into(), name: "Swedish".into(), shortcut: "Option+Space".into(), language: sagascript_core::settings::Language::Swedish };
+
+        assert_eq!(ctrl.handle_hotkey_down_for_profile(swedish).unwrap(), HotkeyDownResult::NoOp);
     }
 
     // -- handle_hotkey_down --

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -17,7 +17,7 @@ use crate::app_controller::{AppController, AppState, StopRecordingOutcome};
 use crate::hotkey::{HotkeyHealth, HotkeyStatus, OperationalHotkey};
 use sagascript_core::audio::decoder;
 use sagascript_core::settings::{
-    validate_hotkey, HotkeyMode, Language, Settings, WhisperModel,
+    validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
 };
 use sagascript_core::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
 
@@ -77,6 +77,13 @@ pub type SharedController = Mutex<AppController>;
 /// the controller lock during blocking transcription
 pub type SharedWhisper = Arc<WhisperBackend>;
 
+#[tauri::command]
+pub async fn get_active_hotkey_profile(
+    controller: State<'_, SharedController>,
+) -> Result<Option<HotkeyProfile>, String> {
+    Ok(controller.lock().unwrap().active_hotkey_profile().cloned())
+}
+
 // -- State queries --
 
 #[tauri::command]
@@ -88,7 +95,11 @@ pub async fn get_state(controller: State<'_, SharedController>) -> Result<AppSta
 #[tauri::command]
 pub async fn get_settings(controller: State<'_, SharedController>) -> Result<Settings, String> {
     let ctrl = controller.lock().unwrap();
-    Ok(ctrl.settings().clone())
+    let mut settings = ctrl.settings().clone();
+    if settings.hotkey_profiles.is_empty() {
+        settings.hotkey_profiles = settings.resolved_hotkey_profiles();
+    }
+    Ok(settings)
 }
 
 #[tauri::command]
@@ -155,10 +166,10 @@ fn set_language_for_controller(
     language: Language,
 ) -> Result<(), String> {
     let persisted = sagascript_core::settings::store::update(|settings| {
-        settings.language = language;
+        settings.set_legacy_language(language);
     })?;
     let mut ctrl = controller.lock().unwrap();
-    ctrl.settings_mut().language = persisted.language;
+    ctrl.update_settings(persisted.clone());
     drop(ctrl);
     crate::update_language_menu(app, persisted.language);
     info!("Language set to {:?}", language);
@@ -229,36 +240,68 @@ pub async fn set_hotkey(
     health: State<'_, HotkeyHealth>,
     shortcut: String,
 ) -> Result<(), String> {
+    validate_hotkey(&shortcut)?;
+    let mut profiles = controller.lock().unwrap().settings().resolved_hotkey_profiles();
+    let profile_index = profiles.iter().position(|profile| profile.id == "default").unwrap_or(0);
+    profiles[profile_index].shortcut = shortcut;
+    set_hotkey_profiles(app, controller, health, profiles).await
+}
+
+#[tauri::command]
+pub async fn set_hotkey_profiles(
+    app: tauri::AppHandle,
+    controller: State<'_, SharedController>,
+    health: State<'_, HotkeyHealth>,
+    profiles: Vec<HotkeyProfile>,
+) -> Result<(), String> {
     use tauri::Emitter;
     use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
-    // Reject malformed or platform-reserved shortcuts before touching the
-    // currently working OS registration.
-    validate_hotkey(&shortcut)?;
+    Settings::validate_hotkey_profiles(&profiles)?;
+    let new_shortcuts: Vec<String> = profiles.iter().map(|profile| profile.shortcut.clone()).collect();
+    let new_primary = profiles
+        .iter()
+        .find(|profile| profile.id == "default")
+        .unwrap_or(&profiles[0])
+        .shortcut
+        .clone();
 
     let _transition = health.transition_guard();
-    let old_shortcut = {
-        let ctrl = controller.lock().unwrap();
-        ctrl.settings().hotkey.clone()
-    };
-
+    let old_settings = controller.lock().unwrap().settings().clone();
+    let old_shortcut = old_settings.hotkey.clone();
     let old_operational = health.operational_hotkey();
-
-    // The saved shortcut can differ from the operational fallback after an
-    // external hot-reload failure. Always unregister what is actually active.
     if old_operational == OperationalHotkey::Unknown {
         return Err(
-            "Hotkey registration state is unknown after an earlier OS error; restart Sagascript before changing the shortcut"
+            "Hotkey registration state is unknown after an earlier OS error; restart Sagascript before changing profiles"
                 .to_string(),
         );
     }
-    if let OperationalHotkey::Registered(old_operational) = &old_operational {
-        if let Err(error) = app.global_shortcut().unregister(old_operational.as_str()) {
-            error!("Failed to unregister operational hotkey '{old_operational}': {error}");
+
+    let old_shortcuts: Vec<String> = old_settings
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .map(|profile| profile.shortcut)
+        .collect();
+    if new_shortcuts == old_shortcuts {
+        let persisted = sagascript_core::settings::store::try_update(|settings| {
+            settings.replace_hotkey_profiles(profiles.clone())?;
+            Ok(())
+        })?;
+        controller.lock().unwrap().update_settings(persisted);
+        let change = health.record(&new_primary, None, old_operational);
+        if change.changed {
+            let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+        }
+        return Ok(());
+    }
+
+    if let OperationalHotkey::Registered(old_shortcuts) = &old_operational {
+        if let Err(error) = app.global_shortcut().unregister_multiple(old_shortcuts.iter().map(String::as_str)) {
+            error!("Failed to unregister operational hotkeys: {error}");
             let change = health.record(
                 &old_shortcut,
                 Some(format!(
-                    "failed to unregister active hotkey '{old_operational}': {error}; operational state is unknown"
+                    "failed to unregister active hotkeys: {error}; operational state is unknown"
                 )),
                 OperationalHotkey::Unknown,
             );
@@ -268,43 +311,32 @@ pub async fn set_hotkey(
                     &change.status,
                 );
             }
-            return Err(format!(
-                "Failed to unregister active hotkey '{old_operational}': {error}"
-            ));
+            return Err(format!("Failed to unregister active hotkeys: {error}"));
         }
     }
 
-    // Register new shortcut
-    if let Err(e) = app.global_shortcut().register(shortcut.as_str()) {
-        error!("Failed to register new hotkey '{}': {}", shortcut, e);
-        // Try to re-register the old one so the app isn't left with no
-        // hotkey bound at all. If that succeeds, the app is still healthy
-        // (the *requested* change failed, which is already surfaced to the
-        // caller via the returned Err below) — only record a health failure
-        // if even the fallback re-registration fails.
+    if let Err(error) = app.global_shortcut().register_multiple(new_shortcuts.iter().map(String::as_str)) {
+        if let Err(cleanup_error) = app.global_shortcut().unregister_multiple(new_shortcuts.iter().map(String::as_str)) {
+            let change = health.record(
+                &old_shortcut,
+                Some(format!("new registration failed: {error}; partial registration cleanup failed: {cleanup_error}; operational state is unknown")),
+                OperationalHotkey::Unknown,
+            );
+            if change.changed {
+                let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+            }
+            return Err(format!("Failed to register hotkey profiles: {error}; cleanup failed: {cleanup_error}"));
+        }
         let change = match &old_operational {
-            OperationalHotkey::Registered(old_operational) => match app
+            OperationalHotkey::Registered(old_shortcuts) => match app
                 .global_shortcut()
-                .register(old_operational.as_str())
+                .register_multiple(old_shortcuts.iter().map(String::as_str))
             {
-                Ok(()) => {
-                    info!("Re-registered old hotkey '{old_operational}' after failed change");
-                    let error = (old_shortcut.as_str() != old_operational.as_str()).then(|| {
-                        format!(
-                            "saved shortcut '{old_shortcut}' is not active; still using fallback '{old_operational}'"
-                        )
-                    });
+                Ok(()) => health.record(&old_shortcut, None, old_operational.clone()),
+                Err(rollback_error) => {
                     health.record(
                         &old_shortcut,
-                        error,
-                        OperationalHotkey::Registered(old_operational.clone()),
-                    )
-                }
-                Err(e2) => {
-                    error!("Failed to re-register old hotkey '{old_operational}': {e2}");
-                    health.record(
-                        &old_shortcut,
-                        Some(e2.to_string()),
+                        Some(format!("new registration failed: {error}; restoring previous hotkeys also failed: {rollback_error}")),
                         OperationalHotkey::Inactive,
                     )
                 }
@@ -319,113 +351,62 @@ pub async fn set_hotkey(
         if change.changed {
             let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
         }
-        return Err(format!("Failed to register hotkey '{}': {}", shortcut, e));
+        return Err(format!("Failed to register hotkey profiles: {error}"));
     }
 
-    // Registration changes before persistence; keep concurrent status reads
-    // truthful during that short synchronous window.
     health.record(
         &old_shortcut,
-        Some("hotkey change is pending persistence".to_string()),
-        OperationalHotkey::registered(&shortcut),
+        Some("hotkey profile change is pending persistence".to_string()),
+        OperationalHotkey::registered_many(&new_shortcuts),
     );
 
-    let persisted = match sagascript_core::settings::store::update(|settings| {
-        settings.hotkey = shortcut.clone();
+    let persisted = match sagascript_core::settings::store::try_update(|settings| {
+        settings.replace_hotkey_profiles(profiles.clone())?;
+        Ok(())
     }) {
         Ok(settings) => settings,
         Err(save_error) => {
-            // Registration already changed process-global state. If the disk
-            // write fails, restore the operational shortcut so controller,
-            // disk, and registration cannot diverge.
-            if let Err(unregister_error) = app.global_shortcut().unregister(shortcut.as_str()) {
-                error!(
-                    "Failed to unregister unpersisted hotkey '{shortcut}': {unregister_error}"
-                );
-                let change = health.record(
-                    &old_shortcut,
-                    Some(format!(
-                        "failed to persist requested hotkey and could not unregister it: {unregister_error}; operational state is unknown"
-                    )),
-                    OperationalHotkey::Unknown,
-                );
-                if change.changed {
-                    let _ = app.emit(
-                        crate::events::event::HOTKEY_REGISTRATION_CHANGED,
-                        &change.status,
-                    );
+            let unregister_error = app.global_shortcut().unregister_multiple(new_shortcuts.iter().map(String::as_str)).err();
+            let rollback_error = if unregister_error.is_none() {
+                match &old_operational {
+                    OperationalHotkey::Registered(old_shortcuts) => app
+                        .global_shortcut()
+                        .register_multiple(old_shortcuts.iter().map(String::as_str))
+                        .err(),
+                    OperationalHotkey::Inactive => None,
+                    OperationalHotkey::Unknown => unreachable!("unknown state returned above"),
                 }
-                return Err(format!(
-                    "Failed to persist hotkey: {save_error}; failed to unregister unpersisted hotkey '{shortcut}': {unregister_error}"
-                ));
-            }
-            let rollback_error = match &old_operational {
-                OperationalHotkey::Registered(old_operational) => app
-                    .global_shortcut()
-                    .register(old_operational.as_str())
-                    .err()
-                    .map(|e| e.to_string()),
-                OperationalHotkey::Inactive => None,
-                OperationalHotkey::Unknown => unreachable!("unknown state returned above"),
+            } else {
+                None
             };
-            let (health_error, restored_operational) =
-                match (&old_operational, rollback_error.as_deref()) {
-                (OperationalHotkey::Registered(old_operational), None) => {
-                    let error = (old_shortcut.as_str() != old_operational.as_str()).then(|| {
-                        format!(
-                            "saved shortcut '{old_shortcut}' is not active; still using fallback '{old_operational}'"
-                        )
-                    });
-                    (
-                        error,
-                        OperationalHotkey::Registered(old_operational.clone()),
-                    )
-                }
-                (OperationalHotkey::Registered(_), Some(error)) => {
-                    (Some(error.to_string()), OperationalHotkey::Inactive)
-                }
-                (OperationalHotkey::Inactive, _) => (
-                    Some("no previous hotkey was active".to_string()),
-                    OperationalHotkey::Inactive,
-                ),
-                (OperationalHotkey::Unknown, _) => unreachable!("unknown state returned above"),
-            };
+            let unknown = unregister_error.is_some();
+            let restored_operational = if unknown { OperationalHotkey::Unknown } else if rollback_error.is_some() { OperationalHotkey::Inactive } else { old_operational.clone() };
+            let health_error = unknown.then(|| "failed to unregister unpersisted hotkeys; operational state is unknown".to_string())
+                .or_else(|| rollback_error.as_ref().map(|error| format!("failed to restore previous hotkeys: {error}")));
             let change = health.record(&old_shortcut, health_error, restored_operational);
             if change.changed {
                 let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
             }
-            return match (old_operational, rollback_error) {
-                (OperationalHotkey::Registered(_), Some(error)) => Err(format!(
-                    "Failed to persist hotkey: {save_error}; restoring the previous operational hotkey also failed: {error}"
-                )),
-                (OperationalHotkey::Registered(_), None) => Err(format!(
-                    "Failed to persist hotkey: {save_error}; restored the previous operational hotkey"
-                )),
-                (OperationalHotkey::Inactive, _) => Err(format!(
-                    "Failed to persist hotkey: {save_error}; no previous hotkey was active"
-                )),
-                (OperationalHotkey::Unknown, _) => unreachable!("unknown state returned above"),
-            };
+            return Err(format!("Failed to persist hotkey profiles: {save_error}"));
         }
     };
 
-    // Update controller state after persistence succeeds.
     {
         let mut ctrl = controller.lock().unwrap();
-        ctrl.settings_mut().hotkey = persisted.hotkey.clone();
+        ctrl.update_settings(persisted.clone());
         ctrl.hotkey_service_mut().set_shortcut(&persisted.hotkey);
     }
 
     let change = health.record(
-        &shortcut,
+        &new_primary,
         None,
-        OperationalHotkey::registered(&shortcut),
+        OperationalHotkey::registered_many(&new_shortcuts),
     );
     if change.changed {
         let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
     }
 
-    info!("Hotkey changed to: {shortcut}");
+    info!("Hotkey profiles changed: {} registered", new_shortcuts.len());
     Ok(())
 }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -15,6 +15,8 @@ pub mod event {
     /// Hotkey registration health changed (registered OK <-> failed to
     /// register). Payload: `{ ok: bool, error: string | null, shortcut: string }`.
     pub const HOTKEY_REGISTRATION_CHANGED: &str = "hotkey-registration-changed";
+    /// Dictation profile selected by the shortcut that started recording.
+    pub const ACTIVE_HOTKEY_PROFILE_CHANGED: &str = "active-hotkey-profile-changed";
 }
 
 #[cfg(test)]
@@ -31,6 +33,7 @@ mod tests {
             MODEL_READY,
             TRANSCRIPTION_PROGRESS,
             HOTKEY_REGISTRATION_CHANGED,
+            ACTIVE_HOTKEY_PROFILE_CHANGED,
         ];
         for name in events {
             assert!(!name.is_empty());
@@ -55,6 +58,7 @@ mod tests {
             MODEL_READY,
             TRANSCRIPTION_PROGRESS,
             HOTKEY_REGISTRATION_CHANGED,
+            ACTIVE_HOTKEY_PROFILE_CHANGED,
         ];
         for (i, a) in events.iter().enumerate() {
             for (j, b) in events.iter().enumerate() {

--- a/src-tauri/src/hotkey/health.rs
+++ b/src-tauri/src/hotkey/health.rs
@@ -9,6 +9,7 @@ pub struct HotkeyStatus {
     pub ok: bool,
     pub error: Option<String>,
     pub shortcut: String,
+    pub shortcuts: Vec<String>,
 }
 
 /// Result of recording a registration attempt: the resulting status, plus
@@ -27,13 +28,18 @@ pub struct HotkeyStatusChange {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OperationalHotkey {
     Inactive,
-    Registered(String),
+    Registered(Vec<String>),
     Unknown,
 }
 
 impl OperationalHotkey {
+    #[cfg(test)]
     pub fn registered(shortcut: &str) -> Self {
-        Self::Registered(shortcut.to_string())
+        Self::Registered(vec![shortcut.to_string()])
+    }
+
+    pub fn registered_many(shortcuts: &[String]) -> Self {
+        Self::Registered(shortcuts.to_vec())
     }
 }
 
@@ -94,6 +100,7 @@ impl HotkeyHealth {
             ok: state.error.is_none(),
             error: state.error.clone(),
             shortcut: state.shortcut.clone(),
+            shortcuts: requested_shortcuts(&state.shortcut, &state.operational_hotkey),
         }
     }
 
@@ -113,19 +120,28 @@ impl HotkeyHealth {
             ok: state.error.is_none(),
             error: state.error.clone(),
             shortcut: state.shortcut.clone(),
+            shortcuts: requested_shortcuts(&state.shortcut, &state.operational_hotkey),
         };
         state.error = error.clone();
         state.shortcut = shortcut.to_string();
-        state.operational_hotkey = operational_hotkey;
+        state.operational_hotkey = operational_hotkey.clone();
         let status = HotkeyStatus {
             ok: error.is_none(),
             error,
             shortcut: shortcut.to_string(),
+            shortcuts: requested_shortcuts(shortcut, &operational_hotkey),
         };
         HotkeyStatusChange {
             changed: status != prev,
             status,
         }
+    }
+}
+
+fn requested_shortcuts(primary: &str, operational: &OperationalHotkey) -> Vec<String> {
+    match operational {
+        OperationalHotkey::Registered(shortcuts) => shortcuts.clone(),
+        OperationalHotkey::Inactive | OperationalHotkey::Unknown => vec![primary.to_string()],
     }
 }
 
@@ -212,6 +228,20 @@ mod tests {
         let h = HotkeyHealth::new("Control+Shift+Space");
         h.record("Alt+D", None, OperationalHotkey::registered("Alt+D"));
         assert_eq!(h.status().shortcut, "Alt+D");
+    }
+
+    #[test]
+    fn status_reports_every_registered_profile_shortcut() {
+        let h = HotkeyHealth::new("Control+Shift+Space");
+        let shortcuts = vec!["Control+Shift+Space".to_string(), "Option+Space".to_string()];
+        h.record(
+            &shortcuts[0],
+            None,
+            OperationalHotkey::registered_many(&shortcuts),
+        );
+
+        assert_eq!(h.status().shortcuts, shortcuts);
+        assert_eq!(h.operational_hotkey(), OperationalHotkey::Registered(shortcuts));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,11 +45,14 @@ use tracing::{error, info, warn};
 
 use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
-use sagascript_core::settings::{validate_hotkey, Language};
+#[cfg(test)]
+use sagascript_core::settings::validate_hotkey;
+use sagascript_core::settings::Language;
 use sagascript_core::transcription::WhisperBackend;
 
 /// Minimum recording duration before we allow stop (300ms)
 const MIN_RECORDING_MS: u64 = 300;
+const SAFE_FALLBACK_HOTKEY: &str = "Control+Shift+Space";
 
 /// Shared tray status menu item for updating from anywhere
 type SharedStatusItem = Mutex<Option<MenuItem<tauri::Wry>>>;
@@ -177,6 +180,7 @@ fn auto_paste_permitted(requested: bool, accessibility_trusted: bool) -> bool {
 /// Select the shortcut that is safe to register at startup. Invalid persisted
 /// values remain visible in Settings, but never become active; the default
 /// stays operational so an upgrade cannot strand dictation entirely.
+#[cfg(test)]
 fn startup_hotkey_candidate(requested: &str) -> (String, Option<String>) {
     match validate_hotkey(requested) {
         Ok(()) => (requested.to_string(), None),
@@ -266,15 +270,30 @@ fn main() {
                     match event.state {
                         ShortcutState::Pressed => {
                             info!("Hotkey pressed: {shortcut}");
-                            let result = {
+                            let (result, active_profile) = {
                                 let mut c = ctrl.lock().unwrap();
-                                match c.handle_hotkey_down() {
-                                    Ok(r) => r,
-                                    Err(e) => {
-                                        error!("Hotkey down error: {e}");
+                                let profile = c
+                                    .settings()
+                                    .hotkey_profile_for_shortcut(&shortcut.to_string())
+                                    .or_else(|| {
+                                        (shortcut.to_string() == SAFE_FALLBACK_HOTKEY).then(|| {
+                                            c.settings().resolved_hotkey_profiles()[0].clone()
+                                        })
+                                    });
+                                let result = match profile {
+                                    Some(profile) => match c.handle_hotkey_down_for_profile(profile) {
+                                        Ok(r) => r,
+                                        Err(e) => {
+                                            error!("Hotkey down error: {e}");
+                                            HotkeyDownResult::NoOp
+                                        }
+                                    },
+                                    None => {
+                                        warn!("Ignoring unconfigured shortcut event: {shortcut}");
                                         HotkeyDownResult::NoOp
                                     }
-                                }
+                                };
+                                (result, c.active_hotkey_profile().cloned())
                             };
                             match result {
                                 HotkeyDownResult::StartedRecording => {
@@ -283,6 +302,9 @@ fn main() {
                                         c.settings().show_overlay
                                     };
                                     let _ = app.emit(events::event::STATE_CHANGED, "recording");
+                                    if let Some(profile) = active_profile {
+                                        let _ = app.emit(events::event::ACTIVE_HOTKEY_PROFILE_CHANGED, profile);
+                                    }
                                     update_tray_status(app, "recording");
                                     if show_overlay {
                                         overlay::show(app);
@@ -296,7 +318,7 @@ fn main() {
                         }
                         ShortcutState::Released => {
                             info!("Hotkey released: {shortcut}");
-                            handle_hotkey_release(app, &ctrl);
+                            handle_hotkey_release(app, &ctrl, &shortcut.to_string());
                         }
                     }
                 })
@@ -321,14 +343,18 @@ fn main() {
             #[cfg(target_os = "macos")]
             platform::macos::set_activation_policy_accessory();
 
-            // Read hotkey from already-loaded settings and register it
-            let shortcut = {
+            // Read every configured dictation profile and register its shortcut.
+            let profiles = {
                 let ctrl: tauri::State<'_, SharedController> = app.state();
                 let c = ctrl.lock().unwrap();
-                let shortcut = c.settings().hotkey.clone();
-                drop(c);
-                shortcut
+                c.settings().resolved_hotkey_profiles()
             };
+            let requested_primary = profiles
+                .iter()
+                .find(|profile| profile.id == "default")
+                .unwrap_or(&profiles[0])
+                .shortcut
+                .clone();
 
             // Register global shortcut. Failure here (combo already claimed by
             // Spotlight/Raycast/etc.) used to be log-only: the app would look
@@ -336,45 +362,60 @@ fn main() {
             // dictate. Recorded in the process-wide health flag so the tray
             // and Settings UI can surface it.
             let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
-            let (registration_shortcut, validation_error) =
-                startup_hotkey_candidate(&shortcut);
+            let validation_error = sagascript_core::settings::Settings::validate_hotkey_profiles(&profiles).err();
+            let registration_shortcuts: Vec<String> = if validation_error.is_some() {
+                vec![SAFE_FALLBACK_HOTKEY.to_string()]
+            } else {
+                profiles.iter().map(|profile| profile.shortcut.clone()).collect()
+            };
             if let Some(error) = &validation_error {
                 warn!(
-                    "Refusing invalid saved hotkey '{shortcut}': {error}; trying safe fallback '{registration_shortcut}'"
+                    "Refusing invalid saved hotkey profiles: {error}; trying safe fallback '{SAFE_FALLBACK_HOTKEY}'"
                 );
             }
             let registration_error = app
                 .global_shortcut()
-                .register(registration_shortcut.as_str())
+                .register_multiple(registration_shortcuts.iter().map(String::as_str))
                 .err()
                 .map(|error| error.to_string());
+            let cleanup_error = registration_error.as_ref().and_then(|_| {
+                app.global_shortcut()
+                    .unregister_multiple(registration_shortcuts.iter().map(String::as_str))
+                    .err()
+                    .map(|error| error.to_string())
+            });
             if let Some(error) = &registration_error {
-                error!("Failed to register hotkey '{registration_shortcut}': {error}");
+                error!("Failed to register hotkey profiles: {error}");
             } else {
-                info!("Hotkey registered: {registration_shortcut}");
+                info!("Registered {} hotkey profile(s)", registration_shortcuts.len());
             }
-            let (health_error, operational_hotkey) = match (validation_error, registration_error) {
-                (None, None) => (
+            let (health_error, operational_hotkey) = match (validation_error, registration_error, cleanup_error) {
+                (validation, Some(registration), Some(cleanup)) => (
+                    Some(format!("{}registration failed: {registration}; partial-registration cleanup failed: {cleanup}", validation.map(|error| format!("{error}; ")).unwrap_or_default())),
+                    hotkey::OperationalHotkey::Unknown,
+                ),
+                (None, None, None) => (
                     None,
-                    hotkey::OperationalHotkey::registered(&registration_shortcut),
+                    hotkey::OperationalHotkey::registered_many(&registration_shortcuts),
                 ),
-                (Some(validation), None) => (
+                (Some(validation), None, None) => (
                     Some(format!(
-                        "{validation}; using safe fallback '{registration_shortcut}'"
+                        "{validation}; using safe fallback '{SAFE_FALLBACK_HOTKEY}'"
                     )),
-                    hotkey::OperationalHotkey::registered(&registration_shortcut),
+                    hotkey::OperationalHotkey::registered_many(&registration_shortcuts),
                 ),
-                (None, Some(registration)) => {
+                (None, Some(registration), None) => {
                     (Some(registration), hotkey::OperationalHotkey::Inactive)
                 }
-                (Some(validation), Some(registration)) => (
+                (Some(validation), Some(registration), None) => (
                     Some(format!(
-                        "{validation}; fallback '{registration_shortcut}' also failed: {registration}"
+                        "{validation}; fallback '{SAFE_FALLBACK_HOTKEY}' also failed: {registration}"
                     )),
                     hotkey::OperationalHotkey::Inactive,
                 ),
+                (_, None, Some(_)) => unreachable!("cleanup only runs after registration failure"),
             };
-            let change = health.record(&shortcut, health_error, operational_hotkey);
+            let change = health.record(&requested_primary, health_error, operational_hotkey);
             if change.changed {
                 let _ = app.emit(events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
             }
@@ -618,6 +659,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::get_state,
             commands::get_settings,
+            commands::get_active_hotkey_profile,
             commands::get_last_transcription,
             commands::get_last_error,
             commands::is_model_ready,
@@ -627,6 +669,7 @@ fn main() {
             commands::set_auto_select_model,
             commands::set_hotkey_mode,
             commands::set_hotkey,
+            commands::set_hotkey_profiles,
             commands::hotkey_status,
             commands::start_recording,
             commands::stop_and_transcribe,
@@ -881,10 +924,11 @@ fn try_open_settings_window(app: &tauri::AppHandle, tab: Option<&str>) -> Result
 fn handle_hotkey_release(
     app: &tauri::AppHandle,
     ctrl: &tauri::State<'_, SharedController>,
+    shortcut: &str,
 ) {
     let should_stop = {
         let c = ctrl.lock().unwrap();
-        c.should_stop_on_key_up()
+        c.should_stop_profile_on_key_up(shortcut)
     };
 
     if !should_stop {
@@ -994,7 +1038,7 @@ fn stop_recording_and_transcribe(
             let c = ctrl.lock().unwrap();
             (
                 c.language(),
-                c.settings().effective_model(),
+                c.settings().effective_model_for(c.language()),
                 commands::build_transcribe_options(c.settings()),
             )
         };
@@ -1188,121 +1232,72 @@ fn start_settings_watcher(app: tauri::AppHandle) {
 
             let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
             let _transition = health.transition_guard();
-            let new_settings = load_settings_with_permission_gate();
+            let mut new_settings = load_settings_with_permission_gate();
             let ctrl: tauri::State<'_, SharedController> = app.state();
             let old_settings = {
                 let c = ctrl.lock().unwrap();
                 c.settings().clone()
             };
 
-            // Hot-reload hotkey if changed
-            if new_settings.hotkey != old_settings.hotkey {
-                info!(
-                    "Settings watcher: hotkey changed '{}' -> '{}'",
-                    old_settings.hotkey, new_settings.hotkey
-                );
-
+            let old_profiles = old_settings.resolved_hotkey_profiles();
+            let new_profiles = new_settings.resolved_hotkey_profiles();
+            let old_profile_shortcuts: Vec<&str> = old_profiles.iter().map(|profile| profile.shortcut.as_str()).collect();
+            let new_profile_shortcuts: Vec<&str> = new_profiles.iter().map(|profile| profile.shortcut.as_str()).collect();
+            if new_profile_shortcuts != old_profile_shortcuts {
+                info!("Settings watcher: hotkey profiles changed");
                 let old_operational = health.operational_hotkey();
-                let validation_error = validate_hotkey(&new_settings.hotkey).err();
+                let new_shortcuts: Vec<String> = new_profiles.iter().map(|profile| profile.shortcut.clone()).collect();
+                let validation_error = sagascript_core::settings::Settings::validate_hotkey_profiles(&new_profiles).err();
                 let unregister_error = if validation_error.is_none() {
                     match &old_operational {
-                        hotkey::OperationalHotkey::Registered(shortcut) => app
+                        hotkey::OperationalHotkey::Registered(shortcuts) => app
                             .global_shortcut()
-                            .unregister(shortcut.as_str())
+                            .unregister_multiple(shortcuts.iter().map(String::as_str))
                             .err()
-                            .map(|e| {
-                                error!(
-                                    "Failed to unregister operational hotkey '{shortcut}': {e}"
-                                );
-                                e.to_string()
-                            }),
+                            .map(|error| error.to_string()),
                         hotkey::OperationalHotkey::Inactive => None,
                         hotkey::OperationalHotkey::Unknown => Some(
-                            "registration state is unknown after an earlier OS error; restart Sagascript"
-                                .to_string(),
+                            "registration state is unknown after an earlier OS error; restart Sagascript".to_string(),
                         ),
                     }
                 } else {
                     None
                 };
 
-                let change = if let Some(validation_error) = validation_error {
-                    error!(
-                        "Refusing invalid hotkey '{}' from settings reload: {validation_error}",
-                        new_settings.hotkey
-                    );
-                    health.record(
-                        &new_settings.hotkey,
-                        Some(format!(
-                            "{validation_error}; previous operational hotkey was left unchanged"
-                        )),
-                        old_operational.clone(),
-                    )
-                } else if let Some(e) = unregister_error {
-                    // The OS registration is now unknown. Do not risk adding a
-                    // second active shortcut after a failed unregister.
-                    health.record(
-                        &new_settings.hotkey,
-                        Some(format!(
-                            "failed to replace previous hotkey because it could not be unregistered: {e}"
-                        )),
-                        hotkey::OperationalHotkey::Unknown,
-                    )
+                let change = if let Some(error) = validation_error {
+                    new_settings.hotkey = old_settings.hotkey.clone();
+                    new_settings.language = old_settings.language;
+                    new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
+                    health.record(&old_settings.hotkey, Some(format!("{error}; previous hotkey profiles remain active")), old_operational)
+                } else if let Some(error) = unregister_error {
+                    new_settings.hotkey = old_settings.hotkey.clone();
+                    new_settings.language = old_settings.language;
+                    new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
+                    health.record(&old_settings.hotkey, Some(format!("failed to unregister previous hotkeys: {error}")), hotkey::OperationalHotkey::Unknown)
                 } else {
-                    match app.global_shortcut().register(new_settings.hotkey.as_str()) {
-                        Ok(()) => {
-                            info!("Hotkey re-registered: {}", new_settings.hotkey);
-                            health.record(
-                                &new_settings.hotkey,
-                                None,
-                                hotkey::OperationalHotkey::registered(&new_settings.hotkey),
-                            )
-                        }
-                        Err(e) => {
-                            error!("Failed to register new hotkey '{}': {e}", new_settings.hotkey);
-                            // Re-register the old one as fallback so the app doesn't
-                            // end up with no hotkey bound at all. Either way the
-                            // SAVED shortcut is not registered — health must report
-                            // the saved shortcut's failure, not a false-normal for
-                            // the operational fallback.
-                            match &old_operational {
-                                hotkey::OperationalHotkey::Registered(old_shortcut) => {
-                                    match app.global_shortcut().register(old_shortcut.as_str()) {
-                                        Ok(()) => {
-                                            info!(
-                                                "Re-registered old hotkey '{old_shortcut}' as fallback"
-                                            );
-                                            health.record(
-                                                &new_settings.hotkey,
-                                                Some(format!(
-                                                    "failed to register: {e}; still using previous hotkey '{old_shortcut}'"
-                                                )),
-                                                hotkey::OperationalHotkey::Registered(
-                                                    old_shortcut.clone(),
-                                                ),
-                                            )
-                                        }
-                                        Err(e2) => {
-                                            error!("Failed to re-register old hotkey: {e2}");
-                                            health.record(
-                                                &new_settings.hotkey,
-                                                Some(format!(
-                                                    "failed to register: {e}; fallback to '{old_shortcut}' also failed: {e2}"
-                                                )),
-                                                hotkey::OperationalHotkey::Inactive,
-                                            )
-                                        }
-                                    }
-                                }
-                                hotkey::OperationalHotkey::Inactive => health.record(
-                                    &new_settings.hotkey,
-                                    Some(format!(
-                                        "failed to register: {e}; no previous hotkey was active"
-                                    )),
-                                    hotkey::OperationalHotkey::Inactive,
+                    match app.global_shortcut().register_multiple(new_shortcuts.iter().map(String::as_str)) {
+                        Ok(()) => health.record(&new_settings.hotkey, None, hotkey::OperationalHotkey::registered_many(&new_shortcuts)),
+                        Err(error) => {
+                            new_settings.hotkey = old_settings.hotkey.clone();
+                            new_settings.language = old_settings.language;
+                            new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
+                            match app.global_shortcut().unregister_multiple(new_shortcuts.iter().map(String::as_str)) {
+                                Err(cleanup_error) => health.record(
+                                    &old_settings.hotkey,
+                                    Some(format!("failed to register new hotkey profiles: {error}; partial-registration cleanup failed: {cleanup_error}")),
+                                    hotkey::OperationalHotkey::Unknown,
                                 ),
-                                hotkey::OperationalHotkey::Unknown => {
-                                    unreachable!("unknown state handled before registration")
+                                Ok(()) => {
+                                    let restored = match &old_operational {
+                                        hotkey::OperationalHotkey::Registered(shortcuts) => app.global_shortcut().register_multiple(shortcuts.iter().map(String::as_str)).is_ok(),
+                                        hotkey::OperationalHotkey::Inactive => true,
+                                        hotkey::OperationalHotkey::Unknown => false,
+                                    };
+                                    health.record(
+                                        &old_settings.hotkey,
+                                        Some(format!("failed to register new hotkey profiles: {error}; previous profiles {}", if restored { "restored" } else { "could not be restored" })),
+                                        if restored { old_operational } else { hotkey::OperationalHotkey::Inactive },
+                                    )
                                 }
                             }
                         }

--- a/src/lib/Overlay.svelte
+++ b/src/lib/Overlay.svelte
@@ -1,11 +1,27 @@
 <script lang="ts">
-  // Minimal overlay — just a pulsing red dot and "Recording..." text.
-  // Rendered in a transparent, click-through WebviewWindow.
+  import { onMount } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { getActiveHotkeyProfile, type HotkeyProfile } from "./api";
+
+  let profile: HotkeyProfile | null = $state(null);
+
+  onMount(() => {
+    let unlisten = () => {};
+    getActiveHotkeyProfile().then((active) => { profile = active; });
+    listen<HotkeyProfile>("active-hotkey-profile-changed", (event) => {
+      profile = event.payload;
+    }).then((stop) => { unlisten = stop; });
+    return () => unlisten();
+  });
+
+  function languageLabel(language: HotkeyProfile["language"]): string {
+    return ({ en: "English", sv: "Swedish", no: "Norwegian", auto: "Auto" })[language];
+  }
 </script>
 
 <div class="pill">
   <span class="dot"></span>
-  <span class="label">Recording...</span>
+  <span class="label">{profile ? `${profile.name} · ${languageLabel(profile.language)}` : "Recording..."}</span>
 </div>
 
 <style>
@@ -52,5 +68,8 @@
     font-weight: 500;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     white-space: nowrap;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -4,7 +4,7 @@
     getSettings,
     setLanguage,
     setHotkeyMode,
-    setHotkey,
+    setHotkeyProfiles,
     setAutoPaste,
     setInitialPrompt,
     setShowOverlay,
@@ -31,6 +31,7 @@
     type WhisperModel,
     type LoadedModelInfo,
     type HotkeyStatus,
+    type HotkeyProfile,
   } from "./api";
   import { listen } from "@tauri-apps/api/event";
   import { open } from "@tauri-apps/plugin-dialog";
@@ -60,7 +61,8 @@
   let accessibilityRequested: boolean = $state(false);
 
   // Hotkey recorder state
-  let recordingHotkey: boolean = $state(false);
+  let recordingProfileId: string | null = $state(null);
+  let draftProfileId: string | null = $state(null);
   let hotkeyError: string = $state("");
   let hotkeyRecorderEl: HTMLButtonElement | undefined = $state();
 
@@ -73,9 +75,7 @@
   let hotkeyStatusError: string = $state("");
 
   $effect(() => {
-    if (recordingHotkey && hotkeyRecorderEl) {
-      hotkeyRecorderEl.focus();
-    }
+    if (recordingProfileId && hotkeyRecorderEl) hotkeyRecorderEl.focus();
   });
 
   // Dictate test state
@@ -423,13 +423,13 @@
       .join(" + ");
   }
 
-  function onHotkeyKeydown(e: KeyboardEvent) {
+  function onHotkeyKeydown(e: KeyboardEvent, profileId: string) {
     e.preventDefault();
     e.stopPropagation();
 
     // Escape cancels recording
     if (e.key === "Escape") {
-      recordingHotkey = false;
+      recordingProfileId = null;
       hotkeyError = "";
       return;
     }
@@ -463,14 +463,57 @@
     const shortcut = parts.join("+");
     hotkeyError = "";
 
-    setHotkey(shortcut)
+    if (!settings) return;
+    const profiles = settings.hotkey_profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, shortcut } : profile
+    );
+    setHotkeyProfiles(profiles)
       .then(async () => {
-        recordingHotkey = false;
+        recordingProfileId = null;
+        draftProfileId = null;
         settings = await getSettings();
       })
       .catch((err: any) => {
         hotkeyError = typeof err === "string" ? err : err.message || "Failed to set hotkey";
       });
+  }
+
+  async function updateProfile(profileId: string, changes: Partial<HotkeyProfile>) {
+    if (!settings) return;
+    const profiles = settings.hotkey_profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, ...changes } : profile
+    );
+    if (profileId === draftProfileId) {
+      settings = { ...settings, hotkey_profiles: profiles };
+      return;
+    }
+    await applySetting(() => setHotkeyProfiles(profiles));
+  }
+
+  function addProfile() {
+    if (!settings) return;
+    let suffix = settings.hotkey_profiles.length + 1;
+    while (settings.hotkey_profiles.some((profile) => profile.id === `profile-${suffix}`)) suffix += 1;
+    const profile: HotkeyProfile = {
+      id: `profile-${suffix}`,
+      name: `Profile ${suffix}`,
+      shortcut: "Control+Option+Shift+F12",
+      language: settings.language === "sv" ? "en" : "sv",
+    };
+    settings = { ...settings, hotkey_profiles: [...settings.hotkey_profiles, profile] };
+    draftProfileId = profile.id;
+    recordingProfileId = profile.id;
+  }
+
+  async function removeProfile(profileId: string) {
+    if (!settings || settings.hotkey_profiles.length <= 1) return;
+    if (profileId === draftProfileId) {
+      settings = { ...settings, hotkey_profiles: settings.hotkey_profiles.filter((profile) => profile.id !== profileId) };
+      draftProfileId = null;
+      recordingProfileId = null;
+      return;
+    }
+    await applySetting(() => setHotkeyProfiles(settings!.hotkey_profiles.filter((profile) => profile.id !== profileId)));
   }
 
   function languageLabel(lang: Language): string {
@@ -521,8 +564,8 @@
       {#if activeTab === "dictate"}
         <button class="active-config-bar" onclick={() => (activeTab = "settings")}>
           <div class="active-config-row">
-            <span class="active-config-label">Language</span>
-            <span class="active-config-value">{languageLabel(settings.language)}</span>
+            <span class="active-config-label">Dictation profiles</span>
+            <span class="active-config-value">{settings.hotkey_profiles.map((profile) => languageLabel(profile.language)).join(" · ")}</span>
           </div>
           <div class="active-config-row">
             <span class="active-config-label">Model</span>
@@ -534,25 +577,51 @@
           <span class="active-config-link">Change</span>
         </button>
 
-        <div class="field">
-          <span class="field-label">Hotkey</span>
-          {#if recordingHotkey}
-            <button
-              class="hotkey-recorder recording"
-              bind:this={hotkeyRecorderEl}
-              onkeydown={onHotkeyKeydown}
-              onblur={() => { recordingHotkey = false; hotkeyError = ""; }}
-            >
-              Press shortcut...
-            </button>
-          {:else}
-            <button
-              class="hotkey-recorder"
-              onclick={() => { recordingHotkey = true; hotkeyError = ""; }}
-            >
-              {formatHotkeyDisplay(settings.hotkey)}
-            </button>
-          {/if}
+        <div class="field profile-field">
+          <div class="profile-heading">
+            <span class="field-label">Dictation shortcuts</span>
+            <button class="link-btn" onclick={addProfile}>+ Add language</button>
+          </div>
+          {#each settings.hotkey_profiles as profile (profile.id)}
+            <div class="profile-card">
+              <div class="profile-row">
+                <input
+                  class="profile-name"
+                  aria-label="Profile name"
+                  value={profile.name}
+                  onblur={(event) => updateProfile(profile.id, { name: (event.target as HTMLInputElement).value })}
+                />
+                <select
+                  aria-label={`${profile.name} language`}
+                  value={profile.language}
+                  onchange={(event) => updateProfile(profile.id, { language: (event.target as HTMLSelectElement).value as Language })}
+                >
+                  <option value="en">English</option>
+                  <option value="sv">Swedish</option>
+                  <option value="no">Norwegian</option>
+                  <option value="auto">Auto-detect</option>
+                </select>
+              </div>
+              <div class="profile-row">
+                {#if recordingProfileId === profile.id}
+                  <button
+                    class="hotkey-recorder recording"
+                    bind:this={hotkeyRecorderEl}
+                    onkeydown={(event) => onHotkeyKeydown(event, profile.id)}
+                    onblur={() => { recordingProfileId = null; hotkeyError = ""; }}
+                  >Press shortcut...</button>
+                {:else}
+                  <button
+                    class="hotkey-recorder"
+                    onclick={() => { recordingProfileId = profile.id; hotkeyError = ""; }}
+                  >{formatHotkeyDisplay(profile.shortcut)}</button>
+                {/if}
+                {#if settings.hotkey_profiles.length > 1}
+                  <button class="profile-remove" aria-label={`Remove ${profile.name}`} onclick={() => removeProfile(profile.id)}>Remove</button>
+                {/if}
+              </div>
+            </div>
+          {/each}
           {#if hotkeyError}
             <div class="hotkey-error">{hotkeyError}</div>
           {:else if !hotkeyStatusOk}
@@ -560,7 +629,7 @@
               ⚠ Not registered{hotkeyStatusError ? `: ${hotkeyStatusError}` : ""} — this shortcut may already be in use by another app. Try a different combination.
             </div>
           {/if}
-          <div class="hotkey-hint">Modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key (A–Z, 0–9, F1–F12, Space, arrows)</div>
+          <div class="hotkey-hint">Each shortcut selects its language. Modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key.</div>
         </div>
 
         <div class="field">
@@ -952,6 +1021,47 @@
     border-color: var(--accent);
     animation: pulse-border 1.2s ease-in-out infinite;
     color: var(--text-muted);
+  }
+
+  .profile-heading,
+  .profile-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .profile-heading {
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .profile-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px;
+    margin-bottom: 8px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+
+  .profile-name {
+    min-width: 0;
+    flex: 1;
+    font-weight: 600;
+  }
+
+  .profile-row .hotkey-recorder {
+    flex: 1;
+  }
+
+  .profile-remove {
+    border: none;
+    background: none;
+    color: var(--danger);
+    cursor: pointer;
+    font-size: 11px;
   }
 
   @keyframes pulse-border {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,13 @@ import { invoke } from "@tauri-apps/api/core";
 export type Language = "en" | "sv" | "no" | "auto";
 export type HotkeyMode = "push" | "toggle";
 
+export interface HotkeyProfile {
+  id: string;
+  name: string;
+  shortcut: string;
+  language: Language;
+}
+
 export interface WhisperModel {
   id: string;
   display_name: string;
@@ -20,6 +27,7 @@ export interface Settings {
   auto_paste: boolean;
   auto_select_model: boolean;
   hotkey: string;
+  hotkey_profiles: HotkeyProfile[];
   initial_prompt: string;
   beam_size: number;
   temperature_fallback: boolean;
@@ -47,6 +55,7 @@ export interface HotkeyStatus {
   ok: boolean;
   error: string | null;
   shortcut: string;
+  shortcuts: string[];
 }
 
 export async function getState(): Promise<AppState> {
@@ -75,6 +84,14 @@ export async function setHotkeyMode(mode: HotkeyMode): Promise<void> {
 
 export async function setHotkey(shortcut: string): Promise<void> {
   return invoke("set_hotkey", { shortcut });
+}
+
+export async function setHotkeyProfiles(profiles: HotkeyProfile[]): Promise<void> {
+  return invoke("set_hotkey_profiles", { profiles });
+}
+
+export async function getActiveHotkeyProfile(): Promise<HotkeyProfile | null> {
+  return invoke("get_active_hotkey_profile");
 }
 
 /** Whether the hotkey is actually registered right now (not just the saved


### PR DESCRIPTION
## Summary
- add persistent dictation profiles with one global shortcut and language per profile
- register all profile shortcuts atomically and freeze the selected language for each recording session
- add GUI and CLI list/create/update/remove flows, plus active profile/language in the recording overlay
- preserve legacy `language` and `hotkey` settings as the default profile

## Safety and compatibility
- rejects duplicate/reserved shortcuts, including semantic aliases such as Option/Alt
- rolls back the complete shortcut set if registration or persistence fails
- fails closed if partial OS registration cleanup cannot be proven
- language/name-only changes do not disturb working OS registrations

## Verification
- `npm run build`
- `npx svelte-check --tsconfig ./tsconfig.json`
- `npm run test:frontend`
- `npm run release:check`
- `npm run licenses:check`
- `cargo test -p sagascript-core settings`
- `cargo test -p sagascript-cli`
- app suite: 103 passed with the known headless named-pasteboard test skipped
- `cargo clippy --workspace --all-targets -- -D warnings`

## Review
Codex review completed and three rollback/fallback findings were fixed. Independent M5 review timed out without output; GitHub CI is the remaining independent gate.

Closes #135