### PR TITLE
chore: prepare v1.0.6 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "arboard",
  "block",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "arboard",
  "clap",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump application, npm, Cargo workspace, and Tauri metadata to 1.0.6
- keep dependency lockfiles and third-party notices consistent
- release the per-hotkey language profile support merged in #136

## Verification
- `npm run release:check`
- `npm run licenses:check`
- `git diff --check`