### PR TITLE
Fix sentence spacing and per-hotkey model compatibility

### DIFF
--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -210,6 +210,25 @@ impl WhisperModel {
         self.is_swedish_optimized() || self.is_norwegian_optimized()
     }
 
+    /// Whether this model can honor an explicitly selected language without
+    /// being biased toward a different language. Multilingual models support
+    /// every explicit language and auto-detection; language-specific models
+    /// support only their own language.
+    pub fn is_compatible_with(&self, language: Language) -> bool {
+        match language {
+            Language::English => {
+                !self.is_swedish_optimized() && !self.is_norwegian_optimized()
+            }
+            Language::Swedish => {
+                !self.is_english_only() && !self.is_norwegian_optimized()
+            }
+            Language::Norwegian => {
+                !self.is_english_only() && !self.is_swedish_optimized()
+            }
+            Language::Auto => !self.is_english_only() && !self.is_language_optimized(),
+        }
+    }
+
     /// GGML model filename
     pub fn ggml_filename(&self) -> &'static str {
         match self {
@@ -535,7 +554,11 @@ impl Settings {
     }
 
     pub fn effective_model_for(&self, language: Language) -> WhisperModel {
-        if self.auto_select_model { WhisperModel::recommended(language) } else { self.whisper_model }
+        if self.auto_select_model || !self.whisper_model.is_compatible_with(language) {
+            WhisperModel::recommended(language)
+        } else {
+            self.whisper_model
+        }
     }
 
     pub fn resolved_hotkey_profiles(&self) -> Vec<HotkeyProfile> {
@@ -1020,8 +1043,13 @@ mod tests {
     }
 
     #[test]
-    fn settings_effective_model_without_auto_select() {
-        let s = Settings { auto_select_model: false, whisper_model: WhisperModel::KbWhisperSmall, language: Language::English, ..Default::default() }; // language shouldn't matter
+    fn settings_effective_model_without_auto_select_uses_compatible_manual_model() {
+        let s = Settings {
+            auto_select_model: false,
+            whisper_model: WhisperModel::KbWhisperSmall,
+            language: Language::Swedish,
+            ..Default::default()
+        };
 
         assert_eq!(s.effective_model(), WhisperModel::KbWhisperSmall);
     }
@@ -1107,6 +1135,67 @@ mod tests {
         let settings = Settings { auto_select_model: true, ..Default::default() };
         assert_eq!(settings.effective_model_for(Language::Swedish), WhisperModel::KbWhisperBase);
         assert_eq!(settings.effective_model_for(Language::Norwegian), WhisperModel::NbWhisperBase);
+    }
+
+    #[test]
+    fn incompatible_manual_model_falls_back_for_profile_language() {
+        let settings = Settings {
+            auto_select_model: false,
+            whisper_model: WhisperModel::KbWhisperBase,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            settings.effective_model_for(Language::Swedish),
+            WhisperModel::KbWhisperBase
+        );
+        assert_eq!(
+            settings.effective_model_for(Language::English),
+            WhisperModel::BaseEn
+        );
+        assert_eq!(
+            settings.effective_model_for(Language::Norwegian),
+            WhisperModel::NbWhisperBase
+        );
+    }
+
+    #[test]
+    fn compatible_manual_multilingual_model_is_shared_across_profiles() {
+        let settings = Settings {
+            auto_select_model: false,
+            whisper_model: WhisperModel::Medium,
+            ..Default::default()
+        };
+
+        for language in [Language::English, Language::Swedish, Language::Norwegian, Language::Auto] {
+            assert_eq!(settings.effective_model_for(language), WhisperModel::Medium);
+        }
+    }
+
+    #[test]
+    fn english_only_manual_model_is_not_reused_for_other_languages() {
+        let settings = Settings {
+            auto_select_model: false,
+            whisper_model: WhisperModel::MediumEn,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            settings.effective_model_for(Language::English),
+            WhisperModel::MediumEn
+        );
+        assert_eq!(
+            settings.effective_model_for(Language::Swedish),
+            WhisperModel::KbWhisperBase
+        );
+        assert_eq!(
+            settings.effective_model_for(Language::Norwegian),
+            WhisperModel::NbWhisperBase
+        );
+        assert_eq!(
+            settings.effective_model_for(Language::Auto),
+            WhisperModel::Base
+        );
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -135,7 +135,45 @@ fn assemble_transcript(segments: &[TranscriptSegment]) -> String {
         transcript.push_str(&segment.text);
     }
 
-    transcript
+    separate_sentence_boundaries(&transcript)
+}
+
+/// Insert a missing word boundary after sentence-ending punctuation when the
+/// following character clearly begins a new sentence. Whisper can omit this
+/// separator inside a single raw segment, so repairing only segment joins is
+/// insufficient. Requiring an uppercase letter keeps decimals such as `1.2`
+/// unchanged, while a one-character lookahead preserves the internal dots in
+/// initialisms such as `U.S.A.`.
+fn separate_sentence_boundaries(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut word_len = 0usize;
+    let mut word_is_single_uppercase = false;
+
+    while let Some(current) = chars.next() {
+        let previous_word_is_initial = word_len == 1 && word_is_single_uppercase;
+        let continues_initialism = current == '.'
+            && previous_word_is_initial
+            && chars.peek().is_some_and(|next| next.is_uppercase())
+            && chars.clone().nth(1) == Some('.');
+        result.push(current);
+        if matches!(current, '.' | '?' | '!')
+            && chars.peek().is_some_and(|next| next.is_uppercase())
+            && !continues_initialism
+        {
+            result.push(' ');
+        }
+
+        if current.is_alphanumeric() {
+            word_len += 1;
+            word_is_single_uppercase = word_len == 1 && current.is_uppercase();
+        } else if !matches!(current, '\'' | '’') {
+            word_len = 0;
+            word_is_single_uppercase = false;
+        }
+    }
+
+    result
 }
 
 /// Bound whisper's segment timestamps to the source audio and preserve output
@@ -1569,6 +1607,56 @@ mod segment_confidence_tests {
         ];
 
         assert_eq!(assemble_transcript(&segments), "First. Second");
+    }
+
+    #[test]
+    fn assembled_transcript_separates_sentences_inside_one_segment() {
+        let segments = [TranscriptSegment {
+            start: 0.0,
+            end: 4.0,
+            text: "Ja.Jag kastar att prata svenska.Jag testar att prata svenska.Jag."
+                .to_string(),
+            avg_logprob: None,
+            no_speech_prob: 0.0,
+        }];
+
+        assert_eq!(
+            assemble_transcript(&segments),
+            "Ja. Jag kastar att prata svenska. Jag testar att prata svenska. Jag."
+        );
+    }
+
+    #[test]
+    fn assembled_transcript_does_not_split_decimal_numbers() {
+        let segments = [TranscriptSegment {
+            start: 0.0,
+            end: 1.0,
+            text: "Version 1.2 är klar. Nästa steg."
+                .to_string(),
+            avg_logprob: None,
+            no_speech_prob: 0.0,
+        }];
+
+        assert_eq!(
+            assemble_transcript(&segments),
+            "Version 1.2 är klar. Nästa steg."
+        );
+    }
+
+    #[test]
+    fn assembled_transcript_does_not_split_initialisms() {
+        let segments = [TranscriptSegment {
+            start: 0.0,
+            end: 1.0,
+            text: "Jag bor i U.S.A.Nästa mening.".to_string(),
+            avg_logprob: None,
+            no_speech_prob: 0.0,
+        }];
+
+        assert_eq!(
+            assemble_transcript(&segments),
+            "Jag bor i U.S.A. Nästa mening."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- repair missing spaces after sentence-ending punctuation inside a single Whisper segment
- preserve decimals and initialisms while normalizing sentence boundaries
- prevent a per-hotkey language profile from reusing an incompatible language-specific Whisper model
- keep compatible manually selected multilingual models unchanged

## Root cause

The previous spacing repair only handled joins between separate `TranscriptSegment` values, while Whisper can omit the space inside one segment. Separately, disabling automatic model selection caused every hotkey profile to reuse the global model even when it was optimized for another language; the English profile therefore ran with Swedish KB-Whisper.

## User impact

Swedish dictation now produces `Ja. Jag...` rather than `Ja.Jag...`. An English hotkey falls back to the recommended English model when the saved manual model is Swedish- or Norwegian-specific, without changing the user's saved Swedish default.

## Verification

- 112 focused `sagascript-core` settings and transcription tests passed
- `cargo clippy -p sagascript-core --all-targets -- -D warnings`
- `cargo check --workspace`
- `git diff --check`

Closes #138
Closes #139