### PR TITLE
Prepare v1.0.9 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "arboard",
  "block",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "arboard",
  "clap",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Bump all release metadata from 1.0.8 to 1.0.9 for the warm per-language model cache merged in #146.

## Verification

- `RELEASE_TAG=v1.0.9 npm run release:check`
- `npm run licenses:check`
- `npm run test:frontend` — 9 passed
- `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors/warnings
- `npm run build`
- `cargo check --workspace`
- `git diff --check`

Feature validation on #146 already passed 494 Rust tests, strict workspace Clippy, frontend checks, and Linux/macOS/Windows CI.
