### PR TITLE
chore: prepare v1.0.8 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "arboard",
  "block",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "arboard",
  "clap",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Prepare the v1.0.8 patch release containing the single-instance fix merged in #143:

- prevent concurrent GUI processes from registering duplicate hotkeys and pasting duplicate dictation
- preserve concurrent CLI commands while the GUI is running
- recover GUI ownership automatically after a crash

## Release metadata

Bump Sagascript from 1.0.7 to 1.0.8 in:

- package.json and root package-lock metadata
- Rust workspace packages and lockfile
- Tauri application metadata

## Verification

- RELEASE_TAG=v1.0.8 npm run release:check
- cargo metadata --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml
- git diff --check
- PR #143 CI passed on macOS, Linux, and Windows

After this PR merges, tag v1.0.8 must point to the exact merge commit. The tag-triggered workflow will rerun the full quality gate, build/sign/notarize/staple the Apple Silicon app and DMG, verify the artifacts and installed CLI path, then create a draft GitHub Release.