### PR TITLE
Prevent duplicate GUI instances

### DIFF
--- a/scripts/smoke-single-instance-macos.sh
+++ b/scripts/smoke-single-instance-macos.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_bundle=${1:?usage: smoke-single-instance-macos.sh /path/to/Sagascript.app}
+executable="$app_bundle/Contents/MacOS/sagascript"
+
+[[ $(uname -s) == "Darwin" ]] || {
+  echo "single-instance smoke test requires macOS" >&2
+  exit 2
+}
+[[ -x "$executable" ]] || {
+  echo "app executable is missing or not executable: $executable" >&2
+  exit 2
+}
+
+# The plugin key is the bundle identifier, not the executable path. Refuse to
+# disturb or accidentally test against an already-running installed instance.
+if pgrep -x sagascript >/dev/null 2>&1; then
+  echo "refusing to run while another sagascript process is active" >&2
+  exit 2
+fi
+
+runtime_root=$(mktemp -d "${TMPDIR:-/tmp}/sagascript-single-instance.XXXXXX")
+primary_pid=""
+secondary_pid=""
+replacement_pid=""
+
+cleanup() {
+  for pid in "$secondary_pid" "$replacement_pid" "$primary_pid"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+  rm -rf "$runtime_root"
+}
+trap cleanup EXIT
+
+candidate_pids() {
+  ps -axo pid=,command= | awk -v target="$executable" '
+    {
+      pid = $1
+      sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", $0)
+      if ($0 == target) print pid
+    }
+  '
+}
+
+wait_for_alive() {
+  local pid=$1
+  for _ in {1..100}; do
+    if kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_exit() {
+  local pid=$1
+  for _ in {1..100}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_log() {
+  local path=$1
+  local pattern=$2
+  for _ in {1..100}; do
+    if [[ -f "$path" ]] && grep -q "$pattern" "$path"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+settings_path=$(HOME="$runtime_root/home" "$executable" config path)
+case "$settings_path" in
+  "$runtime_root/home/"*) ;;
+  *)
+    echo "candidate settings escaped isolated HOME: $settings_path" >&2
+    exit 1
+    ;;
+esac
+
+HOME="$runtime_root/home" RUST_LOG=info "$executable" >"$runtime_root/primary.log" 2>&1 &
+primary_pid=$!
+wait_for_alive "$primary_pid" || {
+  echo "primary GUI process did not stay alive" >&2
+  exit 1
+}
+wait_for_log "$runtime_root/primary.log" "Loaded settings" || {
+  echo "primary GUI process did not finish single-instance startup" >&2
+  exit 1
+}
+
+HOME="$runtime_root/home" RUST_LOG=info "$executable" >"$runtime_root/secondary.log" 2>&1 &
+secondary_pid=$!
+wait_for_exit "$secondary_pid" || {
+  echo "secondary GUI process did not exit" >&2
+  exit 1
+}
+wait "$secondary_pid"
+secondary_pid=""
+
+mapfile_output=$(candidate_pids)
+[[ "$mapfile_output" == "$primary_pid" ]] || {
+  echo "expected exactly primary PID $primary_pid after second launch; found: ${mapfile_output:-none}" >&2
+  exit 1
+}
+
+# CLI dispatch happens before Tauri/plugin initialization and must remain usable
+# while the GUI owns the single-instance key.
+cli_language=$(HOME="$runtime_root/home" "$executable" config get language)
+grep -Eq '^(auto|en|sv|no)$' <<<"$cli_language"
+
+# Simulate an unclean termination. OS-backed ownership must disappear with the
+# process so a replacement launch cannot be stranded by stale state.
+kill -KILL "$primary_pid"
+wait "$primary_pid" 2>/dev/null || true
+primary_pid=""
+
+HOME="$runtime_root/home" RUST_LOG=info "$executable" >"$runtime_root/replacement.log" 2>&1 &
+replacement_pid=$!
+wait_for_alive "$replacement_pid" || {
+  echo "replacement GUI process did not recover after an unclean exit" >&2
+  exit 1
+}
+wait_for_log "$runtime_root/replacement.log" "Loaded settings" || {
+  echo "replacement GUI process did not finish startup after an unclean exit" >&2
+  exit 1
+}
+
+mapfile_output=$(candidate_pids)
+[[ "$mapfile_output" == "$replacement_pid" ]] || {
+  echo "expected exactly replacement PID $replacement_pid; found: ${mapfile_output:-none}" >&2
+  exit 1
+}
+
+echo "Verified one GUI instance, concurrent CLI dispatch, and crash recovery."

--- a/scripts/smoke-single-instance-macos.sh
+++ b/scripts/smoke-single-instance-macos.sh
@@ -13,8 +13,8 @@ executable="$app_bundle/Contents/MacOS/sagascript"
   exit 2
 }
 
-# The plugin key is the bundle identifier, not the executable path. Refuse to
-# disturb or accidentally test against an already-running installed instance.
+# Refuse to disturb or accidentally test against an already-running installed
+# instance (or a concurrent CLI process with the same executable name).
 if pgrep -x sagascript >/dev/null 2>&1; then
   echo "refusing to run while another sagascript process is active" >&2
   exit 2

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4059,6 +4059,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "dirs 6.0.0",
  "enigo",
+ "fs2",
  "notify",
  "objc",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-pn
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
+fs2 = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -248,6 +248,21 @@ fn acquire_gui_instance_guard() -> Result<GuiInstanceGuard, GuiInstanceLockError
     acquire_gui_instance_guard_at(&app_data_dir.join("gui-instance.lock"))
 }
 
+fn is_gui_instance_lock_contention(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+        return true;
+    }
+
+    // LockFileEx reports contention as ERROR_LOCK_VIOLATION. Rust does not
+    // currently normalize that code to WouldBlock on Windows.
+    #[cfg(windows)]
+    if error.raw_os_error() == Some(33) {
+        return true;
+    }
+
+    false
+}
+
 fn acquire_gui_instance_guard_at(path: &Path) -> Result<GuiInstanceGuard, GuiInstanceLockError> {
     let mut options = OpenOptions::new();
     options.create(true).read(true).write(true);
@@ -266,7 +281,7 @@ fn acquire_gui_instance_guard_at(path: &Path) -> Result<GuiInstanceGuard, GuiIns
 
     match file.try_lock_exclusive() {
         Ok(()) => Ok(GuiInstanceGuard { _file: file }),
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+        Err(error) if is_gui_instance_lock_contention(&error) => {
             Err(GuiInstanceLockError::AlreadyRunning)
         }
         Err(error) => Err(GuiInstanceLockError::Unavailable(format!(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,6 +25,9 @@ mod updates;
 
 use tracing_subscriber::EnvFilter;
 
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -220,6 +223,59 @@ fn load_settings_with_permission_gate() -> sagascript_core::settings::Settings {
     settings
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum GuiInstanceLockError {
+    AlreadyRunning,
+    Unavailable(String),
+}
+
+/// Process-lifetime OS lock for the bare GUI launch path. The lock file may
+/// remain on disk, but the kernel-owned lock is released automatically on
+/// clean exit or crash, so stale files cannot strand a later launch.
+#[derive(Debug)]
+struct GuiInstanceGuard {
+    _file: File,
+}
+
+fn acquire_gui_instance_guard() -> Result<GuiInstanceGuard, GuiInstanceLockError> {
+    let app_data_dir = sagascript_core::settings::store::app_data_dir();
+    std::fs::create_dir_all(&app_data_dir).map_err(|error| {
+        GuiInstanceLockError::Unavailable(format!(
+            "failed to create app data directory {}: {error}",
+            app_data_dir.display()
+        ))
+    })?;
+    acquire_gui_instance_guard_at(&app_data_dir.join("gui-instance.lock"))
+}
+
+fn acquire_gui_instance_guard_at(path: &Path) -> Result<GuiInstanceGuard, GuiInstanceLockError> {
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let file = options.open(path).map_err(|error| {
+        GuiInstanceLockError::Unavailable(format!(
+            "failed to open GUI instance lock {}: {error}",
+            path.display()
+        ))
+    })?;
+
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(GuiInstanceGuard { _file: file }),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            Err(GuiInstanceLockError::AlreadyRunning)
+        }
+        Err(error) => Err(GuiInstanceLockError::Unavailable(format!(
+            "failed to lock GUI instance file {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
 fn main() {
     // CLI mode: if a subcommand is given, run CLI and exit. The desktop
     // binary is a full CLI (CLI-first design) — the GUI only launches on a
@@ -248,6 +304,20 @@ fn main() {
         .init();
 
     info!("Sagascript starting...");
+
+    // CLI subcommands returned above, so this lock covers GUI processes only.
+    // Acquire it before TCC checks, state construction, or desktop services.
+    let _gui_instance_guard = match acquire_gui_instance_guard() {
+        Ok(guard) => guard,
+        Err(GuiInstanceLockError::AlreadyRunning) => {
+            info!("Another Sagascript GUI instance is already running; exiting");
+            return;
+        }
+        Err(GuiInstanceLockError::Unavailable(error)) => {
+            error!("Cannot establish single-instance GUI ownership: {error}");
+            return;
+        }
+    };
 
     let settings = load_settings_with_permission_gate();
     info!("Loaded settings: language={:?}, model={:?}, hotkey={}", settings.language, settings.whisper_model, settings.hotkey);
@@ -1327,6 +1397,26 @@ fn start_settings_watcher(app: tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gui_instance_lock_rejects_a_concurrent_owner_and_recovers_after_drop() {
+        let dir = std::env::temp_dir().join(format!(
+            "sagascript-instance-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("gui-instance.lock");
+
+        let first = acquire_gui_instance_guard_at(&path).unwrap();
+        assert_eq!(
+            acquire_gui_instance_guard_at(&path).unwrap_err(),
+            GuiInstanceLockError::AlreadyRunning
+        );
+
+        drop(first);
+        acquire_gui_instance_guard_at(&path).unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 
     #[test]
     fn language_menu_ids_resolve_to_persisted_language_values() {


### PR DESCRIPTION
## Summary

- acquire an atomic process-lifetime OS file lock for bare GUI launches
- exit secondary GUI processes before TCC, settings, controllers, hotkeys, microphone, or paste services initialize
- keep every CLI subcommand independent of GUI ownership
- add unit coverage for contention and lock recovery
- add a macOS smoke test for immediate double launch, concurrent real CLI dispatch, settings isolation, and SIGKILL recovery

## Root cause

Sagascript allowed multiple GUI backends to start. Each process registered the same global hotkeys, so one hotkey press could trigger duplicate recordings and paste the same transcription multiple times.

The guard uses the existing `fs2` OS-locking dependency. The lock file may remain on disk, but ownership belongs to the live file descriptor and is automatically released on clean exit or crash.

## User impact

Repeated GUI launches now leave exactly one backend and one set of global shortcut registrations. CLI commands continue to work while the GUI is running.

## Validation

- `cargo test --workspace` — 485 tests passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run test:frontend`
- `npm run check`
- `npm run build`
- `npm run licenses:check`
- `shellcheck scripts/smoke-single-instance-macos.sh`
- real macOS debug-app smoke: one GUI after immediate double launch, `config get language` works concurrently, replacement GUI starts after SIGKILL
- independent M5 `qwen3-coder-next-80b` review: approved with no findings

Fixes #142