### PR TITLE
Add safe personal glossary corrections

### DIFF
--- a/docs/personal-glossary.md
+++ b/docs/personal-glossary.md
@@ -1,0 +1,42 @@
+# Personal glossary architecture
+
+Sagascript keeps the persisted `initial_prompt` string as the backward-compatible
+source of truth for vocabulary guidance. Existing comma- or newline-separated
+terms continue to be passed to Whisper unchanged.
+
+An entry may optionally authorize deterministic correction:
+
+```text
+OpenRouter = open router | open vrouter
+merge = merch
+Cloudflare = cloud flare
+```
+
+The text to the left is the canonical output. Text to the right contains exact
+aliases separated by `|`. Only entries with explicit aliases can rewrite a
+transcript. This keeps arbitrary prose and legacy prompts hint-only.
+
+## Pipeline
+
+1. Parse the persisted dictionary in `sagascript-core`.
+2. Strip aliases from the decoder prompt so Whisper sees only preferred terms.
+3. Transcribe locally as before.
+4. Find case-insensitive, whole-word or whole-phrase alias matches in the raw
+   transcript. Resolve longest matches first against the original text.
+5. Fail closed when the same alias maps to more than one canonical term.
+6. Apply accepted replacements before results reach the clipboard, auto-paste,
+   GUI, or CLI output.
+
+The GUI live path, GUI file path, CLI `record`, and CLI `transcribe` all use the
+same parser and exact-alias corrector. Batch `--correct-hints` retains its
+additional confidence-gated one-edit correction for plain single-word hints.
+
+## Interfaces
+
+- **Settings → Personal dictionary** edits the persistent source.
+- **Transcribe → Extra context for this file** remains a one-run override.
+- `sagascript glossary list|add|remove|clear` is the CLI equivalent.
+- `sagascript config set initial_prompt ...` remains supported for scripts.
+
+All processing stays local. Sagascript does not ship personal vocabulary,
+phonetic guesses, cloud correction, or telemetry.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4109,6 +4109,7 @@ dependencies = [
  "ndarray",
  "num_cpus",
  "ort",
+ "regex",
  "reqwest 0.12.28",
  "rubato",
  "rustfft",

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -57,7 +57,7 @@ Valid values per key:
   auto_paste           true, false (enabling requires Accessibility approval for the installed GUI)
   auto_select_model    true, false
   hotkey               Modifier+Key (e.g. Control+Shift+Space, Option+Space)
-  initial_prompt       Any string (e.g. names, jargon, preferred spellings)
+  initial_prompt       Personal dictionary text; aliases use TERM = ALIAS | ALIAS
   beam_size            Integer >= 0 (0 = greedy/fast, 5 = beam search/accurate)
   temperature_fallback true, false
   vad_enabled          true, false",
@@ -67,7 +67,7 @@ EXAMPLES:
   sagascript config set whisper_model kb-whisper-base
   sagascript config set hotkey 'Option+Space'
   sagascript config set auto_paste false
-  sagascript config set initial_prompt 'Sagascript, Tauri, whisper-rs'"
+  sagascript config set initial_prompt $'OpenRouter = open router | open vrouter\\nmerge = merch'"
     )]
     Set {
         /// Setting key [possible values: language, whisper_model, hotkey_mode, show_overlay, auto_paste, auto_select_model, hotkey, initial_prompt, beam_size, temperature_fallback, vad_enabled]

--- a/src-tauri/crates/sagascript-cli/src/glossary.rs
+++ b/src-tauri/crates/sagascript-cli/src/glossary.rs
@@ -1,0 +1,136 @@
+use clap::{Args, Subcommand};
+
+use sagascript_core::error::DictationError;
+use sagascript_core::settings;
+use sagascript_core::transcription::Glossary;
+
+#[derive(Args)]
+pub struct GlossaryArgs {
+    #[command(subcommand)]
+    pub action: GlossaryAction,
+}
+
+#[derive(Subcommand)]
+pub enum GlossaryAction {
+    /// List canonical terms and their explicit aliases
+    List,
+    /// Add a term or merge aliases into an existing term
+    Add {
+        /// Preferred spelling written to the transcript
+        term: String,
+        /// Exact mishearing to replace (repeat for more aliases)
+        #[arg(long = "alias", value_name = "TEXT")]
+        aliases: Vec<String>,
+    },
+    /// Remove a canonical term and all of its aliases
+    Remove { term: String },
+    /// Remove every personal dictionary entry
+    Clear {
+        /// Confirm destructive removal of the complete dictionary
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+pub fn run(args: GlossaryArgs) -> Result<(), DictationError> {
+    match args.action {
+        GlossaryAction::List => list(),
+        GlossaryAction::Add { term, aliases } => add(&term, &aliases),
+        GlossaryAction::Remove { term } => remove(&term),
+        GlossaryAction::Clear { yes } => clear(yes),
+    }
+}
+
+fn list() -> Result<(), DictationError> {
+    let stored = settings::store::load();
+    let glossary = Glossary::parse(&stored.initial_prompt);
+    for entry in glossary.entries() {
+        if entry.aliases.is_empty() {
+            println!("{}", entry.canonical);
+        } else {
+            println!("{} = {}", entry.canonical, entry.aliases.join(" | "));
+        }
+    }
+    Ok(())
+}
+
+fn add(term: &str, aliases: &[String]) -> Result<(), DictationError> {
+    let term = validate_component("term", term)?;
+    let aliases = aliases
+        .iter()
+        .map(|alias| validate_component("alias", alias))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    settings::store::update(|stored| {
+        let mut glossary = Glossary::parse(&stored.initial_prompt);
+        glossary.upsert(term.clone(), aliases.clone());
+        stored.initial_prompt = glossary.render();
+    })
+    .map_err(DictationError::SettingsError)?;
+    eprintln!("Saved personal dictionary term: {term}");
+    Ok(())
+}
+
+fn remove(term: &str) -> Result<(), DictationError> {
+    let term = validate_component("term", term)?;
+    let mut removed = false;
+    settings::store::update(|stored| {
+        let mut glossary = Glossary::parse(&stored.initial_prompt);
+        removed = glossary.remove(&term);
+        if removed {
+            stored.initial_prompt = glossary.render();
+        }
+    })
+    .map_err(DictationError::SettingsError)?;
+
+    if removed {
+        eprintln!("Removed personal dictionary term: {term}");
+        Ok(())
+    } else {
+        Err(DictationError::SettingsError(format!(
+            "Personal dictionary term '{term}' was not found"
+        )))
+    }
+}
+
+fn clear(confirmed: bool) -> Result<(), DictationError> {
+    if !confirmed {
+        return Err(DictationError::SettingsError(
+            "Refusing to clear the personal dictionary without --yes".to_string(),
+        ));
+    }
+    settings::store::update(|stored| stored.initial_prompt.clear())
+        .map_err(DictationError::SettingsError)?;
+    eprintln!("Cleared personal dictionary");
+    Ok(())
+}
+
+fn validate_component(label: &str, value: &str) -> Result<String, DictationError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(DictationError::SettingsError(format!(
+            "Glossary {label} cannot be empty"
+        )));
+    }
+    if value
+        .chars()
+        .any(|character| matches!(character, '\n' | '\r' | ',' | '=' | '|'))
+    {
+        return Err(DictationError::SettingsError(format!(
+            "Glossary {label} cannot contain a newline, comma, '=' or '|'"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_grammar_delimiters_in_cli_values() {
+        assert!(validate_component("term", "OpenRouter").is_ok());
+        assert!(validate_component("alias", "open router").is_ok());
+        assert!(validate_component("alias", "open router | router").is_err());
+    }
+}

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod glossary;
 pub mod models;
 // Live recording is optional (`record` feature, on by default) so a pure
 // batch-transcribe build (`--no-default-features`) carries no audio-capture
@@ -360,6 +361,13 @@ EXAMPLES:
     )]
     Config(config::ConfigArgs),
 
+    /// Manage the persistent personal dictionary used by live and batch transcription
+    #[command(
+        long_about = "Add preferred spellings and optional exact mishearings. Plain terms prime Whisper; aliases also authorize deterministic local corrections before output.",
+        after_long_help = "EXAMPLES:\n  sagascript glossary list\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter'\n  sagascript glossary add merge --alias merch\n  sagascript glossary remove OpenRouter\n  sagascript glossary clear --yes"
+    )]
+    Glossary(glossary::GlossaryArgs),
+
     /// List supported audio/video file formats
     #[command(
         long_about = "\
@@ -452,6 +460,7 @@ pub fn run(cli: Cli) {
                 })
         }
         Command::Config(args) => config::run(args),
+        Command::Glossary(args) => glossary::run(args),
         Command::Formats => {
             formats();
             Ok(())
@@ -952,6 +961,31 @@ mod tests {
                 assert_eq!(args.prompt.as_deref(), Some("Notre Dame, Sara"));
             }
             _ => panic!("expected Record"),
+        }
+    }
+
+    #[test]
+    fn parse_glossary_add_with_repeated_aliases() {
+        let cli = Cli::try_parse_from([
+            "sagascript",
+            "glossary",
+            "add",
+            "OpenRouter",
+            "--alias",
+            "open router",
+            "--alias",
+            "open vrouter",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Command::Glossary(args) => match args.action {
+                glossary::GlossaryAction::Add { term, aliases } => {
+                    assert_eq!(term, "OpenRouter");
+                    assert_eq!(aliases, vec!["open router", "open vrouter"]);
+                }
+                _ => panic!("expected glossary add"),
+            },
+            _ => panic!("expected Glossary"),
         }
     }
 

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -9,7 +9,7 @@ use sagascript_core::audio::AudioCaptureService;
 use sagascript_core::audio::resample::TARGET_SAMPLE_RATE;
 use sagascript_core::error::DictationError;
 use sagascript_core::transcription::model;
-use sagascript_core::transcription::WhisperBackend;
+use sagascript_core::transcription::{Glossary, WhisperBackend};
 
 use super::transcribe::{
     copy_to_clipboard, model_id_string, parse_language, resolve_effective_model,
@@ -148,7 +148,9 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
-    let prompt = effective_prompt.as_deref();
+    let glossary = Glossary::parse(effective_prompt.as_deref().unwrap_or_default());
+    let decoder_prompt = glossary.decoder_prompt();
+    let prompt = decoder_prompt.as_deref();
     let text = if duration > 10.0 {
         let pb = ProgressBar::new(100);
         pb.set_style(
@@ -171,6 +173,8 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         backend.transcribe_sync_with_progress_and_prompt(&audio, language, prompt, |_| {})?
     };
 
+    let (text, vocabulary_corrections) = glossary.correct_text(&text);
+
     // Output
     if args.json {
         let json = serde_json::json!({
@@ -178,6 +182,7 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
             "language": language,
             "model": model_id_string(model),
             "duration_seconds": duration,
+            "vocabulary_corrections": vocabulary_corrections,
         });
         println!("{}", serde_json::to_string_pretty(&json).unwrap());
     } else {

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -416,13 +416,18 @@ fn transcribe_file(
 
         let diarized = merge_with_transcript(&speaker_segments, &transcript);
         let mut consolidated = consolidate(&diarized);
-        let mut glossary_corrections = Vec::new();
         for segment in &mut consolidated {
             segment.text = normalize_nonspeech_markers(&segment.text, language);
-            let (corrected, corrections) = glossary.correct_text(&segment.text);
-            segment.text = corrected;
-            glossary_corrections.extend(corrections);
         }
+        let fragments = consolidated.iter().map(|segment| segment.text.as_str()).collect::<Vec<_>>();
+        let (corrected_fragments, projected_corrections) = glossary.correct_fragments(&fragments);
+        for (segment, text) in consolidated.iter_mut().zip(corrected_fragments) {
+            segment.text = text;
+        }
+        let glossary_corrections = projected_corrections
+            .into_iter()
+            .map(|(_, correction)| correction)
+            .collect::<Vec<_>>();
         let diagnostic_segments: Vec<TranscriptSegment> = consolidated
             .iter()
             .map(|segment| TranscriptSegment {
@@ -720,29 +725,10 @@ fn apply_glossary_corrections(
     segments: &mut [TranscriptSegment],
     glossary: &Glossary,
 ) -> Vec<VocabularyCorrection> {
-    let original = segments.iter().map(|segment| segment.text.as_str()).collect::<String>();
-    let (corrected, applied) = glossary.correct_text(&original);
-    if applied.is_empty() {
-        return Vec::new();
-    }
-
-    let mut ranges = Vec::with_capacity(segments.len());
-    let mut offset = 0;
-    for segment in segments.iter() {
-        let end = offset + segment.text.len();
-        ranges.push((offset, end));
-        offset = end;
-    }
-
-    let mut rebuilt = vec![String::new(); segments.len()];
+    let fragments = segments.iter().map(|segment| segment.text.as_str()).collect::<Vec<_>>();
+    let (corrected_fragments, applied) = glossary.correct_fragments(&fragments);
     let mut corrections = Vec::with_capacity(applied.len());
-    let mut cursor = 0;
-    for correction in applied {
-        append_original_range(&original, cursor, correction.start, &ranges, &mut rebuilt);
-        let segment_index = ranges.iter()
-            .position(|(start, end)| *start <= correction.start && correction.start < *end)
-            .unwrap_or_else(|| segments.len().saturating_sub(1));
-        rebuilt[segment_index].push_str(&correction.replacement);
+    for (segment_index, correction) in applied {
         corrections.push(VocabularyCorrection {
             segment_index,
             original: correction.original,
@@ -751,31 +737,11 @@ fn apply_glossary_corrections(
             avg_logprob: segments[segment_index].avg_logprob,
             no_speech_prob: segments[segment_index].no_speech_prob,
         });
-        cursor = correction.end;
     }
-    append_original_range(&original, cursor, original.len(), &ranges, &mut rebuilt);
-
-    for (segment, text) in segments.iter_mut().zip(rebuilt) {
+    for (segment, text) in segments.iter_mut().zip(corrected_fragments) {
         segment.text = text;
     }
-    debug_assert_eq!(segments.iter().map(|segment| segment.text.as_str()).collect::<String>(), corrected);
     corrections
-}
-
-fn append_original_range(
-    original: &str,
-    start: usize,
-    end: usize,
-    segment_ranges: &[(usize, usize)],
-    output: &mut [String],
-) {
-    for (segment_index, (segment_start, segment_end)) in segment_ranges.iter().enumerate() {
-        let slice_start = start.max(*segment_start);
-        let slice_end = end.min(*segment_end);
-        if slice_start < slice_end {
-            output[segment_index].push_str(&original[slice_start..slice_end]);
-        }
-    }
 }
 
 fn correct_segment_text(

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -6,17 +6,17 @@ use clap::Args;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
-use sagascript_core::audio::decoder::{decode_audio_file, SUPPORTED_EXTENSIONS};
+use sagascript_core::audio::decoder::{SUPPORTED_EXTENSIONS, decode_audio_file};
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{Language, Settings, WhisperModel};
 use sagascript_core::transcription::diagnostics::{
-    analyze_coverage, analyze_language_windows, analyze_repetition, language_mismatch_warning,
     CoverageDiagnostics, LanguageDetection, LanguageRegionDiagnostics, LanguageWindow,
-    TranscriptionWarning,
+    TranscriptionWarning, analyze_coverage, analyze_language_windows, analyze_repetition,
+    language_mismatch_warning,
 };
 use sagascript_core::transcription::model;
 use sagascript_core::transcription::{
-    normalize_nonspeech_markers, Glossary, TranscribeOptions, TranscriptSegment, WhisperBackend,
+    Glossary, TranscriptSegment, TranscribeOptions, WhisperBackend, normalize_nonspeech_markers,
 };
 
 #[derive(Args)]
@@ -81,12 +81,7 @@ pub struct TranscribeArgs {
     /// Read the hint/initial prompt from a file instead of the command line
     /// (handy for longer vocabulary lists). Mutually exclusive with --hint/--prompt.
     /// Leading/trailing whitespace is trimmed; an empty file means no hint.
-    #[arg(
-        long,
-        visible_alias = "hint-file",
-        value_name = "PATH",
-        conflicts_with = "prompt"
-    )]
+    #[arg(long, visible_alias = "hint-file", value_name = "PATH", conflicts_with = "prompt")]
     pub prompt_file: Option<PathBuf>,
 
     /// Opt in to strict one-edit vocabulary correction from the selected hint.
@@ -205,11 +200,7 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         )));
     }
 
-    eprintln!(
-        "Loading model once for {} input(s): {}...",
-        files.len(),
-        model.display_name()
-    );
+    eprintln!("Loading model once for {} input(s): {}...", files.len(), model.display_name());
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
@@ -275,15 +266,9 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             let BatchItem::Ok { result, .. } = &items[0] else {
                 unreachable!("successful single item")
             };
-            println!(
-                "{}",
-                serde_json::to_string_pretty(result).expect("result serializes")
-            );
+            println!("{}", serde_json::to_string_pretty(result).expect("result serializes"));
         } else {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&items).expect("batch serializes")
-            );
+            println!("{}", serde_json::to_string_pretty(&items).expect("batch serializes"));
         }
     }
 
@@ -345,6 +330,7 @@ fn transcribe_file(
     glossary: &Glossary,
     correction_vocabulary: &[String],
 ) -> Result<FileTranscription, DictationError> {
+
     // Decode audio file
     eprintln!("Decoding {}...", file.display());
     let audio = decode_audio_file(file)?;
@@ -381,29 +367,25 @@ fn transcribe_file(
             eprintln!("Note: --beam / --vad have no effect with --diarize.");
         }
         use sagascript_core::diarization::{
+            DiarizeConfig, TimestampedSegment,
             diarize,
             merge::{consolidate, merge_with_transcript},
             model::all_models_downloaded,
-            DiarizeConfig, TimestampedSegment,
         };
 
         if !all_models_downloaded() {
             return Err(DictationError::DiarizationError(
-                "Diarization models not found. Run: sagascript download-model diarization"
-                    .to_string(),
+                "Diarization models not found. Run: sagascript download-model diarization".to_string(),
             ));
         }
 
         // Run diarization and timestamped transcription in parallel isn't possible
         // with a single-threaded whisper context, so we run sequentially.
         eprintln!("Running speaker diarization...");
-        let speaker_segments = diarize(
-            &audio,
-            &DiarizeConfig {
-                threshold: args.diarize_threshold,
-                ..DiarizeConfig::default()
-            },
-        )?;
+        let speaker_segments = diarize(&audio, &DiarizeConfig {
+            threshold: args.diarize_threshold,
+            ..DiarizeConfig::default()
+        })?;
         eprintln!("Found {} speaker segment(s)", speaker_segments.len());
         if std::env::var("SAGA_DIAR_DEBUG").is_ok() {
             for s in &speaker_segments {
@@ -532,12 +514,18 @@ fn transcribe_file(
 
     let mut segments = if duration > 10.0 {
         let pb = ProgressBar::new(100);
-        pb.set_style(ProgressStyle::with_template("  Transcribing [{bar:40}] {pos}%").unwrap());
+        pb.set_style(
+            ProgressStyle::with_template("  Transcribing [{bar:40}] {pos}%").unwrap(),
+        );
         let pb_cb = pb.clone();
-        let segments =
-            backend.transcribe_sync_with_options_segments(&audio, language, &opts, move |pct| {
+        let segments = backend.transcribe_sync_with_options_segments(
+            &audio,
+            language,
+            &opts,
+            move |pct| {
                 crate::set_transcription_progress(&pb_cb, pct);
-            })?;
+            },
+        )?;
         pb.finish_and_clear();
         segments
     } else {
@@ -708,7 +696,8 @@ fn apply_hint_corrections(
         let Some(avg_logprob) = segment.avg_logprob else {
             continue;
         };
-        if !(VOCAB_CORRECTION_MIN_LOGPROB..=VOCAB_CORRECTION_MAX_LOGPROB).contains(&avg_logprob)
+        if !(VOCAB_CORRECTION_MIN_LOGPROB..=VOCAB_CORRECTION_MAX_LOGPROB)
+            .contains(&avg_logprob)
             || segment.no_speech_prob > VOCAB_CORRECTION_MAX_NO_SPEECH_PROB
         {
             continue;
@@ -731,10 +720,7 @@ fn apply_glossary_corrections(
     segments: &mut [TranscriptSegment],
     glossary: &Glossary,
 ) -> Vec<VocabularyCorrection> {
-    let original = segments
-        .iter()
-        .map(|segment| segment.text.as_str())
-        .collect::<String>();
+    let original = segments.iter().map(|segment| segment.text.as_str()).collect::<String>();
     let (corrected, applied) = glossary.correct_text(&original);
     if applied.is_empty() {
         return Vec::new();
@@ -753,8 +739,7 @@ fn apply_glossary_corrections(
     let mut cursor = 0;
     for correction in applied {
         append_original_range(&original, cursor, correction.start, &ranges, &mut rebuilt);
-        let segment_index = ranges
-            .iter()
+        let segment_index = ranges.iter()
             .position(|(start, end)| *start <= correction.start && correction.start < *end)
             .unwrap_or_else(|| segments.len().saturating_sub(1));
         rebuilt[segment_index].push_str(&correction.replacement);
@@ -773,13 +758,7 @@ fn apply_glossary_corrections(
     for (segment, text) in segments.iter_mut().zip(rebuilt) {
         segment.text = text;
     }
-    debug_assert_eq!(
-        segments
-            .iter()
-            .map(|segment| segment.text.as_str())
-            .collect::<String>(),
-        corrected
-    );
+    debug_assert_eq!(segments.iter().map(|segment| segment.text.as_str()).collect::<String>(), corrected);
     corrections
 }
 
@@ -1023,7 +1002,8 @@ fn detect_file_language(
         return transcription_backend.detect_language(audio);
     }
 
-    let Some(detection_model) = neutral_language_detection_model(model::is_model_downloaded) else {
+    let Some(detection_model) = neutral_language_detection_model(model::is_model_downloaded)
+    else {
         eprintln!(
             "Warning: language mismatch check skipped because no neutral multilingual model is downloaded."
         );
@@ -1247,8 +1227,8 @@ pub fn model_id_string(model: WhisperModel) -> &'static str {
 
 pub fn copy_to_clipboard(text: &str) -> Result<(), DictationError> {
     use arboard::Clipboard;
-    let mut clipboard = Clipboard::new()
-        .map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
+    let mut clipboard =
+        Clipboard::new().map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
     clipboard
         .set_text(text)
         .map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
@@ -1261,8 +1241,10 @@ mod tests {
 
     #[test]
     fn directory_expansion_filters_sorts_recurses_and_deduplicates() {
-        let root =
-            std::env::temp_dir().join(format!("sagascript-batch-test-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-batch-test-{}",
+            uuid::Uuid::new_v4()
+        ));
         std::fs::create_dir(&root).unwrap();
         let nested = root.join("nested");
         std::fs::create_dir(&nested).unwrap();
@@ -1306,9 +1288,7 @@ mod tests {
             |_, file| {
                 visited.push(file.to_path_buf());
                 if file == Path::new("bad.wav") {
-                    Err(DictationError::FileDecodeError(
-                        "corrupt fixture".to_string(),
-                    ))
+                    Err(DictationError::FileDecodeError("corrupt fixture".to_string()))
                 } else {
                     Ok(FileTranscription {
                         json: serde_json::json!({"text": file.display().to_string()}),
@@ -1467,12 +1447,7 @@ mod tests {
     #[test]
     fn does_not_correct_confident_suspect_or_non_speech_segments() {
         let vocabulary = ["Grimnir".to_string()];
-        for (avg_logprob, no_speech_prob) in [
-            (Some(-0.2), 0.0),
-            (Some(-0.9), 0.0),
-            (None, 0.0),
-            (Some(-0.313), 0.6),
-        ] {
+        for (avg_logprob, no_speech_prob) in [(Some(-0.2), 0.0), (Some(-0.9), 0.0), (None, 0.0), (Some(-0.313), 0.6)] {
             let mut segments = vec![segment(" Grimner", avg_logprob, no_speech_prob)];
             assert!(apply_hint_corrections(&mut segments, &vocabulary).is_empty());
             assert_eq!(segments[0].text, " Grimner");
@@ -1521,9 +1496,7 @@ mod tests {
     #[test]
     fn effective_prompt_none_when_all_empty() {
         assert!(resolve_effective_prompt(None, None, "").unwrap().is_none());
-        assert!(resolve_effective_prompt(None, None, "   ")
-            .unwrap()
-            .is_none());
+        assert!(resolve_effective_prompt(None, None, "   ").unwrap().is_none());
     }
 
     #[test]
@@ -1720,17 +1693,25 @@ mod tests {
 
     #[test]
     fn resolve_effective_model_none_no_auto_uses_fallback_ignoring_language() {
-        let result =
-            resolve_effective_model(None, Language::Swedish, false, WhisperModel::LargeV3Turbo)
-                .unwrap();
+        let result = resolve_effective_model(
+            None,
+            Language::Swedish,
+            false,
+            WhisperModel::LargeV3Turbo,
+        )
+        .unwrap();
         assert_eq!(result, WhisperModel::LargeV3Turbo);
     }
 
     #[test]
     fn resolve_effective_model_explicit_arg_wins_over_auto_select() {
-        let result =
-            resolve_effective_model(Some("tiny.en"), Language::Swedish, true, WhisperModel::Base)
-                .unwrap();
+        let result = resolve_effective_model(
+            Some("tiny.en"),
+            Language::Swedish,
+            true,
+            WhisperModel::Base,
+        )
+        .unwrap();
         assert_eq!(result, WhisperModel::TinyEn);
     }
 
@@ -1761,12 +1742,7 @@ mod tests {
     #[test]
     fn uncertain_language_detector_escalates_to_downloaded_turbo() {
         let selected = accurate_language_detection_model(
-            |model| {
-                matches!(
-                    model,
-                    WhisperModel::LargeV3TurboQ8 | WhisperModel::LargeV3Turbo
-                )
-            },
+            |model| matches!(model, WhisperModel::LargeV3TurboQ8 | WhisperModel::LargeV3Turbo),
             WhisperModel::Base,
         );
         assert_eq!(selected, Some(WhisperModel::LargeV3TurboQ8));

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -16,7 +16,7 @@ use sagascript_core::transcription::diagnostics::{
 };
 use sagascript_core::transcription::model;
 use sagascript_core::transcription::{
-    TranscriptSegment, TranscribeOptions, WhisperBackend, normalize_nonspeech_markers,
+    Glossary, TranscriptSegment, TranscribeOptions, WhisperBackend, normalize_nonspeech_markers,
 };
 
 #[derive(Args)]
@@ -171,14 +171,15 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         args.prompt_file.as_deref(),
         &stored.initial_prompt,
     )?;
+    let glossary = Glossary::parse(effective_prompt.as_deref().unwrap_or_default());
     let correction_vocabulary = if args.correct_hints {
-        let prompt = effective_prompt.as_deref().ok_or_else(|| {
+        effective_prompt.as_deref().ok_or_else(|| {
             DictationError::SettingsError(
                 "--correct-hints requires a non-empty --hint/--prompt (or saved initial_prompt)"
                     .to_string(),
             )
         })?;
-        let vocabulary = correction_vocabulary_from_hint(prompt);
+        let vocabulary = glossary.single_word_terms();
         if vocabulary.is_empty() {
             return Err(DictationError::SettingsError(
                 "--correct-hints requires at least one single-word vocabulary item in the hint"
@@ -216,7 +217,7 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
                 &stored,
                 language,
                 model,
-                effective_prompt.clone(),
+                &glossary,
                 &correction_vocabulary,
             )
         },
@@ -326,7 +327,7 @@ fn transcribe_file(
     stored: &Settings,
     language: Language,
     model: WhisperModel,
-    effective_prompt: Option<String>,
+    glossary: &Glossary,
     correction_vocabulary: &[String],
 ) -> Result<FileTranscription, DictationError> {
 
@@ -399,7 +400,7 @@ fn transcribe_file(
         let raw_segments = backend.transcribe_sync_for_diarization(
             &audio,
             language,
-            effective_prompt.as_deref(),
+            glossary.decoder_prompt().as_deref(),
         )?;
         eprintln!("Got {} word/segment(s) for merging", raw_segments.len());
         if std::env::var("SAGA_DIAR_DEBUG").is_ok() {
@@ -415,8 +416,12 @@ fn transcribe_file(
 
         let diarized = merge_with_transcript(&speaker_segments, &transcript);
         let mut consolidated = consolidate(&diarized);
+        let mut glossary_corrections = Vec::new();
         for segment in &mut consolidated {
             segment.text = normalize_nonspeech_markers(&segment.text, language);
+            let (corrected, corrections) = glossary.correct_text(&segment.text);
+            segment.text = corrected;
+            glossary_corrections.extend(corrections);
         }
         let diagnostic_segments: Vec<TranscriptSegment> = consolidated
             .iter()
@@ -461,6 +466,7 @@ fn transcribe_file(
             "language_redetection_enabled": language_regions.is_some(),
             "language_regions": language_regions.as_ref().map(|diagnostics| &diagnostics.regions),
             "warnings": warnings,
+            "vocabulary_corrections": glossary_corrections,
         });
         return Ok(FileTranscription { json, plain });
     }
@@ -485,7 +491,7 @@ fn transcribe_file(
         None
     };
     let opts = TranscribeOptions {
-        prompt: effective_prompt,
+        prompt: glossary.decoder_prompt(),
         // File transcription isn't latency-sensitive, so default to beam search
         // (fewer repetition loops). Honor an explicit beam setting/flag.
         beam_size: args.beam_size.unwrap_or(if stored.beam_size >= 2 {
@@ -526,11 +532,10 @@ fn transcribe_file(
         eprintln!("Transcribing...");
         backend.transcribe_sync_with_options_segments(&audio, language, &opts, |_| {})?
     };
-    let corrections = if args.correct_hints {
-        apply_hint_corrections(&mut segments, correction_vocabulary)
-    } else {
-        Vec::new()
-    };
+    let mut corrections = apply_glossary_corrections(&mut segments, glossary);
+    if args.correct_hints {
+        corrections.extend(apply_hint_corrections(&mut segments, correction_vocabulary));
+    }
     let repetition = analyze_repetition(&segments);
     let trusted_segments: Vec<TranscriptSegment> = segments
         .iter()
@@ -677,23 +682,9 @@ struct VocabularyCorrection {
     segment_index: usize,
     original: String,
     replacement: String,
-    avg_logprob: f32,
+    method: &'static str,
+    avg_logprob: Option<f32>,
     no_speech_prob: f32,
-}
-
-/// Extract the deliberately narrow v1 correction vocabulary from an existing
-/// decoder hint. Hints are comma- or newline-separated; phrases, numbers and
-/// punctuation are intentionally ignored so ordinary prose cannot become a
-/// correction target.
-fn correction_vocabulary_from_hint(hint: &str) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    hint
-        .split([',', '\n'])
-        .map(str::trim)
-        .filter(|candidate| !candidate.is_empty() && candidate.chars().all(char::is_alphabetic))
-        .filter(|candidate| seen.insert(candidate.to_lowercase()))
-        .map(str::to_string)
-        .collect()
 }
 
 fn apply_hint_corrections(
@@ -721,6 +712,26 @@ fn apply_hint_corrections(
         );
         segment.text = corrected;
         corrections.extend(segment_corrections);
+    }
+    corrections
+}
+
+fn apply_glossary_corrections(
+    segments: &mut [TranscriptSegment],
+    glossary: &Glossary,
+) -> Vec<VocabularyCorrection> {
+    let mut corrections = Vec::new();
+    for (segment_index, segment) in segments.iter_mut().enumerate() {
+        let (corrected, applied) = glossary.correct_text(&segment.text);
+        segment.text = corrected;
+        corrections.extend(applied.into_iter().map(|correction| VocabularyCorrection {
+            segment_index,
+            original: correction.original,
+            replacement: correction.replacement,
+            method: "explicit_alias",
+            avg_logprob: segment.avg_logprob,
+            no_speech_prob: segment.no_speech_prob,
+        }));
     }
     corrections
 }
@@ -759,7 +770,8 @@ fn correct_segment_text(
                 segment_index,
                 original: word.clone(),
                 replacement: replacement.clone(),
-                avg_logprob,
+                method: "fuzzy_one_edit",
+                avg_logprob: Some(avg_logprob),
                 no_speech_prob,
             });
             corrected.push_str(&replacement);
@@ -1340,9 +1352,22 @@ mod tests {
     }
 
     #[test]
+    fn explicit_aliases_correct_without_confidence_guessing() {
+        let glossary = Glossary::parse("OpenRouter = open router\nmerge = merch");
+        let mut segments = vec![segment(" Open router och Merch.", None, 0.0)];
+        let corrections = apply_glossary_corrections(&mut segments, &glossary);
+
+        assert_eq!(segments[0].text, " OpenRouter och merge.");
+        assert_eq!(corrections.len(), 2);
+        assert_eq!(corrections[0].method, "explicit_alias");
+        assert_eq!(corrections[0].avg_logprob, None);
+    }
+
+    #[test]
     fn correction_vocabulary_accepts_only_single_word_hint_items() {
         assert_eq!(
-            correction_vocabulary_from_hint("Grimnir, grimnir, Erik Fredlund\nHugin, M5, AI-agent"),
+            Glossary::parse("Grimnir, grimnir, Erik Fredlund\nHugin, M5, AI-agent")
+                .single_word_terms(),
             vec!["Grimnir", "Hugin"]
         );
     }
@@ -1357,7 +1382,8 @@ mod tests {
         assert_eq!(corrections[0].original, "Grimner");
         assert_eq!(corrections[0].replacement, "Grimnir");
         assert_eq!(corrections[0].segment_index, 0);
-        assert_eq!(corrections[0].avg_logprob, -0.313);
+        assert_eq!(corrections[0].method, "fuzzy_one_edit");
+        assert_eq!(corrections[0].avg_logprob, Some(-0.313));
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -6,17 +6,17 @@ use clap::Args;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
-use sagascript_core::audio::decoder::{SUPPORTED_EXTENSIONS, decode_audio_file};
+use sagascript_core::audio::decoder::{decode_audio_file, SUPPORTED_EXTENSIONS};
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{Language, Settings, WhisperModel};
 use sagascript_core::transcription::diagnostics::{
+    analyze_coverage, analyze_language_windows, analyze_repetition, language_mismatch_warning,
     CoverageDiagnostics, LanguageDetection, LanguageRegionDiagnostics, LanguageWindow,
-    TranscriptionWarning, analyze_coverage, analyze_language_windows, analyze_repetition,
-    language_mismatch_warning,
+    TranscriptionWarning,
 };
 use sagascript_core::transcription::model;
 use sagascript_core::transcription::{
-    Glossary, TranscriptSegment, TranscribeOptions, WhisperBackend, normalize_nonspeech_markers,
+    normalize_nonspeech_markers, Glossary, TranscribeOptions, TranscriptSegment, WhisperBackend,
 };
 
 #[derive(Args)]
@@ -81,7 +81,12 @@ pub struct TranscribeArgs {
     /// Read the hint/initial prompt from a file instead of the command line
     /// (handy for longer vocabulary lists). Mutually exclusive with --hint/--prompt.
     /// Leading/trailing whitespace is trimmed; an empty file means no hint.
-    #[arg(long, visible_alias = "hint-file", value_name = "PATH", conflicts_with = "prompt")]
+    #[arg(
+        long,
+        visible_alias = "hint-file",
+        value_name = "PATH",
+        conflicts_with = "prompt"
+    )]
     pub prompt_file: Option<PathBuf>,
 
     /// Opt in to strict one-edit vocabulary correction from the selected hint.
@@ -200,7 +205,11 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         )));
     }
 
-    eprintln!("Loading model once for {} input(s): {}...", files.len(), model.display_name());
+    eprintln!(
+        "Loading model once for {} input(s): {}...",
+        files.len(),
+        model.display_name()
+    );
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
@@ -266,9 +275,15 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             let BatchItem::Ok { result, .. } = &items[0] else {
                 unreachable!("successful single item")
             };
-            println!("{}", serde_json::to_string_pretty(result).expect("result serializes"));
+            println!(
+                "{}",
+                serde_json::to_string_pretty(result).expect("result serializes")
+            );
         } else {
-            println!("{}", serde_json::to_string_pretty(&items).expect("batch serializes"));
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&items).expect("batch serializes")
+            );
         }
     }
 
@@ -330,7 +345,6 @@ fn transcribe_file(
     glossary: &Glossary,
     correction_vocabulary: &[String],
 ) -> Result<FileTranscription, DictationError> {
-
     // Decode audio file
     eprintln!("Decoding {}...", file.display());
     let audio = decode_audio_file(file)?;
@@ -367,25 +381,29 @@ fn transcribe_file(
             eprintln!("Note: --beam / --vad have no effect with --diarize.");
         }
         use sagascript_core::diarization::{
-            DiarizeConfig, TimestampedSegment,
             diarize,
             merge::{consolidate, merge_with_transcript},
             model::all_models_downloaded,
+            DiarizeConfig, TimestampedSegment,
         };
 
         if !all_models_downloaded() {
             return Err(DictationError::DiarizationError(
-                "Diarization models not found. Run: sagascript download-model diarization".to_string(),
+                "Diarization models not found. Run: sagascript download-model diarization"
+                    .to_string(),
             ));
         }
 
         // Run diarization and timestamped transcription in parallel isn't possible
         // with a single-threaded whisper context, so we run sequentially.
         eprintln!("Running speaker diarization...");
-        let speaker_segments = diarize(&audio, &DiarizeConfig {
-            threshold: args.diarize_threshold,
-            ..DiarizeConfig::default()
-        })?;
+        let speaker_segments = diarize(
+            &audio,
+            &DiarizeConfig {
+                threshold: args.diarize_threshold,
+                ..DiarizeConfig::default()
+            },
+        )?;
         eprintln!("Found {} speaker segment(s)", speaker_segments.len());
         if std::env::var("SAGA_DIAR_DEBUG").is_ok() {
             for s in &speaker_segments {
@@ -514,18 +532,12 @@ fn transcribe_file(
 
     let mut segments = if duration > 10.0 {
         let pb = ProgressBar::new(100);
-        pb.set_style(
-            ProgressStyle::with_template("  Transcribing [{bar:40}] {pos}%").unwrap(),
-        );
+        pb.set_style(ProgressStyle::with_template("  Transcribing [{bar:40}] {pos}%").unwrap());
         let pb_cb = pb.clone();
-        let segments = backend.transcribe_sync_with_options_segments(
-            &audio,
-            language,
-            &opts,
-            move |pct| {
+        let segments =
+            backend.transcribe_sync_with_options_segments(&audio, language, &opts, move |pct| {
                 crate::set_transcription_progress(&pb_cb, pct);
-            },
-        )?;
+            })?;
         pb.finish_and_clear();
         segments
     } else {
@@ -696,8 +708,7 @@ fn apply_hint_corrections(
         let Some(avg_logprob) = segment.avg_logprob else {
             continue;
         };
-        if !(VOCAB_CORRECTION_MIN_LOGPROB..=VOCAB_CORRECTION_MAX_LOGPROB)
-            .contains(&avg_logprob)
+        if !(VOCAB_CORRECTION_MIN_LOGPROB..=VOCAB_CORRECTION_MAX_LOGPROB).contains(&avg_logprob)
             || segment.no_speech_prob > VOCAB_CORRECTION_MAX_NO_SPEECH_PROB
         {
             continue;
@@ -720,20 +731,72 @@ fn apply_glossary_corrections(
     segments: &mut [TranscriptSegment],
     glossary: &Glossary,
 ) -> Vec<VocabularyCorrection> {
-    let mut corrections = Vec::new();
-    for (segment_index, segment) in segments.iter_mut().enumerate() {
-        let (corrected, applied) = glossary.correct_text(&segment.text);
-        segment.text = corrected;
-        corrections.extend(applied.into_iter().map(|correction| VocabularyCorrection {
+    let original = segments
+        .iter()
+        .map(|segment| segment.text.as_str())
+        .collect::<String>();
+    let (corrected, applied) = glossary.correct_text(&original);
+    if applied.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::with_capacity(segments.len());
+    let mut offset = 0;
+    for segment in segments.iter() {
+        let end = offset + segment.text.len();
+        ranges.push((offset, end));
+        offset = end;
+    }
+
+    let mut rebuilt = vec![String::new(); segments.len()];
+    let mut corrections = Vec::with_capacity(applied.len());
+    let mut cursor = 0;
+    for correction in applied {
+        append_original_range(&original, cursor, correction.start, &ranges, &mut rebuilt);
+        let segment_index = ranges
+            .iter()
+            .position(|(start, end)| *start <= correction.start && correction.start < *end)
+            .unwrap_or_else(|| segments.len().saturating_sub(1));
+        rebuilt[segment_index].push_str(&correction.replacement);
+        corrections.push(VocabularyCorrection {
             segment_index,
             original: correction.original,
             replacement: correction.replacement,
             method: "explicit_alias",
-            avg_logprob: segment.avg_logprob,
-            no_speech_prob: segment.no_speech_prob,
-        }));
+            avg_logprob: segments[segment_index].avg_logprob,
+            no_speech_prob: segments[segment_index].no_speech_prob,
+        });
+        cursor = correction.end;
     }
+    append_original_range(&original, cursor, original.len(), &ranges, &mut rebuilt);
+
+    for (segment, text) in segments.iter_mut().zip(rebuilt) {
+        segment.text = text;
+    }
+    debug_assert_eq!(
+        segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect::<String>(),
+        corrected
+    );
     corrections
+}
+
+fn append_original_range(
+    original: &str,
+    start: usize,
+    end: usize,
+    segment_ranges: &[(usize, usize)],
+    output: &mut [String],
+) {
+    for (segment_index, (segment_start, segment_end)) in segment_ranges.iter().enumerate() {
+        let slice_start = start.max(*segment_start);
+        let slice_end = end.min(*segment_end);
+        if slice_start < slice_end {
+            output[segment_index].push_str(&original[slice_start..slice_end]);
+        }
+    }
 }
 
 fn correct_segment_text(
@@ -960,8 +1023,7 @@ fn detect_file_language(
         return transcription_backend.detect_language(audio);
     }
 
-    let Some(detection_model) = neutral_language_detection_model(model::is_model_downloaded)
-    else {
+    let Some(detection_model) = neutral_language_detection_model(model::is_model_downloaded) else {
         eprintln!(
             "Warning: language mismatch check skipped because no neutral multilingual model is downloaded."
         );
@@ -1185,8 +1247,8 @@ pub fn model_id_string(model: WhisperModel) -> &'static str {
 
 pub fn copy_to_clipboard(text: &str) -> Result<(), DictationError> {
     use arboard::Clipboard;
-    let mut clipboard =
-        Clipboard::new().map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
+    let mut clipboard = Clipboard::new()
+        .map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
     clipboard
         .set_text(text)
         .map_err(|e| DictationError::PasteError(format!("Clipboard error: {e}")))?;
@@ -1199,10 +1261,8 @@ mod tests {
 
     #[test]
     fn directory_expansion_filters_sorts_recurses_and_deduplicates() {
-        let root = std::env::temp_dir().join(format!(
-            "sagascript-batch-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("sagascript-batch-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir(&root).unwrap();
         let nested = root.join("nested");
         std::fs::create_dir(&nested).unwrap();
@@ -1246,7 +1306,9 @@ mod tests {
             |_, file| {
                 visited.push(file.to_path_buf());
                 if file == Path::new("bad.wav") {
-                    Err(DictationError::FileDecodeError("corrupt fixture".to_string()))
+                    Err(DictationError::FileDecodeError(
+                        "corrupt fixture".to_string(),
+                    ))
                 } else {
                     Ok(FileTranscription {
                         json: serde_json::json!({"text": file.display().to_string()}),
@@ -1364,6 +1426,22 @@ mod tests {
     }
 
     #[test]
+    fn explicit_phrase_aliases_cross_whisper_segment_boundaries() {
+        let glossary = Glossary::parse("OpenRouter = open router");
+        let mut segments = vec![
+            segment("Jag använder open", Some(-0.2), 0.0),
+            segment(" router varje dag.", Some(-0.4), 0.0),
+        ];
+        let corrections = apply_glossary_corrections(&mut segments, &glossary);
+
+        assert_eq!(segments[0].text, "Jag använder OpenRouter");
+        assert_eq!(segments[1].text, " varje dag.");
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].segment_index, 0);
+        assert_eq!(corrections[0].avg_logprob, Some(-0.2));
+    }
+
+    #[test]
     fn correction_vocabulary_accepts_only_single_word_hint_items() {
         assert_eq!(
             Glossary::parse("Grimnir, grimnir, Erik Fredlund\nHugin, M5, AI-agent")
@@ -1389,7 +1467,12 @@ mod tests {
     #[test]
     fn does_not_correct_confident_suspect_or_non_speech_segments() {
         let vocabulary = ["Grimnir".to_string()];
-        for (avg_logprob, no_speech_prob) in [(Some(-0.2), 0.0), (Some(-0.9), 0.0), (None, 0.0), (Some(-0.313), 0.6)] {
+        for (avg_logprob, no_speech_prob) in [
+            (Some(-0.2), 0.0),
+            (Some(-0.9), 0.0),
+            (None, 0.0),
+            (Some(-0.313), 0.6),
+        ] {
             let mut segments = vec![segment(" Grimner", avg_logprob, no_speech_prob)];
             assert!(apply_hint_corrections(&mut segments, &vocabulary).is_empty());
             assert_eq!(segments[0].text, " Grimner");
@@ -1438,7 +1521,9 @@ mod tests {
     #[test]
     fn effective_prompt_none_when_all_empty() {
         assert!(resolve_effective_prompt(None, None, "").unwrap().is_none());
-        assert!(resolve_effective_prompt(None, None, "   ").unwrap().is_none());
+        assert!(resolve_effective_prompt(None, None, "   ")
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -1635,25 +1720,17 @@ mod tests {
 
     #[test]
     fn resolve_effective_model_none_no_auto_uses_fallback_ignoring_language() {
-        let result = resolve_effective_model(
-            None,
-            Language::Swedish,
-            false,
-            WhisperModel::LargeV3Turbo,
-        )
-        .unwrap();
+        let result =
+            resolve_effective_model(None, Language::Swedish, false, WhisperModel::LargeV3Turbo)
+                .unwrap();
         assert_eq!(result, WhisperModel::LargeV3Turbo);
     }
 
     #[test]
     fn resolve_effective_model_explicit_arg_wins_over_auto_select() {
-        let result = resolve_effective_model(
-            Some("tiny.en"),
-            Language::Swedish,
-            true,
-            WhisperModel::Base,
-        )
-        .unwrap();
+        let result =
+            resolve_effective_model(Some("tiny.en"), Language::Swedish, true, WhisperModel::Base)
+                .unwrap();
         assert_eq!(result, WhisperModel::TinyEn);
     }
 
@@ -1684,7 +1761,12 @@ mod tests {
     #[test]
     fn uncertain_language_detector_escalates_to_downloaded_turbo() {
         let selected = accurate_language_detection_model(
-            |model| matches!(model, WhisperModel::LargeV3TurboQ8 | WhisperModel::LargeV3Turbo),
+            |model| {
+                matches!(
+                    model,
+                    WhisperModel::LargeV3TurboQ8 | WhisperModel::LargeV3Turbo
+                )
+            },
             WhisperModel::Base,
         );
         assert_eq!(selected, Some(WhisperModel::LargeV3TurboQ8));

--- a/src-tauri/crates/sagascript-core/Cargo.toml
+++ b/src-tauri/crates/sagascript-core/Cargo.toml
@@ -20,6 +20,7 @@ sha2 = "0.10"
 num_cpus = "1"
 symphonia = { version = "0.5", features = ["aac", "alac", "flac", "mp3", "pcm", "vorbis", "isomp4", "mkv", "ogg"] }
 rubato = "0.14"
+regex = "1"
 
 # Live audio capture (optional): a pure batch-transcribe build
 # (`--no-default-features` on sagascript-cli) needs no cpal — and on Linux, no ALSA.

--- a/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
@@ -83,11 +83,7 @@ impl Glossary {
             }
         }
 
-        let mut glossary = Self {
-            source,
-            entries,
-            matchers: Vec::new(),
-        };
+        let mut glossary = Self { source, entries, matchers: Vec::new() };
         glossary.rebuild_matchers();
         glossary
     }
@@ -157,7 +153,7 @@ impl Glossary {
         let mut candidates = Vec::new();
         for matcher in &self.matchers {
             for matched in matcher.pattern.find_iter(text) {
-                if &text[matched.start()..matched.end()] != matcher.canonical {
+                if text[matched.start()..matched.end()] != matcher.canonical {
                     candidates.push(Candidate {
                         start: matched.start(),
                         end: matched.end(),
@@ -184,10 +180,7 @@ impl Glossary {
         let mut candidates = candidates.into_iter().peekable();
         while let Some(candidate) = candidates.next() {
             let mut ambiguous = false;
-            while candidates
-                .peek()
-                .is_some_and(|next| next.start == candidate.start && next.end == candidate.end)
-            {
+            while candidates.peek().is_some_and(|next| next.start == candidate.start && next.end == candidate.end) {
                 let duplicate = candidates.next().expect("peeked candidate");
                 ambiguous |= duplicate.canonical != candidate.canonical;
             }
@@ -195,7 +188,6 @@ impl Glossary {
                 unambiguous.push(candidate);
             }
         }
-
         let mut selected = Vec::new();
         let mut cursor = 0;
         for candidate in unambiguous {
@@ -251,20 +243,16 @@ impl Glossary {
     }
 
     fn rebuild_matchers(&mut self) {
-        self.matchers = self
-            .entries
-            .iter()
+        self.matchers = self.entries.iter()
             .filter(|entry| !entry.aliases.is_empty())
             .flat_map(|entry| {
                 std::iter::once(entry.canonical.as_str())
                     .chain(entry.aliases.iter().map(String::as_str))
                     .filter(|alias| has_word_edges(alias))
-                    .filter_map(|alias| {
-                        whole_alias_regex(alias).map(|pattern| AliasMatcher {
-                            canonical: entry.canonical.clone(),
-                            pattern,
-                        })
-                    })
+                    .filter_map(|alias| whole_alias_regex(alias).map(|pattern| AliasMatcher {
+                        canonical: entry.canonical.clone(),
+                        pattern,
+                    }))
             })
             .collect();
     }

--- a/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
@@ -64,13 +64,13 @@ impl Glossary {
 
             if let Some(existing) = entries
                 .iter_mut()
-                .find(|entry| entry.canonical.eq_ignore_ascii_case(canonical))
+                .find(|entry| same_term(&entry.canonical, canonical))
             {
                 for alias in aliases {
                     if !existing
                         .aliases
                         .iter()
-                        .any(|known| known.eq_ignore_ascii_case(&alias))
+                        .any(|known| same_term(known, &alias))
                     {
                         existing.aliases.push(alias);
                     }
@@ -96,13 +96,13 @@ impl Glossary {
         if let Some(existing) = self
             .entries
             .iter_mut()
-            .find(|entry| entry.canonical.eq_ignore_ascii_case(&canonical))
+            .find(|entry| same_term(&entry.canonical, &canonical))
         {
             for alias in aliases {
                 if !existing
                     .aliases
                     .iter()
-                    .any(|known| known.eq_ignore_ascii_case(&alias))
+                    .any(|known| same_term(known, &alias))
                 {
                     existing.aliases.push(alias);
                 }
@@ -117,7 +117,7 @@ impl Glossary {
     pub fn remove(&mut self, canonical: &str) -> bool {
         let previous_len = self.entries.len();
         self.entries
-            .retain(|entry| !entry.canonical.eq_ignore_ascii_case(canonical));
+            .retain(|entry| !same_term(&entry.canonical, canonical));
         let removed = self.entries.len() != previous_len;
         if removed {
             self.source = self.render();
@@ -220,6 +220,47 @@ impl Glossary {
         (corrected, corrections)
     }
 
+    /// Correct one logical transcript while preserving its original fragment
+    /// boundaries. This lets timestamped and diarized callers match phrases
+    /// that Whisper split across adjacent segments.
+    pub fn correct_fragments(
+        &self,
+        fragments: &[&str],
+    ) -> (Vec<String>, Vec<(usize, GlossaryCorrection)>) {
+        let original = fragments.concat();
+        let (corrected, corrections) = self.correct_text(&original);
+        if corrections.is_empty() {
+            return (
+                fragments.iter().map(|fragment| (*fragment).to_string()).collect(),
+                Vec::new(),
+            );
+        }
+
+        let mut ranges = Vec::with_capacity(fragments.len());
+        let mut offset = 0;
+        for fragment in fragments {
+            let end = offset + fragment.len();
+            ranges.push((offset, end));
+            offset = end;
+        }
+
+        let mut rebuilt = vec![String::new(); fragments.len()];
+        let mut projected = Vec::with_capacity(corrections.len());
+        let mut cursor = 0;
+        for correction in corrections {
+            append_original_range(&original, cursor, correction.start, &ranges, &mut rebuilt);
+            let fragment_index = ranges.iter()
+                .position(|(start, end)| *start <= correction.start && correction.start < *end)
+                .unwrap_or_else(|| fragments.len().saturating_sub(1));
+            rebuilt[fragment_index].push_str(&correction.replacement);
+            cursor = correction.end;
+            projected.push((fragment_index, correction));
+        }
+        append_original_range(&original, cursor, original.len(), &ranges, &mut rebuilt);
+        debug_assert_eq!(rebuilt.concat(), corrected);
+        (rebuilt, projected)
+    }
+
     pub fn render(&self) -> String {
         self.entries
             .iter()
@@ -255,6 +296,26 @@ impl Glossary {
                     }))
             })
             .collect();
+    }
+}
+
+fn same_term(left: &str, right: &str) -> bool {
+    left.to_lowercase() == right.to_lowercase()
+}
+
+fn append_original_range(
+    original: &str,
+    start: usize,
+    end: usize,
+    fragment_ranges: &[(usize, usize)],
+    output: &mut [String],
+) {
+    for (fragment_index, (fragment_start, fragment_end)) in fragment_ranges.iter().enumerate() {
+        let slice_start = start.max(*fragment_start);
+        let slice_end = end.min(*fragment_end);
+        if slice_start < slice_end {
+            output[fragment_index].push_str(&original[slice_start..slice_end]);
+        }
     }
 }
 
@@ -360,6 +421,25 @@ mod tests {
         assert_eq!(corrections.len(), 1);
         assert_eq!(corrections[0].start, 5);
         assert_eq!(corrections[0].end, 16);
+    }
+
+    #[test]
+    fn corrects_phrases_across_fragment_boundaries() {
+        let glossary = Glossary::parse("OpenRouter = open router");
+        let (fragments, corrections) = glossary.correct_fragments(&["open", " router!"]);
+        assert_eq!(fragments, vec!["OpenRouter", "!"]);
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].0, 0);
+    }
+
+    #[test]
+    fn unicode_case_is_consistent_for_parse_upsert_and_remove() {
+        let mut glossary = Glossary::parse("Ångström = ångstrom\nåNGSTRÖM = angstrom");
+        assert_eq!(glossary.entries().len(), 1);
+        glossary.upsert("ångström".to_string(), vec!["ång stroem".to_string()]);
+        assert_eq!(glossary.entries().len(), 1);
+        assert!(glossary.remove("åNGSTRÖM"));
+        assert!(glossary.entries().is_empty());
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
@@ -300,7 +300,8 @@ impl Glossary {
 }
 
 fn same_term(left: &str, right: &str) -> bool {
-    left.to_lowercase() == right.to_lowercase()
+    Regex::new(&format!(r"(?iu)^{}$", escaped_alias_pattern(left)))
+        .is_ok_and(|pattern| pattern.is_match(right))
 }
 
 fn append_original_range(
@@ -329,6 +330,10 @@ fn has_word_edges(alias: &str) -> bool {
 }
 
 fn whole_alias_regex(alias: &str) -> Option<Regex> {
+    Regex::new(&format!(r"(?iu)\b{}\b", escaped_alias_pattern(alias))).ok()
+}
+
+fn escaped_alias_pattern(alias: &str) -> String {
     let mut escaped = String::new();
     let mut in_whitespace = false;
     for character in alias.chars() {
@@ -342,7 +347,7 @@ fn whole_alias_regex(alias: &str) -> Option<Regex> {
             in_whitespace = false;
         }
     }
-    Regex::new(&format!(r"(?iu)\b{escaped}\b")).ok()
+    escaped
 }
 
 #[cfg(test)]
@@ -439,6 +444,18 @@ mod tests {
         glossary.upsert("ångström".to_string(), vec!["ång stroem".to_string()]);
         assert_eq!(glossary.entries().len(), 1);
         assert!(glossary.remove("åNGSTRÖM"));
+        assert!(glossary.entries().is_empty());
+    }
+
+    #[test]
+    fn management_uses_the_matchers_unicode_case_equivalents() {
+        let mut glossary = Glossary::parse("s, ſ, k, K");
+        assert_eq!(glossary.entries().len(), 2);
+        glossary.upsert("ſ".to_string(), vec!["long ess".to_string()]);
+        assert_eq!(glossary.entries().len(), 2);
+        assert!(glossary.remove("K"));
+        assert_eq!(glossary.entries().len(), 1);
+        assert!(glossary.remove("ſ"));
         assert!(glossary.entries().is_empty());
     }
 

--- a/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
@@ -4,8 +4,6 @@
 //! continue to act only as Whisper hints; `canonical = alias | alias` entries
 //! additionally authorize exact, whole-word/phrase replacements.
 
-use std::collections::{HashMap, HashSet};
-
 use regex::Regex;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,12 +16,23 @@ pub struct GlossaryEntry {
 pub struct GlossaryCorrection {
     pub original: String,
     pub replacement: String,
+    #[serde(skip)]
+    pub start: usize,
+    #[serde(skip)]
+    pub end: usize,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone)]
+struct AliasMatcher {
+    canonical: String,
+    pattern: Regex,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct Glossary {
     source: String,
     entries: Vec<GlossaryEntry>,
+    matchers: Vec<AliasMatcher>,
 }
 
 impl Glossary {
@@ -74,7 +83,13 @@ impl Glossary {
             }
         }
 
-        Self { source, entries }
+        let mut glossary = Self {
+            source,
+            entries,
+            matchers: Vec::new(),
+        };
+        glossary.rebuild_matchers();
+        glossary
     }
 
     pub fn entries(&self) -> &[GlossaryEntry] {
@@ -100,6 +115,7 @@ impl Glossary {
             self.entries.push(GlossaryEntry { canonical, aliases });
         }
         self.source = self.render();
+        self.rebuild_matchers();
     }
 
     pub fn remove(&mut self, canonical: &str) -> bool {
@@ -109,6 +125,7 @@ impl Glossary {
         let removed = self.entries.len() != previous_len;
         if removed {
             self.source = self.render();
+            self.rebuild_matchers();
         }
         removed
     }
@@ -131,65 +148,20 @@ impl Glossary {
 
     pub fn correct_text(&self, text: &str) -> (String, Vec<GlossaryCorrection>) {
         #[derive(Debug)]
-        struct Binding<'a> {
-            alias: String,
-            canonical: &'a str,
-        }
-
-        #[derive(Debug)]
         struct Candidate<'a> {
             start: usize,
             end: usize,
             canonical: &'a str,
         }
 
-        // One alias may appear only once in the effective map. If it points to
-        // different canonical terms, fail closed instead of guessing.
-        let mut bindings_by_key: HashMap<String, Vec<Binding<'_>>> = HashMap::new();
-        for entry in self
-            .entries
-            .iter()
-            .filter(|entry| !entry.aliases.is_empty())
-        {
-            for alias in std::iter::once(entry.canonical.as_str())
-                .chain(entry.aliases.iter().map(String::as_str))
-            {
-                if !has_word_edges(alias) {
-                    continue;
-                }
-                let key = alias_key(alias);
-                let bindings = bindings_by_key.entry(key).or_default();
-                if !bindings.iter().any(|binding| {
-                    binding.canonical.eq_ignore_ascii_case(&entry.canonical)
-                        && binding.alias.eq_ignore_ascii_case(alias)
-                }) {
-                    bindings.push(Binding {
-                        alias: alias.to_string(),
-                        canonical: &entry.canonical,
-                    });
-                }
-            }
-        }
-
         let mut candidates = Vec::new();
-        for bindings in bindings_by_key.values() {
-            let canonical_keys: HashSet<String> = bindings
-                .iter()
-                .map(|binding| binding.canonical.to_lowercase())
-                .collect();
-            if canonical_keys.len() != 1 {
-                continue;
-            }
-            let binding = &bindings[0];
-            let Some(pattern) = whole_alias_regex(&binding.alias) else {
-                continue;
-            };
-            for matched in pattern.find_iter(text) {
-                if &text[matched.start()..matched.end()] != binding.canonical {
+        for matcher in &self.matchers {
+            for matched in matcher.pattern.find_iter(text) {
+                if &text[matched.start()..matched.end()] != matcher.canonical {
                     candidates.push(Candidate {
                         start: matched.start(),
                         end: matched.end(),
-                        canonical: binding.canonical,
+                        canonical: &matcher.canonical,
                     });
                 }
             }
@@ -204,9 +176,29 @@ impl Glossary {
                 .then_with(|| (right.end - right.start).cmp(&(left.end - left.start)))
                 .then_with(|| left.canonical.cmp(right.canonical))
         });
+        // Regex Unicode case folding has equivalence classes that are not
+        // reproduced by lowercasing (for example s/long-s and k/Kelvin sign).
+        // Detect ambiguity by the actual matched byte span so those aliases
+        // fail closed just like identical spellings do.
+        let mut unambiguous = Vec::new();
+        let mut candidates = candidates.into_iter().peekable();
+        while let Some(candidate) = candidates.next() {
+            let mut ambiguous = false;
+            while candidates
+                .peek()
+                .is_some_and(|next| next.start == candidate.start && next.end == candidate.end)
+            {
+                let duplicate = candidates.next().expect("peeked candidate");
+                ambiguous |= duplicate.canonical != candidate.canonical;
+            }
+            if !ambiguous {
+                unambiguous.push(candidate);
+            }
+        }
+
         let mut selected = Vec::new();
         let mut cursor = 0;
-        for candidate in candidates {
+        for candidate in unambiguous {
             if candidate.start >= cursor {
                 cursor = candidate.end;
                 selected.push(candidate);
@@ -227,6 +219,8 @@ impl Glossary {
             corrections.push(GlossaryCorrection {
                 original: original.to_string(),
                 replacement: candidate.canonical.to_string(),
+                start: candidate.start,
+                end: candidate.end,
             });
             last = candidate.end;
         }
@@ -255,14 +249,25 @@ impl Glossary {
             .map(|entry| entry.canonical.clone())
             .collect()
     }
-}
 
-fn alias_key(alias: &str) -> String {
-    alias
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_lowercase()
+    fn rebuild_matchers(&mut self) {
+        self.matchers = self
+            .entries
+            .iter()
+            .filter(|entry| !entry.aliases.is_empty())
+            .flat_map(|entry| {
+                std::iter::once(entry.canonical.as_str())
+                    .chain(entry.aliases.iter().map(String::as_str))
+                    .filter(|alias| has_word_edges(alias))
+                    .filter_map(|alias| {
+                        whole_alias_regex(alias).map(|pattern| AliasMatcher {
+                            canonical: entry.canonical.clone(),
+                            pattern,
+                        })
+                    })
+            })
+            .collect();
+    }
 }
 
 fn has_word_edges(alias: &str) -> bool {
@@ -350,6 +355,23 @@ mod tests {
         let (text, corrections) = glossary.correct_text("grimner");
         assert_eq!(text, "grimner");
         assert!(corrections.is_empty());
+    }
+
+    #[test]
+    fn unicode_case_equivalents_fail_closed_by_actual_match_span() {
+        let glossary = Glossary::parse("LetterS = s\nLongS = ſ\nLetterK = k\nKelvin = K");
+        let (text, corrections) = glossary.correct_text("s ſ k K");
+        assert_eq!(text, "s ſ k K");
+        assert!(corrections.is_empty());
+    }
+
+    #[test]
+    fn corrections_report_original_byte_spans() {
+        let glossary = Glossary::parse("OpenRouter = open router");
+        let (_, corrections) = glossary.correct_text("Hej, open router!");
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].start, 5);
+        assert_eq!(corrections[0].end, 16);
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/glossary.rs
@@ -1,0 +1,385 @@
+//! Personal glossary parsing and deterministic post-transcription correction.
+//!
+//! The persisted `initial_prompt` remains the source of truth. Plain entries
+//! continue to act only as Whisper hints; `canonical = alias | alias` entries
+//! additionally authorize exact, whole-word/phrase replacements.
+
+use std::collections::{HashMap, HashSet};
+
+use regex::Regex;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlossaryEntry {
+    pub canonical: String,
+    pub aliases: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct GlossaryCorrection {
+    pub original: String,
+    pub replacement: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Glossary {
+    source: String,
+    entries: Vec<GlossaryEntry>,
+}
+
+impl Glossary {
+    pub fn parse(source: &str) -> Self {
+        let source = source.trim().to_string();
+        let mut entries: Vec<GlossaryEntry> = Vec::new();
+
+        for item in source
+            .split([',', '\n'])
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+        {
+            let (canonical, aliases) = match item.split_once('=') {
+                Some((canonical, aliases)) => {
+                    let canonical = canonical.trim();
+                    if canonical.is_empty() {
+                        continue;
+                    }
+                    let aliases = aliases
+                        .split('|')
+                        .map(str::trim)
+                        .filter(|alias| !alias.is_empty())
+                        .map(str::to_string)
+                        .collect();
+                    (canonical, aliases)
+                }
+                None => (item, Vec::new()),
+            };
+
+            if let Some(existing) = entries
+                .iter_mut()
+                .find(|entry| entry.canonical.eq_ignore_ascii_case(canonical))
+            {
+                for alias in aliases {
+                    if !existing
+                        .aliases
+                        .iter()
+                        .any(|known| known.eq_ignore_ascii_case(&alias))
+                    {
+                        existing.aliases.push(alias);
+                    }
+                }
+            } else {
+                entries.push(GlossaryEntry {
+                    canonical: canonical.to_string(),
+                    aliases,
+                });
+            }
+        }
+
+        Self { source, entries }
+    }
+
+    pub fn entries(&self) -> &[GlossaryEntry] {
+        &self.entries
+    }
+
+    pub fn upsert(&mut self, canonical: String, aliases: Vec<String>) {
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.canonical.eq_ignore_ascii_case(&canonical))
+        {
+            for alias in aliases {
+                if !existing
+                    .aliases
+                    .iter()
+                    .any(|known| known.eq_ignore_ascii_case(&alias))
+                {
+                    existing.aliases.push(alias);
+                }
+            }
+        } else {
+            self.entries.push(GlossaryEntry { canonical, aliases });
+        }
+        self.source = self.render();
+    }
+
+    pub fn remove(&mut self, canonical: &str) -> bool {
+        let previous_len = self.entries.len();
+        self.entries
+            .retain(|entry| !entry.canonical.eq_ignore_ascii_case(canonical));
+        let removed = self.entries.len() != previous_len;
+        if removed {
+            self.source = self.render();
+        }
+        removed
+    }
+
+    pub fn decoder_prompt(&self) -> Option<String> {
+        if self.source.is_empty() {
+            None
+        } else if self.entries.iter().any(|entry| !entry.aliases.is_empty()) {
+            Some(
+                self.entries
+                    .iter()
+                    .map(|entry| entry.canonical.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        } else {
+            Some(self.source.clone())
+        }
+    }
+
+    pub fn correct_text(&self, text: &str) -> (String, Vec<GlossaryCorrection>) {
+        #[derive(Debug)]
+        struct Binding<'a> {
+            alias: String,
+            canonical: &'a str,
+        }
+
+        #[derive(Debug)]
+        struct Candidate<'a> {
+            start: usize,
+            end: usize,
+            canonical: &'a str,
+        }
+
+        // One alias may appear only once in the effective map. If it points to
+        // different canonical terms, fail closed instead of guessing.
+        let mut bindings_by_key: HashMap<String, Vec<Binding<'_>>> = HashMap::new();
+        for entry in self
+            .entries
+            .iter()
+            .filter(|entry| !entry.aliases.is_empty())
+        {
+            for alias in std::iter::once(entry.canonical.as_str())
+                .chain(entry.aliases.iter().map(String::as_str))
+            {
+                if !has_word_edges(alias) {
+                    continue;
+                }
+                let key = alias_key(alias);
+                let bindings = bindings_by_key.entry(key).or_default();
+                if !bindings.iter().any(|binding| {
+                    binding.canonical.eq_ignore_ascii_case(&entry.canonical)
+                        && binding.alias.eq_ignore_ascii_case(alias)
+                }) {
+                    bindings.push(Binding {
+                        alias: alias.to_string(),
+                        canonical: &entry.canonical,
+                    });
+                }
+            }
+        }
+
+        let mut candidates = Vec::new();
+        for bindings in bindings_by_key.values() {
+            let canonical_keys: HashSet<String> = bindings
+                .iter()
+                .map(|binding| binding.canonical.to_lowercase())
+                .collect();
+            if canonical_keys.len() != 1 {
+                continue;
+            }
+            let binding = &bindings[0];
+            let Some(pattern) = whole_alias_regex(&binding.alias) else {
+                continue;
+            };
+            for matched in pattern.find_iter(text) {
+                if &text[matched.start()..matched.end()] != binding.canonical {
+                    candidates.push(Candidate {
+                        start: matched.start(),
+                        end: matched.end(),
+                        canonical: binding.canonical,
+                    });
+                }
+            }
+        }
+
+        // Select against the original transcript in one pass. Longest-first at
+        // each position prevents phrase aliases from being split by shorter
+        // aliases, and avoiding cascading replacements makes behavior stable.
+        candidates.sort_by(|left, right| {
+            left.start
+                .cmp(&right.start)
+                .then_with(|| (right.end - right.start).cmp(&(left.end - left.start)))
+                .then_with(|| left.canonical.cmp(right.canonical))
+        });
+        let mut selected = Vec::new();
+        let mut cursor = 0;
+        for candidate in candidates {
+            if candidate.start >= cursor {
+                cursor = candidate.end;
+                selected.push(candidate);
+            }
+        }
+
+        if selected.is_empty() {
+            return (text.to_string(), Vec::new());
+        }
+
+        let mut corrected = String::with_capacity(text.len());
+        let mut corrections = Vec::with_capacity(selected.len());
+        let mut last = 0;
+        for candidate in selected {
+            corrected.push_str(&text[last..candidate.start]);
+            let original = &text[candidate.start..candidate.end];
+            corrected.push_str(candidate.canonical);
+            corrections.push(GlossaryCorrection {
+                original: original.to_string(),
+                replacement: candidate.canonical.to_string(),
+            });
+            last = candidate.end;
+        }
+        corrected.push_str(&text[last..]);
+        (corrected, corrections)
+    }
+
+    pub fn render(&self) -> String {
+        self.entries
+            .iter()
+            .map(|entry| {
+                if entry.aliases.is_empty() {
+                    entry.canonical.clone()
+                } else {
+                    format!("{} = {}", entry.canonical, entry.aliases.join(" | "))
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    pub fn single_word_terms(&self) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.canonical.chars().all(char::is_alphabetic))
+            .map(|entry| entry.canonical.clone())
+            .collect()
+    }
+}
+
+fn alias_key(alias: &str) -> String {
+    alias
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn has_word_edges(alias: &str) -> bool {
+    let mut characters = alias.chars();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+    let last = characters.last().unwrap_or(first);
+    first.is_alphanumeric() && last.is_alphanumeric()
+}
+
+fn whole_alias_regex(alias: &str) -> Option<Regex> {
+    let mut escaped = String::new();
+    let mut in_whitespace = false;
+    for character in alias.chars() {
+        if character.is_whitespace() {
+            if !in_whitespace {
+                escaped.push_str(r"\s+");
+                in_whitespace = true;
+            }
+        } else {
+            escaped.push_str(&regex::escape(&character.to_string()));
+            in_whitespace = false;
+        }
+    }
+    Regex::new(&format!(r"(?iu)\b{escaped}\b")).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_prompt_remains_byte_for_byte_decoder_context() {
+        let glossary = Glossary::parse("OpenRouter, merge, pull request");
+        assert_eq!(
+            glossary.decoder_prompt().as_deref(),
+            Some("OpenRouter, merge, pull request")
+        );
+        assert_eq!(glossary.entries().len(), 3);
+    }
+
+    #[test]
+    fn mapped_prompt_hides_mishearings_from_whisper() {
+        let glossary =
+            Glossary::parse("OpenRouter = open router | open vrouter\nmerge = merch\nGrimnir");
+        assert_eq!(
+            glossary.decoder_prompt().as_deref(),
+            Some("OpenRouter, merge, Grimnir")
+        );
+    }
+
+    #[test]
+    fn corrects_observed_aliases_and_preserves_punctuation() {
+        let glossary = Glossary::parse(
+            "OpenRouter = open router | open vrouter\nmerge = merch\nGrimnir = grimminer | skrimnir\nBroker = brocker",
+        );
+        let (text, corrections) =
+            glossary.correct_text("Open router, Merch, Grimminer, Skrimnir och Brocker.");
+        assert_eq!(text, "OpenRouter, merge, Grimnir, Grimnir och Broker.");
+        assert_eq!(corrections.len(), 5);
+        assert_eq!(corrections[0].original, "Open router");
+        assert_eq!(corrections[0].replacement, "OpenRouter");
+    }
+
+    #[test]
+    fn never_replaces_inside_an_unrelated_word() {
+        let glossary = Glossary::parse("merge = merch");
+        let (text, corrections) = glossary.correct_text("Merch merchandise merchant");
+        assert_eq!(text, "merge merchandise merchant");
+        assert_eq!(corrections.len(), 1);
+    }
+
+    #[test]
+    fn longest_alias_wins_without_cascading_replacements() {
+        let glossary = Glossary::parse("OpenRouter = open router\nRouter = router");
+        let (text, corrections) = glossary.correct_text("open router router");
+        assert_eq!(text, "OpenRouter Router");
+        assert_eq!(corrections.len(), 2);
+    }
+
+    #[test]
+    fn ambiguous_aliases_fail_closed() {
+        let glossary = Glossary::parse("Grimnir = grimner\nGrimmer = grimner");
+        let (text, corrections) = glossary.correct_text("grimner");
+        assert_eq!(text, "grimner");
+        assert!(corrections.is_empty());
+    }
+
+    #[test]
+    fn render_and_single_word_terms_support_cli_and_batch() {
+        let glossary = Glossary::parse(
+            "OpenRouter = open router | open vrouter, merge = merch, pull request, Grimnir",
+        );
+        assert_eq!(
+            glossary.render(),
+            "OpenRouter = open router | open vrouter\nmerge = merch\npull request\nGrimnir"
+        );
+        assert_eq!(
+            glossary.single_word_terms(),
+            vec!["OpenRouter", "merge", "Grimnir"]
+        );
+    }
+
+    #[test]
+    fn upsert_and_remove_preserve_other_entries() {
+        let mut glossary = Glossary::parse("OpenRouter, Grimnir = grimminer");
+        glossary.upsert(
+            "OpenRouter".to_string(),
+            vec!["open router".to_string(), "open vrouter".to_string()],
+        );
+        glossary.upsert("merge".to_string(), vec!["merch".to_string()]);
+        assert!(glossary.remove("grimnir"));
+        assert!(!glossary.remove("missing"));
+        assert_eq!(
+            glossary.render(),
+            "OpenRouter = open router | open vrouter\nmerge = merch"
+        );
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/transcription/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/mod.rs
@@ -1,4 +1,5 @@
 pub mod diagnostics;
+pub mod glossary;
 pub mod model;
 mod postprocess;
 pub mod whisper_backend;
@@ -10,4 +11,5 @@ pub use whisper_backend::{
     FILE_TRANSCRIBE_BEAM, TranscribeOptions, TranscriptSegment, WARM_MODEL_CACHE_BUDGET_MB,
     WARM_MODEL_CACHE_MAX_MODELS, WhisperBackend,
 };
+pub use glossary::{Glossary, GlossaryCorrection, GlossaryEntry};
 pub use postprocess::normalize_nonspeech_markers;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,13 +19,14 @@ use sagascript_core::audio::decoder;
 use sagascript_core::settings::{
     validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
 };
+use sagascript_core::transcription::Glossary;
 use sagascript_core::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
 
 /// Build the per-transcription options from the current settings. Resolves the
 /// VAD model path only when VAD is enabled and the model is present (otherwise
 /// VAD is silently skipped — whisper would fail on a missing model).
 pub(crate) fn build_transcribe_options(settings: &Settings) -> TranscribeOptions {
-    let prompt = settings.initial_prompt.trim();
+    let prompt = Glossary::parse(&settings.initial_prompt).decoder_prompt();
     let vad_model_path = if settings.vad_enabled {
         let p = model::vad_model_path();
         if p.exists() {
@@ -38,11 +39,7 @@ pub(crate) fn build_transcribe_options(settings: &Settings) -> TranscribeOptions
         None
     };
     TranscribeOptions {
-        prompt: if prompt.is_empty() {
-            None
-        } else {
-            Some(prompt.to_string())
-        },
+        prompt,
         beam_size: settings.beam_size,
         temperature_fallback: settings.temperature_fallback,
         vad_model_path,
@@ -61,12 +58,54 @@ pub(crate) fn build_file_transcribe_options(
     if opts.beam_size < 2 {
         opts.beam_size = FILE_TRANSCRIBE_BEAM;
     }
-    if let Some(p) = prompt {
-        if !p.trim().is_empty() {
-            opts.prompt = Some(p.trim().to_string());
-        }
-    }
+    opts.prompt = effective_file_glossary(settings, prompt.as_deref()).decoder_prompt();
     opts
+}
+
+pub(crate) fn effective_file_glossary(settings: &Settings, prompt: Option<&str>) -> Glossary {
+    let source = prompt
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+        .unwrap_or(settings.initial_prompt.trim());
+    Glossary::parse(source)
+}
+
+pub(crate) fn apply_glossary(text: String, glossary: &Glossary) -> String {
+    let (corrected, corrections) = glossary.correct_text(&text);
+    if !corrections.is_empty() {
+        info!(correction_count = corrections.len(), "Applied personal glossary corrections");
+    }
+    corrected
+}
+
+#[cfg(test)]
+mod glossary_options_tests {
+    use super::*;
+
+    #[test]
+    fn live_options_prime_with_canonical_terms_only() {
+        let settings = Settings {
+            initial_prompt: "OpenRouter = open router | open vrouter\nmerge = merch".to_string(),
+            ..Settings::default()
+        };
+        assert_eq!(build_transcribe_options(&settings).prompt.as_deref(), Some("OpenRouter, merge"));
+    }
+
+    #[test]
+    fn file_context_overrides_the_saved_dictionary_for_one_run() {
+        let settings = Settings {
+            initial_prompt: "OpenRouter = open router".to_string(),
+            ..Settings::default()
+        };
+        let prompt = Some("Cloudflare = cloud flare".to_string());
+        assert_eq!(build_file_transcribe_options(&settings, prompt).prompt.as_deref(), Some("Cloudflare"));
+    }
+
+    #[test]
+    fn correction_helper_applies_explicit_aliases() {
+        let glossary = Glossary::parse("merge = merch");
+        assert_eq!(apply_glossary("Merch it".to_string(), &glossary), "merge it");
+    }
 }
 
 /// Shared app state type — uses std::sync::Mutex (not tokio) because
@@ -460,7 +499,7 @@ pub async fn stop_and_transcribe(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
 ) -> Result<String, String> {
-    let (audio, language, effective_model, opts) = {
+    let (audio, language, effective_model, opts, glossary) = {
         let mut ctrl = controller.lock().unwrap();
         // Guard against a late/duplicate invoke racing the hotkey stop path
         // (finding 3): if we're not recording, do nothing and return Ok-empty
@@ -476,7 +515,8 @@ pub async fn stop_and_transcribe(
         let language = ctrl.language();
         let effective_model = ctrl.settings().effective_model();
         let opts = build_transcribe_options(ctrl.settings());
-        (audio, language, effective_model, opts)
+        let glossary = Glossary::parse(&ctrl.settings().initial_prompt);
+        (audio, language, effective_model, opts, glossary)
     };
 
     if audio.is_empty() {
@@ -528,7 +568,8 @@ pub async fn stop_and_transcribe(
                 ))
             }
         }
-    };
+    }
+    .map(|text| apply_glossary(text, &glossary));
 
     // NOTE: auto-paste is NOT done here — enigo's macOS TIS APIs crash if
     // called from a tokio worker thread (SIGTRAP in dispatch_assert_queue).
@@ -771,9 +812,13 @@ pub async fn transcribe_file(
     let _ = &diarize;
 
     // Get transcription settings
-    let (language, effective_model) = {
+    let (language, effective_model, glossary) = {
         let ctrl = controller.lock().unwrap();
-        (ctrl.language(), ctrl.settings().effective_model())
+        (
+            ctrl.language(),
+            ctrl.settings().effective_model(),
+            effective_file_glossary(ctrl.settings(), prompt.as_deref()),
+        )
     };
 
     // Show model loading status if needed
@@ -814,10 +859,7 @@ pub async fn transcribe_file(
         let whisper_ref = whisper.inner().clone();
         // Fall back to the saved initial_prompt when the file-dialog prompt is
         // empty (matches the standard file path).
-        let prompt_ref: Option<String> = prompt.clone().filter(|p| !p.trim().is_empty()).or_else(|| {
-            let saved = controller.lock().unwrap().settings().initial_prompt.trim().to_string();
-            (!saved.is_empty()).then_some(saved)
-        });
+        let prompt_ref = glossary.decoder_prompt();
         let audio_for_diarize = audio.clone();
         let audio_for_transcribe = audio.clone();
 
@@ -905,6 +947,7 @@ pub async fn transcribe_file(
             .map(|s| format!("[{}] {}", s.speaker, s.text.trim()))
             .collect::<Vec<_>>()
             .join("\n");
+        let text = apply_glossary(text, &glossary);
 
         info!("Diarized file transcription complete: {} chars", text.len());
 
@@ -981,6 +1024,7 @@ pub async fn transcribe_file(
 
     match result {
         Ok(text) => {
+            let text = apply_glossary(text, &glossary);
             info!("File transcription complete: {} chars", text.len());
 
             // Auto-paste if enabled

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1156,12 +1156,13 @@ fn stop_recording_and_transcribe(
         let whisper: tauri::State<'_, SharedWhisper> = app_handle.state();
 
         // Extract what we need for transcription (lock briefly)
-        let (language, effective_model, opts) = {
+        let (language, effective_model, opts, glossary) = {
             let c = ctrl.lock().unwrap();
             (
                 c.language(),
                 c.settings().effective_model_for(c.language()),
                 commands::build_transcribe_options(c.settings()),
+                sagascript_core::transcription::Glossary::parse(&c.settings().initial_prompt),
             )
         };
 
@@ -1216,6 +1217,7 @@ fn stop_recording_and_transcribe(
 
         match result {
             Ok(text) => {
+                let text = commands::apply_glossary(text, &glossary);
                 info!("Transcription complete: {} chars", text.len());
 
                 // Check if auto-paste is enabled (lock briefly)

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -734,10 +734,12 @@
           </label>
           <textarea
             class="prompt-input"
-            placeholder="Context / vocabulary hint (optional) — e.g. names, technical terms"
+            aria-label="Extra context for this file"
+            placeholder="Extra context for this file only (optional)"
             bind:value={transcribePrompt}
             rows="2"
           ></textarea>
+          <div class="hotkey-hint">Temporary context for this import. Your personal dictionary is managed in Settings.</div>
         </div>
 
         {#if transcribeError}
@@ -818,16 +820,19 @@
         </div>
 
         <div class="field">
-          <label for="initial-prompt">Initial prompt</label>
+          <label for="initial-prompt">Personal dictionary</label>
           <textarea
             id="initial-prompt"
             class="initial-prompt-input"
-            rows="3"
+            rows="5"
             value={settings.initial_prompt}
             onblur={onInitialPromptBlur}
-            placeholder="Prime the transcriber with names, jargon, or preferred spellings."
+            placeholder="OpenRouter = open router | open vrouter&#10;merge = merch&#10;Cloudflare = cloud flare"
           ></textarea>
-          <div class="hotkey-hint">Prime the transcriber with names, jargon, or preferred spellings.</div>
+          <div class="hotkey-hint">
+            One preferred spelling per line. Add exact mishearings after <code>=</code>, separated by <code>|</code>.
+            Plain terms still guide Whisper. Saved automatically when you leave the field and used for live dictation and batch jobs.
+          </div>
         </div>
 
         <div class="field">


### PR DESCRIPTION
Closes #148.

## What changed

- added a shared local personal-glossary parser and deterministic exact-alias correction engine
- applied explicit aliases before GUI live auto-paste, GUI file output, CLI `record`, and CLI batch output
- kept existing plain `initial_prompt` values backward compatible as Whisper hints
- retained batch `--correct-hints` and its confidence-gated fuzzy correction, now using canonical glossary terms
- added `sagascript glossary list|add|remove|clear`
- renamed the persistent UI field to **Personal dictionary** and the one-run file field to **Extra context for this file**
- documented the architecture and safety boundaries

Example:

```text
OpenRouter = open router | open vrouter
merge = merch
Cloudflare = cloud flare
Grimnir = grimminer | skrimnir
```

Only explicit aliases authorize deterministic rewriting. Matching is case-insensitive, whole-word/phrase, longest-first, non-cascading, and fails closed for ambiguous aliases.

## Why

Whisper's initial prompt is only a decoding hint and continued to misrecognize recurring technical names during push-to-talk. The previous correction path was batch-only and intentionally too narrow to handle phrases or common multi-edit mishearings.

## Review follow-up

Independent review found and the branch now fixes:

- phrase aliases split across Whisper segment boundaries
- Unicode case-equivalent aliases that could otherwise bypass ambiguous-alias fail-closed handling
- repeated regex compilation across batch segments

## Validation

- `cargo test --workspace` — 514 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build -p sagascript-cli --no-default-features`
- `cargo clippy -p sagascript-cli --no-default-features --all-targets -- -D warnings`
- `npm run test:frontend` — 9 passed
- `npm run check`
- `npm run build`
- `npm audit --omit=dev` — 0 vulnerabilities
- `git diff --check`

The macOS pasteboard integration test was run outside the filesystem sandbox because Cocoa returned a null named pasteboard inside the sandbox; the full workspace suite passed there.