### PR TITLE
Add Teach Sagascript flow for learning a personal dictionary from corrected dictation

### DIFF
--- a/docs/personal-glossary.md
+++ b/docs/personal-glossary.md
@@ -4,6 +4,16 @@ Sagascript keeps the persisted `initial_prompt` string as the backward-compatibl
 source of truth for vocabulary guidance. Existing comma- or newline-separated
 terms continue to be passed to Whisper unchanged.
 
+New entries learned through **Teach Sagascript** are stored separately per
+dictation profile. At transcription time, the legacy global dictionary is
+combined with only the active profile's entries. Conflicting aliases still
+fail closed. This prevents a correction learned for one language/profile from
+silently rewriting another profile's output.
+
+Removing a profile makes its scoped entries inactive but does not silently
+delete the user's vocabulary. Its old profile ID remains reserved, preventing
+a later profile from accidentally reactivating those aliases.
+
 An entry may optionally authorize deterministic correction:
 
 ```text
@@ -34,9 +44,32 @@ additional confidence-gated one-edit correction for plain single-word hints.
 ## Interfaces
 
 - **Settings → Personal dictionary** edits the persistent source.
+- **Teach** records locally, keeps raw and effective transcripts ephemeral,
+  compares the effective transcript with the user's correction, and applies
+  only explicitly reviewed candidates to the selected profile.
 - **Transcribe → Extra context for this file** remains a one-run override.
-- `sagascript glossary list|add|remove|clear` is the CLI equivalent.
+- `sagascript glossary list|add|remove|clear [--profile ID]` manages either the
+  legacy global dictionary or one profile.
+- `sagascript glossary suggest training.wav --corrected corrected.txt --profile ID`
+  transcribes audio/video locally and prints conservative candidates without
+  writing. A `.txt` or `.md` transcript is also accepted. Add `--apply` to
+  atomically save the displayed candidates, or `--json` for machine-readable
+  output. The selected profile must have an explicit language and its model
+  must already be downloaded.
 - `sagascript config set initial_prompt ...` remains supported for scripts.
 
-All processing stays local. Sagascript does not ship personal vocabulary,
-phonetic guesses, cloud correction, or telemetry.
+Suggestion generation uses a deterministic Unicode-aware word diff. Bounded
+replacements may become aliases, insertions may become hint-only entries, and
+deletions, punctuation/case changes, repeated-token ambiguity, or broad
+rewrites produce no alias. The backend recomputes reviewed candidates against
+the latest settings while holding the cross-process settings lock. A reviewer
+may edit the preferred spelling or downgrade an observed replacement to a
+decoder-only hint; the observed phrase and context must still match a fresh
+candidate, so a stale or fabricated UI payload cannot be persisted.
+
+A fixed core evaluation fixture tracks candidate recall, unsafe-alias proposal
+rate, and p50/p95 suggestion latency independently of Whisper transcription.
+
+All processing stays local. Training does not mutate model weights, persist
+audio, ship personal vocabulary, make cloud correction calls, or emit
+telemetry.

--- a/docs/personal-glossary.md
+++ b/docs/personal-glossary.md
@@ -56,7 +56,23 @@ additional confidence-gated one-edit correction for plain single-word hints.
   atomically save the displayed candidates, or `--json` for machine-readable
   output. The selected profile must have an explicit language and its model
   must already be downloaded.
+- Set `SAGASCRIPT_SETTINGS_PATH=/absolute/path/to/settings.json` to run an
+  isolated CLI session against that exact settings file. While the override is
+  active, Sagascript does not inspect or migrate legacy settings. This is
+  useful for automation, end-to-end tests, and disposable training profiles.
 - `sagascript config set initial_prompt ...` remains supported for scripts.
+
+The CLI exposes the complete review workflow without requiring an interactive
+prompt. Run `glossary suggest` as a dry run, then either apply every displayed
+candidate with `--apply` or save only selected/edited candidates explicitly:
+
+```console
+sagascript glossary add Quuxmark --alias testar --profile swedish
+sagascript glossary add Loveable --profile swedish
+```
+
+The first command accepts an alias replacement; the second deliberately
+downgrades a candidate to a decoder-only hint. Omitting a candidate rejects it.
 
 Suggestion generation uses a deterministic Unicode-aware word diff. Bounded
 replacements may become aliases, insertions may become hint-only entries, and

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -197,7 +197,12 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             Ok(())
         }
         ProfileAction::Remove { id } => {
-            let mut profiles = settings::store::load().resolved_hotkey_profiles();
+            let stored = settings::store::load();
+            let dictionary_kept = stored
+                .profile_glossaries
+                .get(&id)
+                .is_some_and(|source| !source.trim().is_empty());
+            let mut profiles = stored.resolved_hotkey_profiles();
             let original_len = profiles.len();
             profiles.retain(|profile| profile.id != id);
             if profiles.len() == original_len {
@@ -205,6 +210,11 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             }
             persist_profiles(profiles)?;
             eprintln!("Removed profile {id}");
+            if dictionary_kept {
+                eprintln!(
+                    "Its personal dictionary was kept. Inspect it with `sagascript glossary list --profile {id}` or remove it with `sagascript glossary clear --profile {id}`."
+                );
+            }
             Ok(())
         }
     }

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -633,7 +633,11 @@ mod tests {
     fn valid_keys_count_matches_settings_struct() {
         // Internal fields that are serialized but not user-configurable via `config`.
         // These have dedicated CLI commands instead (e.g. `reset-onboarding`).
-        const INTERNAL_FIELDS: &[&str] = &["has_completed_onboarding", "hotkey_profiles"];
+        const INTERNAL_FIELDS: &[&str] = &[
+            "has_completed_onboarding",
+            "hotkey_profiles",
+            "profile_glossaries",
+        ];
 
         let settings = Settings::default();
         let json = serde_json::to_value(&settings).unwrap();

--- a/src-tauri/crates/sagascript-cli/src/glossary.rs
+++ b/src-tauri/crates/sagascript-cli/src/glossary.rs
@@ -1,8 +1,18 @@
+use std::path::PathBuf;
+
 use clap::{Args, Subcommand};
 
+use sagascript_core::audio::decoder::decode_audio_file;
 use sagascript_core::error::DictationError;
 use sagascript_core::settings;
-use sagascript_core::transcription::Glossary;
+use sagascript_core::settings::Language;
+use sagascript_core::transcription::model;
+use sagascript_core::transcription::{
+    suggest_glossary_candidates, Glossary, GlossarySuggestion, GlossarySuggestionKind,
+    WhisperBackend,
+};
+
+use crate::transcribe::model_id_string;
 
 #[derive(Args)]
 pub struct GlossaryArgs {
@@ -13,7 +23,11 @@ pub struct GlossaryArgs {
 #[derive(Subcommand)]
 pub enum GlossaryAction {
     /// List canonical terms and their explicit aliases
-    List,
+    List {
+        /// Show entries saved only for this dictation profile
+        #[arg(long)]
+        profile: Option<String>,
+    },
     /// Add a term or merge aliases into an existing term
     Add {
         /// Preferred spelling written to the transcript
@@ -21,29 +35,63 @@ pub enum GlossaryAction {
         /// Exact mishearing to replace (repeat for more aliases)
         #[arg(long = "alias", value_name = "TEXT")]
         aliases: Vec<String>,
+        /// Save to this dictation profile instead of the legacy global dictionary
+        #[arg(long)]
+        profile: Option<String>,
     },
     /// Remove a canonical term and all of its aliases
-    Remove { term: String },
+    Remove {
+        term: String,
+        /// Remove from this dictation profile instead of the legacy global dictionary
+        #[arg(long)]
+        profile: Option<String>,
+    },
     /// Remove every personal dictionary entry
     Clear {
         /// Confirm destructive removal of the complete dictionary
         #[arg(long)]
         yes: bool,
+        /// Clear this profile instead of the legacy global dictionary
+        #[arg(long)]
+        profile: Option<String>,
+    },
+    /// Compare a transcript with its manual correction and propose safe entries
+    Suggest {
+        /// Audio/video file to transcribe, or a UTF-8 .txt/.md transcript
+        heard: PathBuf,
+        /// UTF-8 text file containing the final corrected transcript
+        #[arg(long, value_name = "FILE")]
+        corrected: PathBuf,
+        /// Dictation profile that owns learned entries
+        #[arg(long)]
+        profile: String,
+        /// Emit a stable machine-readable result
+        #[arg(long)]
+        json: bool,
+        /// Atomically add every displayed candidate; dry-run is the default
+        #[arg(long)]
+        apply: bool,
     },
 }
 
 pub fn run(args: GlossaryArgs) -> Result<(), DictationError> {
     match args.action {
-        GlossaryAction::List => list(),
-        GlossaryAction::Add { term, aliases } => add(&term, &aliases),
-        GlossaryAction::Remove { term } => remove(&term),
-        GlossaryAction::Clear { yes } => clear(yes),
+        GlossaryAction::List { profile } => list(profile.as_deref()),
+        GlossaryAction::Add { term, aliases, profile } => {
+            add(&term, &aliases, profile.as_deref())
+        }
+        GlossaryAction::Remove { term, profile } => remove(&term, profile.as_deref()),
+        GlossaryAction::Clear { yes, profile } => clear(yes, profile.as_deref()),
+        GlossaryAction::Suggest { heard, corrected, profile, json, apply } => {
+            suggest(&heard, &corrected, &profile, json, apply)
+        }
     }
 }
 
-fn list() -> Result<(), DictationError> {
+fn list(profile: Option<&str>) -> Result<(), DictationError> {
     let stored = settings::store::load();
-    let glossary = Glossary::parse(&stored.initial_prompt);
+    let source = glossary_source(&stored, profile)?;
+    let glossary = Glossary::parse(source);
     for entry in glossary.entries() {
         if entry.aliases.is_empty() {
             println!("{}", entry.canonical);
@@ -54,32 +102,42 @@ fn list() -> Result<(), DictationError> {
     Ok(())
 }
 
-fn add(term: &str, aliases: &[String]) -> Result<(), DictationError> {
+fn add(term: &str, aliases: &[String], profile: Option<&str>) -> Result<(), DictationError> {
     let term = validate_component("term", term)?;
     let aliases = aliases
         .iter()
         .map(|alias| validate_component("alias", alias))
         .collect::<Result<Vec<_>, _>>()?;
+    if let Some(profile) = profile {
+        validate_learning_profile(&settings::store::load(), profile)?;
+    }
 
-    settings::store::update(|stored| {
-        let mut glossary = Glossary::parse(&stored.initial_prompt);
+    settings::store::try_update(|stored| {
+        if let Some(profile) = profile {
+            validate_learning_profile(stored, profile).map_err(|error| error.to_string())?;
+        }
+        let source = glossary_source_mut(stored, profile)?;
+        let mut glossary = Glossary::parse(source);
         glossary.upsert(term.clone(), aliases.clone());
-        stored.initial_prompt = glossary.render();
+        *source = glossary.render();
+        Ok(())
     })
     .map_err(DictationError::SettingsError)?;
     eprintln!("Saved personal dictionary term: {term}");
     Ok(())
 }
 
-fn remove(term: &str) -> Result<(), DictationError> {
+fn remove(term: &str, profile: Option<&str>) -> Result<(), DictationError> {
     let term = validate_component("term", term)?;
     let mut removed = false;
-    settings::store::update(|stored| {
-        let mut glossary = Glossary::parse(&stored.initial_prompt);
+    settings::store::try_update(|stored| {
+        let source = glossary_source_mut(stored, profile)?;
+        let mut glossary = Glossary::parse(source);
         removed = glossary.remove(&term);
         if removed {
-            stored.initial_prompt = glossary.render();
+            *source = glossary.render();
         }
+        Ok(())
     })
     .map_err(DictationError::SettingsError)?;
 
@@ -93,15 +151,216 @@ fn remove(term: &str) -> Result<(), DictationError> {
     }
 }
 
-fn clear(confirmed: bool) -> Result<(), DictationError> {
+fn clear(confirmed: bool, profile: Option<&str>) -> Result<(), DictationError> {
     if !confirmed {
         return Err(DictationError::SettingsError(
             "Refusing to clear the personal dictionary without --yes".to_string(),
         ));
     }
-    settings::store::update(|stored| stored.initial_prompt.clear())
+    settings::store::try_update(|stored| {
+        glossary_source_mut(stored, profile)?.clear();
+        Ok(())
+    })
         .map_err(DictationError::SettingsError)?;
     eprintln!("Cleared personal dictionary");
+    Ok(())
+}
+
+fn suggest(
+    heard_path: &PathBuf,
+    corrected_path: &PathBuf,
+    profile: &str,
+    json: bool,
+    apply: bool,
+) -> Result<(), DictationError> {
+    let corrected = std::fs::read_to_string(corrected_path).map_err(|error| {
+        DictationError::SettingsError(format!(
+            "Failed to read corrected transcript '{}': {error}",
+            corrected_path.display()
+        ))
+    })?;
+
+    let stored = settings::store::load();
+    validate_learning_profile(&stored, profile)?;
+    let glossary = Glossary::parse(&stored.effective_glossary_source(Some(profile)));
+    let heard = load_training_input(heard_path, &stored, profile, &glossary)?;
+    let suggestions = suggest_glossary_candidates(&heard, &corrected, &glossary);
+
+    if apply {
+        if suggestions.is_empty() {
+            return Err(DictationError::SettingsError(
+                "No safe dictionary suggestions to apply".to_string(),
+            ));
+        }
+        let reviewed = suggestions.clone();
+        settings::store::try_update(|latest| {
+            validate_learning_profile(latest, profile).map_err(|error| error.to_string())?;
+            let effective = Glossary::parse(&latest.effective_glossary_source(Some(profile)));
+            let current = suggest_glossary_candidates(&heard, &corrected, &effective);
+            if current != reviewed {
+                return Err(
+                    "Dictionary changed since the dry run; review suggestions again".to_string(),
+                );
+            }
+
+            let source = latest.profile_glossaries.entry(profile.to_string()).or_default();
+            let mut scoped = Glossary::parse(source);
+            apply_candidates(&mut scoped, &reviewed);
+            *source = scoped.render();
+            Ok(())
+        })
+        .map_err(DictationError::SettingsError)?;
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "profile": profile,
+                "applied": apply,
+                "suggestions": suggestions,
+            })
+        );
+    } else if suggestions.is_empty() {
+        println!("No safe personal dictionary suggestions.");
+    } else {
+        for candidate in &suggestions {
+            match candidate.kind {
+                GlossarySuggestionKind::Alias => {
+                    println!("{} = {}", candidate.canonical, candidate.observed);
+                }
+                GlossarySuggestionKind::HintOnly => println!("{}", candidate.canonical),
+            }
+        }
+        if !apply {
+            eprintln!("Dry run only. Re-run with --apply to save these profile-scoped entries.");
+        }
+    }
+    Ok(())
+}
+
+fn load_training_input(
+    path: &PathBuf,
+    stored: &settings::Settings,
+    profile_id: &str,
+    glossary: &Glossary,
+) -> Result<String, DictationError> {
+    let is_text = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension.to_ascii_lowercase().as_str(), "txt" | "md"));
+    if is_text {
+        return std::fs::read_to_string(path).map_err(|error| {
+            DictationError::SettingsError(format!(
+                "Failed to read transcript '{}': {error}",
+                path.display()
+            ))
+        });
+    }
+
+    let profile = stored
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|profile| profile.id == profile_id)
+        .expect("validated profile must still exist");
+    let model = stored.effective_model_for(profile.language);
+    if !model::is_model_downloaded(model) {
+        return Err(DictationError::TranscriptionFailed(format!(
+            "Model '{}' is not downloaded. Run: sagascript download-model {}",
+            model.display_name(),
+            model_id_string(model)
+        )));
+    }
+
+    let audio = decode_audio_file(path)?;
+    if audio.is_empty() {
+        return Err(DictationError::FileDecodeError(format!(
+            "No audio decoded from '{}'",
+            path.display()
+        )));
+    }
+    eprintln!("Transcribing training input locally with {}...", model.display_name());
+    let backend = WhisperBackend::new();
+    backend.load_model(model)?;
+    let raw = backend.transcribe_sync_with_progress_and_prompt(
+        &audio,
+        profile.language,
+        glossary.decoder_prompt().as_deref(),
+        |_| {},
+    )?;
+    Ok(glossary.correct_text(&raw).0)
+}
+
+fn apply_candidates(glossary: &mut Glossary, candidates: &[GlossarySuggestion]) {
+    for candidate in candidates {
+        match candidate.kind {
+            GlossarySuggestionKind::Alias => {
+                glossary.upsert(candidate.canonical.clone(), vec![candidate.observed.clone()]);
+            }
+            GlossarySuggestionKind::HintOnly => {
+                glossary.upsert(candidate.canonical.clone(), Vec::new());
+            }
+        }
+    }
+}
+
+fn glossary_source<'a>(
+    stored: &'a settings::Settings,
+    profile: Option<&str>,
+) -> Result<&'a str, DictationError> {
+    match profile {
+        Some(profile) => {
+            validate_profile(stored, profile)?;
+            Ok(stored
+                .profile_glossaries
+                .get(profile)
+                .map(String::as_str)
+                .unwrap_or_default())
+        }
+        None => Ok(&stored.initial_prompt),
+    }
+}
+
+fn glossary_source_mut<'a>(
+    stored: &'a mut settings::Settings,
+    profile: Option<&str>,
+) -> Result<&'a mut String, String> {
+    match profile {
+        Some(profile) => {
+            validate_profile(stored, profile).map_err(|error| error.to_string())?;
+            Ok(stored.profile_glossaries.entry(profile.to_string()).or_default())
+        }
+        None => Ok(&mut stored.initial_prompt),
+    }
+}
+
+fn validate_profile(stored: &settings::Settings, profile: &str) -> Result<(), DictationError> {
+    stored
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|candidate| candidate.id == profile)
+        .ok_or_else(|| {
+            DictationError::SettingsError(format!("Unknown dictation profile '{profile}'"))
+        })?;
+    Ok(())
+}
+
+fn validate_learning_profile(
+    stored: &settings::Settings,
+    profile: &str,
+) -> Result<(), DictationError> {
+    let profile = stored
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|candidate| candidate.id == profile)
+        .ok_or_else(|| {
+            DictationError::SettingsError(format!("Unknown dictation profile '{profile}'"))
+        })?;
+    if profile.language == Language::Auto {
+        return Err(DictationError::SettingsError(
+            "Glossary learning requires a profile with an explicit language".to_string(),
+        ));
+    }
     Ok(())
 }
 

--- a/src-tauri/crates/sagascript-cli/src/glossary.rs
+++ b/src-tauri/crates/sagascript-cli/src/glossary.rs
@@ -310,12 +310,11 @@ fn glossary_source<'a>(
 ) -> Result<&'a str, DictationError> {
     match profile {
         Some(profile) => {
+            if let Some(source) = stored.profile_glossaries.get(profile) {
+                return Ok(source);
+            }
             validate_profile(stored, profile)?;
-            Ok(stored
-                .profile_glossaries
-                .get(profile)
-                .map(String::as_str)
-                .unwrap_or_default())
+            Ok("")
         }
         None => Ok(&stored.initial_prompt),
     }
@@ -327,7 +326,9 @@ fn glossary_source_mut<'a>(
 ) -> Result<&'a mut String, String> {
     match profile {
         Some(profile) => {
-            validate_profile(stored, profile).map_err(|error| error.to_string())?;
+            if !stored.profile_glossaries.contains_key(profile) {
+                validate_profile(stored, profile).map_err(|error| error.to_string())?;
+            }
             Ok(stored.profile_glossaries.entry(profile.to_string()).or_default())
         }
         None => Ok(&mut stored.initial_prompt),
@@ -391,5 +392,22 @@ mod tests {
         assert!(validate_component("term", "OpenRouter").is_ok());
         assert!(validate_component("alias", "open router").is_ok());
         assert!(validate_component("alias", "open router | router").is_err());
+    }
+
+    #[test]
+    fn orphaned_profile_dictionary_remains_listable_and_clearable() {
+        let mut stored = settings::Settings::default();
+        stored
+            .profile_glossaries
+            .insert("removed".to_string(), "Lovable = love a ball".to_string());
+
+        assert_eq!(
+            glossary_source(&stored, Some("removed")).unwrap(),
+            "Lovable = love a ball"
+        );
+        glossary_source_mut(&mut stored, Some("removed"))
+            .unwrap()
+            .clear();
+        assert_eq!(stored.profile_glossaries.get("removed").unwrap(), "");
     }
 }

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -364,7 +364,7 @@ EXAMPLES:
     /// Manage the persistent personal dictionary used by live and batch transcription
     #[command(
         long_about = "Add preferred spellings and optional exact mishearings. Plain terms prime Whisper; aliases also authorize deterministic local corrections before output.",
-        after_long_help = "EXAMPLES:\n  sagascript glossary list\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter'\n  sagascript glossary add merge --alias merch\n  sagascript glossary remove OpenRouter\n  sagascript glossary clear --yes"
+        after_long_help = "EXAMPLES:\n  sagascript glossary list\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter'\n  sagascript glossary add merge --alias merch --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish --apply\n  sagascript glossary remove OpenRouter\n  sagascript glossary clear --yes"
     )]
     Glossary(glossary::GlossaryArgs),
 
@@ -979,11 +979,47 @@ mod tests {
         .unwrap();
         match cli.command.unwrap() {
             Command::Glossary(args) => match args.action {
-                glossary::GlossaryAction::Add { term, aliases } => {
+                glossary::GlossaryAction::Add { term, aliases, profile } => {
                     assert_eq!(term, "OpenRouter");
                     assert_eq!(aliases, vec!["open router", "open vrouter"]);
+                    assert!(profile.is_none());
                 }
                 _ => panic!("expected glossary add"),
+            },
+            _ => panic!("expected Glossary"),
+        }
+    }
+
+    #[test]
+    fn parse_glossary_suggest_is_dry_run_by_default_and_profile_scoped() {
+        let cli = Cli::try_parse_from([
+            "sagascript",
+            "glossary",
+            "suggest",
+            "heard.txt",
+            "--corrected",
+            "corrected.txt",
+            "--profile",
+            "swedish",
+            "--json",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Command::Glossary(args) => match args.action {
+                glossary::GlossaryAction::Suggest {
+                    heard,
+                    corrected,
+                    profile,
+                    json,
+                    apply,
+                } => {
+                    assert_eq!(heard, PathBuf::from("heard.txt"));
+                    assert_eq!(corrected, PathBuf::from("corrected.txt"));
+                    assert_eq!(profile, "swedish");
+                    assert!(json);
+                    assert!(!apply);
+                }
+                _ => panic!("expected glossary suggest"),
             },
             _ => panic!("expected Glossary"),
         }

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -12,7 +12,7 @@ use sagascript_core::transcription::model;
 use sagascript_core::transcription::{Glossary, WhisperBackend};
 
 use super::transcribe::{
-    copy_to_clipboard, model_id_string, parse_language, resolve_effective_model,
+    copy_to_clipboard, model_id_string, parse_language, resolve_effective_model, resolve_profile,
     resolve_effective_prompt,
 };
 
@@ -21,6 +21,10 @@ pub struct RecordArgs {
     /// Language for transcription [possible values: en, sv, no, auto (less accurate)]
     #[arg(short, long, value_name = "LANG")]
     pub language: Option<String>,
+
+    /// Use this dictation profile's language and personal dictionary
+    #[arg(long, value_name = "ID", conflicts_with = "language")]
+    pub profile: Option<String>,
 
     /// Whisper model ID to use [see: sagascript list-models]
     #[arg(short, long, value_name = "MODEL_ID")]
@@ -56,9 +60,15 @@ pub struct RecordArgs {
 
 pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     let stored = sagascript_core::settings::store::load();
-    let language = match &args.language {
-        Some(l) => parse_language(l)?,
-        None => stored.language,
+    let profile = args
+        .profile
+        .as_deref()
+        .map(|profile_id| resolve_profile(&stored, profile_id))
+        .transpose()?;
+    let language = match (&profile, &args.language) {
+        (Some(profile), _) => profile.language,
+        (None, Some(language)) => parse_language(language)?,
+        (None, None) => stored.language,
     };
     let save_only = args.output.is_some();
     // Effective hint/prompt: --prompt-file, else --hint/--prompt, else the saved
@@ -68,10 +78,11 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     let effective_prompt = if save_only {
         None
     } else {
+        let stored_prompt = stored.effective_glossary_source(args.profile.as_deref());
         resolve_effective_prompt(
             args.prompt.as_deref(),
             args.prompt_file.as_deref(),
-            &stored.initial_prompt,
+            &stored_prompt,
         )?
     };
 

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -8,7 +8,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use sagascript_core::audio::decoder::{SUPPORTED_EXTENSIONS, decode_audio_file};
 use sagascript_core::error::DictationError;
-use sagascript_core::settings::{Language, Settings, WhisperModel};
+use sagascript_core::settings::{HotkeyProfile, Language, Settings, WhisperModel};
 use sagascript_core::transcription::diagnostics::{
     CoverageDiagnostics, LanguageDetection, LanguageRegionDiagnostics, LanguageWindow,
     TranscriptionWarning, analyze_coverage, analyze_language_windows, analyze_repetition,
@@ -33,6 +33,10 @@ pub struct TranscribeArgs {
     /// Language for transcription [possible values: en, sv, no, auto (less accurate)]
     #[arg(short, long, value_name = "LANG")]
     pub language: Option<String>,
+
+    /// Use this dictation profile's language and personal dictionary
+    #[arg(long, value_name = "ID", conflicts_with = "language")]
+    pub profile: Option<String>,
 
     /// Whisper model ID to use [see: sagascript list-models]
     #[arg(short, long, value_name = "MODEL_ID")]
@@ -153,9 +157,15 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
     }
 
     let stored = sagascript_core::settings::store::load();
-    let language = match &args.language {
-        Some(l) => parse_language(l)?,
-        None => stored.language,
+    let profile = args
+        .profile
+        .as_deref()
+        .map(|profile_id| resolve_profile(&stored, profile_id))
+        .transpose()?;
+    let language = match (&profile, &args.language) {
+        (Some(profile), _) => profile.language,
+        (None, Some(language)) => parse_language(language)?,
+        (None, None) => stored.language,
     };
     let model = resolve_effective_model(
         args.model.as_deref(),
@@ -166,10 +176,11 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
 
     // Resolve and validate this before decoding or loading a model: an invalid
     // opt-in correction request should not spend time on transcription first.
+    let stored_prompt = stored.effective_glossary_source(args.profile.as_deref());
     let effective_prompt = resolve_effective_prompt(
         args.prompt.as_deref(),
         args.prompt_file.as_deref(),
-        &stored.initial_prompt,
+        &stored_prompt,
     )?;
     let glossary = Glossary::parse(effective_prompt.as_deref().unwrap_or_default());
     let correction_vocabulary = if args.correct_hints {
@@ -1059,6 +1070,25 @@ fn parse_diarize_threshold(s: &str) -> Result<f32, String> {
         ));
     }
     Ok(value)
+}
+
+pub(crate) fn resolve_profile(
+    settings: &Settings,
+    profile_id: &str,
+) -> Result<HotkeyProfile, DictationError> {
+    let profile = settings
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| {
+            DictationError::SettingsError(format!("Unknown dictation profile '{profile_id}'"))
+        })?;
+    if profile.language == Language::Auto {
+        return Err(DictationError::SettingsError(
+            "Profile-scoped dictionaries require an explicit language".to_string(),
+        ));
+    }
+    Ok(profile)
 }
 
 pub fn parse_language(s: &str) -> Result<Language, DictationError> {

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -513,6 +513,9 @@ pub struct Settings {
     /// Optional initial prompt that primes the decoder with domain vocabulary
     /// (names, jargon, spellings) for more accurate transcription. Empty = none.
     pub initial_prompt: String,
+    /// Additional personal dictionary entries scoped to a dictation profile.
+    /// The legacy `initial_prompt` remains the global compatibility layer.
+    pub profile_glossaries: BTreeMap<String, String>,
     /// Beam search width. 0 = greedy decoding (fastest); >=2 enables beam search
     /// (more accurate on hard audio, several times slower).
     pub beam_size: u32,
@@ -539,6 +542,7 @@ impl Default for Settings {
             hotkey: "Control+Shift+Space".to_string(),
             hotkey_profiles: Vec::new(),
             initial_prompt: String::new(),
+            profile_glossaries: BTreeMap::new(),
             beam_size: 0,
             temperature_fallback: true,
             vad_enabled: false,
@@ -548,6 +552,30 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// Combine the legacy global dictionary with the selected profile's
+    /// private additions. Keeping the legacy value first preserves existing
+    /// decoder hints while the glossary matcher fails closed on conflicts.
+    pub fn effective_glossary_source(&self, profile_id: Option<&str>) -> String {
+        let global = self.initial_prompt.trim();
+        let scoped_profile_id = profile_id.filter(|requested_id| {
+            self.resolved_hotkey_profiles().iter().any(|profile| {
+                profile.id == **requested_id && profile.language != Language::Auto
+            })
+        });
+        let scoped = scoped_profile_id
+            .and_then(|id| self.profile_glossaries.get(id))
+            .map(String::as_str)
+            .map(str::trim)
+            .unwrap_or_default();
+
+        match (global.is_empty(), scoped.is_empty()) {
+            (true, true) => String::new(),
+            (false, true) => global.to_string(),
+            (true, false) => scoped.to_string(),
+            (false, false) => format!("{global}\n{scoped}"),
+        }
+    }
+
     /// Returns the effective model considering auto-selection
     pub fn effective_model(&self) -> WhisperModel {
         self.effective_model_for(self.language)
@@ -603,6 +631,20 @@ impl Settings {
 
     pub fn replace_hotkey_profiles(&mut self, profiles: Vec<HotkeyProfile>) -> Result<(), String> {
         Self::validate_hotkey_profiles(&profiles)?;
+        let current_ids: HashSet<String> = self
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .map(|profile| profile.id)
+            .collect();
+        if let Some(profile) = profiles.iter().find(|profile| {
+            !current_ids.contains(&profile.id)
+                && self.profile_glossaries.contains_key(&profile.id)
+        }) {
+            return Err(format!(
+                "Profile id '{}' has an inactive personal dictionary; choose a new id to avoid reactivating old aliases",
+                profile.id
+            ));
+        }
         let legacy = profiles.iter().find(|profile| profile.id == "default").unwrap_or(&profiles[0]);
         self.hotkey = legacy.shortcut.clone();
         self.language = legacy.language;
@@ -1064,9 +1106,114 @@ mod tests {
         assert!(s.auto_select_model);
         assert_eq!(s.hotkey, "Control+Shift+Space");
         assert_eq!(s.initial_prompt, "");
+        assert!(s.profile_glossaries.is_empty());
         assert_eq!(s.beam_size, 0);
         assert!(s.temperature_fallback);
         assert!(!s.vad_enabled);
+    }
+
+    #[test]
+    fn effective_glossary_combines_global_and_selected_profile_only() {
+        let mut settings = Settings {
+            initial_prompt: "Codex = code x".to_string(),
+            hotkey_profiles: vec![
+                HotkeyProfile {
+                    id: "swedish".to_string(),
+                    name: "Swedish".to_string(),
+                    shortcut: "Control+Shift+Space".to_string(),
+                    language: Language::Swedish,
+                },
+                HotkeyProfile {
+                    id: "english".to_string(),
+                    name: "English".to_string(),
+                    shortcut: "Control+Option+Space".to_string(),
+                    language: Language::English,
+                },
+            ],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("swedish".to_string(), "mergea = mördsa".to_string());
+        settings
+            .profile_glossaries
+            .insert("english".to_string(), "Lovable = love a ball".to_string());
+
+        assert_eq!(
+            settings.effective_glossary_source(Some("swedish")),
+            "Codex = code x\nmergea = mördsa"
+        );
+        assert_eq!(
+            settings.effective_glossary_source(Some("english")),
+            "Codex = code x\nLovable = love a ball"
+        );
+        assert_eq!(settings.effective_glossary_source(None), "Codex = code x");
+    }
+
+    #[test]
+    fn effective_glossary_uses_scoped_source_without_legacy_global_entries() {
+        let mut settings = Settings::default();
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "Magnus Gille = Magnus Jille".to_string());
+
+        assert_eq!(
+            settings.effective_glossary_source(Some("default")),
+            "Magnus Gille = Magnus Jille"
+        );
+    }
+
+    #[test]
+    fn effective_glossary_ignores_unknown_and_auto_profile_entries() {
+        let mut settings = Settings {
+            language: Language::Auto,
+            initial_prompt: "Codex = code x".to_string(),
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+        settings
+            .profile_glossaries
+            .insert("removed".to_string(), "Lovable = love a ball".to_string());
+
+        assert_eq!(
+            settings.effective_glossary_source(Some("default")),
+            "Codex = code x"
+        );
+        assert_eq!(
+            settings.effective_glossary_source(Some("removed")),
+            "Codex = code x"
+        );
+    }
+
+    #[test]
+    fn removed_profile_glossary_stays_inert_and_reserves_its_old_id() {
+        let mut settings = Settings::default();
+        settings
+            .profile_glossaries
+            .insert("removed".to_string(), "Lovable = love a ball".to_string());
+
+        let error = settings
+            .replace_hotkey_profiles(vec![
+                HotkeyProfile::legacy_default(
+                    "Control+Shift+Space".to_string(),
+                    Language::Swedish,
+                ),
+                HotkeyProfile {
+                    id: "removed".to_string(),
+                    name: "Reused".to_string(),
+                    shortcut: "Control+Option+Space".to_string(),
+                    language: Language::English,
+                },
+            ])
+            .unwrap_err();
+
+        assert!(error.contains("inactive personal dictionary"));
+        assert_eq!(
+            settings.profile_glossaries.get("removed").map(String::as_str),
+            Some("Lovable = love a ball")
+        );
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -631,14 +631,32 @@ impl Settings {
 
     pub fn replace_hotkey_profiles(&mut self, profiles: Vec<HotkeyProfile>) -> Result<(), String> {
         Self::validate_hotkey_profiles(&profiles)?;
-        let current_ids: HashSet<String> = self
-            .resolved_hotkey_profiles()
-            .into_iter()
-            .map(|profile| profile.id)
+        let current_profiles = self.resolved_hotkey_profiles();
+        if let Some(profile) = profiles.iter().find(|profile| {
+            current_profiles.iter().any(|current| {
+                current.id == profile.id
+                    && current.language != profile.language
+                    && self
+                        .profile_glossaries
+                        .get(&profile.id)
+                        .is_some_and(|source| !source.trim().is_empty())
+            })
+        }) {
+            return Err(format!(
+                "Profile '{}' has a personal dictionary; clear it before changing the profile language",
+                profile.id
+            ));
+        }
+        let current_ids: HashSet<&str> = current_profiles
+            .iter()
+            .map(|profile| profile.id.as_str())
             .collect();
         if let Some(profile) = profiles.iter().find(|profile| {
-            !current_ids.contains(&profile.id)
-                && self.profile_glossaries.contains_key(&profile.id)
+            !current_ids.contains(profile.id.as_str())
+                && self
+                    .profile_glossaries
+                    .get(&profile.id)
+                    .is_some_and(|source| !source.trim().is_empty())
         }) {
             return Err(format!(
                 "Profile id '{}' has an inactive personal dictionary; choose a new id to avoid reactivating old aliases",
@@ -1214,6 +1232,51 @@ mod tests {
             settings.profile_glossaries.get("removed").map(String::as_str),
             Some("Lovable = love a ball")
         );
+    }
+
+    #[test]
+    fn empty_removed_profile_glossary_does_not_reserve_its_old_id() {
+        let mut settings = Settings::default();
+        settings
+            .profile_glossaries
+            .insert("removed".to_string(), "  \n".to_string());
+
+        settings
+            .replace_hotkey_profiles(vec![
+                HotkeyProfile::legacy_default(
+                    "Control+Shift+Space".to_string(),
+                    Language::Swedish,
+                ),
+                HotkeyProfile {
+                    id: "removed".to_string(),
+                    name: "Reused".to_string(),
+                    shortcut: "Control+Option+Space".to_string(),
+                    language: Language::English,
+                },
+            ])
+            .unwrap();
+    }
+
+    #[test]
+    fn profile_with_dictionary_cannot_change_language_in_place() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "mergea = mördsa".to_string());
+
+        let error = settings
+            .replace_hotkey_profiles(vec![HotkeyProfile::legacy_default(
+                "Control+Shift+Space".to_string(),
+                Language::English,
+            )])
+            .unwrap_err();
+
+        assert!(error.contains("personal dictionary"));
+        assert!(error.contains("language"));
+        assert_eq!(settings.language, Language::Swedish);
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -39,6 +39,11 @@ pub fn settings_path() -> PathBuf {
     configured_settings_location().0
 }
 
+/// Returns whether this process is using an explicit settings file.
+pub fn settings_path_is_overridden() -> bool {
+    settings_override_path(std::env::var_os(SETTINGS_PATH_ENV)).is_some()
+}
+
 fn legacy_settings_paths() -> impl Iterator<Item = PathBuf> {
     configured_settings_location().1.into_iter()
 }
@@ -54,8 +59,8 @@ fn settings_location(
     override_path: Option<OsString>,
     data_dir: PathBuf,
 ) -> (PathBuf, Vec<PathBuf>) {
-    if let Some(override_path) = override_path.filter(|value| !value.is_empty()) {
-        return (PathBuf::from(override_path), Vec::new());
+    if let Some(override_path) = settings_override_path(override_path) {
+        return (override_path, Vec::new());
     }
 
     let settings_path = data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME);
@@ -64,6 +69,12 @@ fn settings_location(
         .map(|identifier| data_dir.join(identifier).join(SETTINGS_FILENAME))
         .collect();
     (settings_path, legacy_paths)
+}
+
+fn settings_override_path(value: Option<OsString>) -> Option<PathBuf> {
+    value
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
 }
 
 /// Caller must hold the destination's settings lock.

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     fs::OpenOptions,
     path::{Path, PathBuf},
 };
@@ -10,6 +11,11 @@ use crate::settings::Settings;
 const APP_IDENTIFIER: &str = "ai.gille.sagascript";
 const LEGACY_APP_IDENTIFIERS: &[&str] = &["com.sagascript.app"];
 const SETTINGS_FILENAME: &str = "sagascript-settings.json";
+/// Optional exact settings-file location for isolated CLI sessions and tests.
+///
+/// When set, legacy settings migration is disabled so an isolated session can
+/// never import or mutate the user's normal application settings by accident.
+pub const SETTINGS_PATH_ENV: &str = "SAGASCRIPT_SETTINGS_PATH";
 const LEGACY_ONBOARDING_KEY: &str = "hasCompletedOnboarding";
 const ONBOARDING_KEY: &str = "has_completed_onboarding";
 
@@ -30,14 +36,34 @@ pub fn app_data_dir() -> PathBuf {
 
 /// Returns the full path to the settings file.
 pub fn settings_path() -> PathBuf {
-    app_data_dir().join(SETTINGS_FILENAME)
+    configured_settings_location().0
 }
 
 fn legacy_settings_paths() -> impl Iterator<Item = PathBuf> {
-    let base = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
-    LEGACY_APP_IDENTIFIERS
+    configured_settings_location().1.into_iter()
+}
+
+fn configured_settings_location() -> (PathBuf, Vec<PathBuf>) {
+    settings_location(
+        std::env::var_os(SETTINGS_PATH_ENV),
+        dirs::data_dir().unwrap_or_else(|| PathBuf::from(".")),
+    )
+}
+
+fn settings_location(
+    override_path: Option<OsString>,
+    data_dir: PathBuf,
+) -> (PathBuf, Vec<PathBuf>) {
+    if let Some(override_path) = override_path.filter(|value| !value.is_empty()) {
+        return (PathBuf::from(override_path), Vec::new());
+    }
+
+    let settings_path = data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME);
+    let legacy_paths = LEGACY_APP_IDENTIFIERS
         .iter()
-        .map(move |identifier| base.join(identifier).join(SETTINGS_FILENAME))
+        .map(|identifier| data_dir.join(identifier).join(SETTINGS_FILENAME))
+        .collect();
+    (settings_path, legacy_paths)
 }
 
 /// Caller must hold the destination's settings lock.
@@ -351,10 +377,41 @@ mod tests {
     }
 
     #[test]
-    fn settings_path_is_under_app_data_dir() {
-        let p = settings_path();
+    fn default_settings_path_is_under_app_data_dir() {
+        let data_dir = PathBuf::from("/example/application-support");
+        let (p, legacy) = settings_location(None, data_dir.clone());
         assert!(p.ends_with(SETTINGS_FILENAME));
         assert!(p.parent().unwrap().ends_with(APP_IDENTIFIER));
+        assert_eq!(
+            legacy,
+            vec![data_dir
+                .join(LEGACY_APP_IDENTIFIERS[0])
+                .join(SETTINGS_FILENAME)]
+        );
+    }
+
+    #[test]
+    fn explicit_settings_path_disables_legacy_migration_sources() {
+        let isolated = PathBuf::from("/tmp/sagascript-cli-test/settings.json");
+        let (path, legacy) = settings_location(
+            Some(isolated.clone().into_os_string()),
+            PathBuf::from("/real/application-support"),
+        );
+
+        assert_eq!(path, isolated);
+        assert!(legacy.is_empty());
+    }
+
+    #[test]
+    fn empty_settings_path_override_uses_the_normal_location() {
+        let data_dir = PathBuf::from("/example/application-support");
+        let (path, legacy) = settings_location(Some(OsString::new()), data_dir.clone());
+
+        assert_eq!(
+            path,
+            data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME)
+        );
+        assert_eq!(legacy.len(), LEGACY_APP_IDENTIFIERS.len());
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/transcription/glossary_suggestions.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/glossary_suggestions.rs
@@ -1,0 +1,621 @@
+//! Conservative, deterministic suggestions for teaching a personal glossary.
+
+use crate::transcription::Glossary;
+
+const MAX_REPLACEMENT_WORDS: usize = 4;
+const MAX_REPLACEMENT_BYTES: usize = 96;
+const MAX_TRANSCRIPT_WORDS: usize = 2_048;
+
+/// The action a reviewed suggestion is safe to take in the glossary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GlossarySuggestionKind {
+    /// The observed text can be stored as an alias for the corrected text.
+    Alias,
+    /// The corrected text is useful decoder context, but has no safe alias.
+    HintOnly,
+}
+
+/// A deterministic candidate produced from a raw/effective transcript and its
+/// manually corrected version.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct GlossarySuggestion {
+    /// Text as heard by the recognizer. Empty for an insertion hint.
+    pub observed: String,
+    /// Text the user supplied as the correction.
+    pub canonical: String,
+    pub kind: GlossarySuggestionKind,
+    /// Small word window around the edit for human review.
+    pub context: String,
+}
+
+/// Compare two transcripts and return only bounded, unambiguous glossary
+/// candidates. Punctuation and case are deliberately ignored for alignment;
+/// the returned values retain the user's original spelling.
+pub fn suggest_glossary_candidates(
+    heard: &str,
+    corrected: &str,
+    glossary: &Glossary,
+) -> Vec<GlossarySuggestion> {
+    let heard_tokens = tokenize(heard);
+    let corrected_tokens = tokenize(corrected);
+    if heard_tokens.is_empty()
+        || corrected_tokens.is_empty()
+        || heard_tokens.len() > MAX_TRANSCRIPT_WORDS
+        || corrected_tokens.len() > MAX_TRANSCRIPT_WORDS
+    {
+        return Vec::new();
+    }
+
+    let mut suggestions = Vec::new();
+    let mut heard_index = 0;
+    let mut corrected_index = 0;
+    let mut unchanged_words = 0;
+    while heard_index < heard_tokens.len() || corrected_index < corrected_tokens.len() {
+        if heard_index < heard_tokens.len()
+            && corrected_index < corrected_tokens.len()
+            && same_word(
+                &heard_tokens[heard_index].text,
+                &corrected_tokens[corrected_index].text,
+            )
+        {
+            heard_index += 1;
+            corrected_index += 1;
+            unchanged_words += 1;
+            continue;
+        }
+
+        let heard_start = heard_index;
+        let corrected_start = corrected_index;
+        while heard_index < heard_tokens.len()
+            && corrected_index < corrected_tokens.len()
+            && !same_word(
+                &heard_tokens[heard_index].text,
+                &corrected_tokens[corrected_index].text,
+            )
+        {
+            let heard_reappears = corrected_tokens[corrected_index + 1..]
+                .iter()
+                .any(|token| same_word(&heard_tokens[heard_index].text, &token.text));
+            let corrected_reappears = heard_tokens[heard_index + 1..]
+                .iter()
+                .any(|token| same_word(&corrected_tokens[corrected_index].text, &token.text));
+            if heard_reappears && !corrected_reappears {
+                corrected_index += 1;
+            } else if corrected_reappears && !heard_reappears {
+                heard_index += 1;
+            } else {
+                // Neither current token is a unique synchronization point:
+                // consume both as one bounded replacement. This also handles
+                // a multi-token observation such as "Love a ball" ->
+                // "Lovable" without inventing an insertion/deletion alias.
+                heard_index += 1;
+                corrected_index += 1;
+            }
+        }
+
+        let heard_end = if corrected_index == corrected_tokens.len() {
+            heard_tokens.len()
+        } else {
+            heard_index
+        };
+        let corrected_end = if heard_index == heard_tokens.len() {
+            corrected_tokens.len()
+        } else {
+            corrected_index
+        };
+        heard_index = heard_end;
+        corrected_index = corrected_end;
+        let heard_count = heard_end - heard_start;
+        let corrected_count = corrected_end - corrected_start;
+
+        if heard_count == 0 {
+            let canonical = join_tokens(&corrected_tokens[corrected_start..corrected_end]);
+            if is_bounded(corrected_count, canonical.len())
+                && !canonical.is_empty()
+                && !is_represented_hint(glossary, &canonical)
+            {
+                suggestions.push(GlossarySuggestion {
+                    observed: String::new(),
+                    canonical,
+                    kind: GlossarySuggestionKind::HintOnly,
+                    context: context_window(
+                        &corrected_tokens,
+                        corrected_start,
+                        corrected_end,
+                    ),
+                });
+            }
+            continue;
+        }
+
+        if corrected_count == 0 {
+            // A deletion has no corrected spelling from which to learn.
+            continue;
+        }
+
+        let observed = join_tokens(&heard_tokens[heard_start..heard_end]);
+        let canonical = join_tokens(&corrected_tokens[corrected_start..corrected_end]);
+        if !is_bounded(heard_count, observed.len())
+            || !is_bounded(corrected_count, canonical.len())
+            || (heard_count > 1 && corrected_count > 1)
+            || same_word(&observed, &canonical)
+            || is_represented_alias(glossary, &observed, &canonical)
+        {
+            continue;
+        }
+
+        suggestions.push(GlossarySuggestion {
+            observed,
+            canonical,
+            kind: GlossarySuggestionKind::Alias,
+            context: context_window(&heard_tokens, heard_start, heard_end),
+        });
+    }
+
+    let alias_count = suggestions
+        .iter()
+        .filter(|candidate| candidate.kind == GlossarySuggestionKind::Alias)
+        .count();
+    if alias_count > 1
+        && unchanged_words * 2 < heard_tokens.len().max(corrected_tokens.len())
+    {
+        return Vec::new();
+    }
+
+    let batch = suggestions.clone();
+    suggestions.retain(|candidate| {
+        candidate.kind != GlossarySuggestionKind::Alias
+            || !batch.iter().any(|other| {
+                other.kind == GlossarySuggestionKind::Alias
+                    && same_word(&candidate.observed, &other.observed)
+                    && !same_word(&candidate.canonical, &other.canonical)
+            })
+    });
+    suggestions
+}
+
+#[derive(Debug, Clone)]
+struct Token {
+    text: String,
+}
+
+fn tokenize(text: &str) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        if is_word_character(character)
+            || (matches!(character, '-' | '.' | '/')
+                && !current.is_empty()
+                && characters.peek().is_some_and(|next| next.is_alphanumeric()))
+        {
+            current.push(character);
+        } else if !current.is_empty() {
+            tokens.push(Token {
+                text: std::mem::take(&mut current),
+            });
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(Token { text: current });
+    }
+    tokens
+}
+
+fn is_word_character(character: char) -> bool {
+    character.is_alphanumeric()
+        || matches!(
+            character as u32,
+            0x0300..=0x036f | 0x1ab0..=0x1aff | 0x1dc0..=0x1dff | 0x20d0..=0x20ff
+        )
+}
+
+fn join_tokens(tokens: &[Token]) -> String {
+    tokens
+        .iter()
+        .map(|token| token.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn context_window(tokens: &[Token], start: usize, end: usize) -> String {
+    let window_start = start.saturating_sub(4);
+    let window_end = (end + 4).min(tokens.len());
+    join_tokens(&tokens[window_start..window_end])
+}
+
+fn normalized(text: &str) -> String {
+    text.chars().flat_map(char::to_lowercase).collect()
+}
+
+fn same_word(left: &str, right: &str) -> bool {
+    normalized(left) == normalized(right)
+}
+
+fn is_bounded(word_count: usize, byte_count: usize) -> bool {
+    word_count > 0 && word_count <= MAX_REPLACEMENT_WORDS && byte_count <= MAX_REPLACEMENT_BYTES
+}
+
+fn is_represented_hint(glossary: &Glossary, canonical: &str) -> bool {
+    glossary
+        .entries()
+        .iter()
+        .any(|entry| same_word(&entry.canonical, canonical))
+}
+
+fn is_represented_alias(glossary: &Glossary, observed: &str, canonical: &str) -> bool {
+    glossary.entries().iter().any(|entry| {
+        same_word(&entry.canonical, observed)
+            || entry
+                .aliases
+                .iter()
+                .any(|alias| same_word(alias, canonical))
+            || entry.aliases.iter().any(|alias| same_word(alias, observed))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcription::Glossary;
+
+    #[test]
+    fn suggests_a_single_word_correction() {
+        let suggestions = suggest_glossary_candidates(
+            "Magnus Jille arbetar här.",
+            "Magnus Gille arbetar här.",
+            &Glossary::default(),
+        );
+
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "Jille");
+        assert_eq!(suggestions[0].canonical, "Gille");
+        assert_eq!(suggestions[0].kind, GlossarySuggestionKind::Alias);
+    }
+
+    #[test]
+    fn suggests_a_phrase_correction() {
+        let suggestions = suggest_glossary_candidates(
+            "Vi använder Love a ball i dag.",
+            "Vi använder Lovable i dag.",
+            &Glossary::default(),
+        );
+
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "Love a ball");
+        assert_eq!(suggestions[0].canonical, "Lovable");
+        assert_eq!(suggestions[0].kind, GlossarySuggestionKind::Alias);
+    }
+
+    #[test]
+    fn preserves_hyphenated_and_dotted_canonical_terms() {
+        let suggestions = suggest_glossary_candidates(
+            "Vi använder GPT 4o i dag.",
+            "Vi använder GPT-4o i dag.",
+            &Glossary::default(),
+        );
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "GPT 4o");
+        assert_eq!(suggestions[0].canonical, "GPT-4o");
+
+        let suggestions = suggest_glossary_candidates(
+            "Vi använder version 4 1 nu.",
+            "Vi använder version 4.1 nu.",
+            &Glossary::default(),
+        );
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].canonical, "4.1");
+    }
+
+    #[test]
+    fn suggests_swedish_unicode_correction() {
+        let suggestions = suggest_glossary_candidates(
+            "Vi använder klåd i dag.",
+            "Vi använder Claude i dag.",
+            &Glossary::default(),
+        );
+
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "klåd");
+        assert_eq!(suggestions[0].canonical, "Claude");
+    }
+
+    #[test]
+    fn suggests_multiple_independent_replacements() {
+        let suggestions = suggest_glossary_candidates(
+            "mördsa till branch.",
+            "mergea till branch.",
+            &Glossary::default(),
+        );
+
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "mördsa");
+        assert_eq!(suggestions[0].canonical, "mergea");
+
+        let suggestions = suggest_glossary_candidates(
+            "Jag vill mördsa den här branschen med klåd i dag.",
+            "Jag vill mergea den här branschen med Claude i dag.",
+            &Glossary::default(),
+        );
+        assert_eq!(
+            suggestions
+                .iter()
+                .map(|candidate| (&candidate.observed, &candidate.canonical))
+                .collect::<Vec<_>>(),
+            vec![
+                (&"mördsa".to_string(), &"mergea".to_string()),
+                (&"klåd".to_string(), &"Claude".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn insertion_is_hint_only() {
+        let suggestions = suggest_glossary_candidates(
+            "Vi arbetar dag.",
+            "Vi arbetar Sagascript dag.",
+            &Glossary::default(),
+        );
+
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "");
+        assert_eq!(suggestions[0].canonical, "Sagascript");
+        assert_eq!(suggestions[0].kind, GlossarySuggestionKind::HintOnly);
+    }
+
+    #[test]
+    fn deletions_do_not_create_candidates() {
+        let suggestions = suggest_glossary_candidates(
+            "Vi arbetar i Sagascript i dag.",
+            "Vi arbetar i dag.",
+            &Glossary::default(),
+        );
+
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn end_of_input_insertions_and_deletions_terminate() {
+        let suggestions = suggest_glossary_candidates(
+            "Vi arbetar.",
+            "Vi arbetar Sagascript.",
+            &Glossary::default(),
+        );
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].kind, GlossarySuggestionKind::HintOnly);
+        assert_eq!(suggestions[0].canonical, "Sagascript");
+
+        assert!(suggest_glossary_candidates(
+            "Vi arbetar Sagascript.",
+            "Vi arbetar.",
+            &Glossary::default(),
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn punctuation_and_case_only_changes_do_not_create_candidates() {
+        assert!(
+            suggest_glossary_candidates("Hej, Magnus.", "hej Magnus!", &Glossary::default(),)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn broad_rewrites_and_empty_text_fail_closed() {
+        assert!(suggest_glossary_candidates(
+            "Det här är en helt ny mening.",
+            "Nu skriver vi något totalt annorlunda.",
+            &Glossary::default(),
+        )
+        .is_empty());
+        assert!(suggest_glossary_candidates("", "Lovable", &Glossary::default()).is_empty());
+        assert!(suggest_glossary_candidates("Lovable", "", &Glossary::default()).is_empty());
+
+        assert!(suggest_glossary_candidates(
+            "alpha Paris beta",
+            "gamma Paris delta",
+            &Glossary::default(),
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn oversized_training_passages_fail_closed() {
+        let heard = std::iter::repeat_n("ord", MAX_TRANSCRIPT_WORDS + 1)
+            .collect::<Vec<_>>()
+            .join(" ");
+        let corrected = heard.replacen("ord", "term", 1);
+        assert!(suggest_glossary_candidates(&heard, &corrected, &Glossary::default()).is_empty());
+    }
+
+    #[test]
+    fn repeated_token_ambiguity_fails_closed() {
+        let suggestions =
+            suggest_glossary_candidates("gå till gå hem.", "gå hem.", &Glossary::default());
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn repeated_unchanged_words_do_not_hide_a_bounded_correction() {
+        let suggestions = suggest_glossary_candidates(
+            "Jag använder Codex och jag använder klåd.",
+            "Jag använder Codex och jag använder Claude.",
+            &Glossary::default(),
+        );
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].observed, "klåd");
+        assert_eq!(suggestions[0].canonical, "Claude");
+    }
+
+    #[test]
+    fn existing_aliases_and_hints_are_suppressed() {
+        let glossary = Glossary::parse("mergea = mördsa\nSagascript");
+        assert!(suggest_glossary_candidates("mördsa", "mergea", &glossary).is_empty());
+        assert!(suggest_glossary_candidates("vi dag", "vi Sagascript dag", &glossary).is_empty());
+    }
+
+    #[test]
+    fn existing_canonical_and_conflicting_aliases_fail_closed() {
+        let glossary = Glossary::parse("merchandise = merch\nmerge");
+        assert!(suggest_glossary_candidates("merch", "merge", &glossary).is_empty());
+        assert!(suggest_glossary_candidates("merge", "mergea", &glossary).is_empty());
+
+        let glossary = Glossary::parse("product = mergea");
+        assert!(suggest_glossary_candidates("mördsa", "mergea", &glossary).is_empty());
+    }
+
+    #[test]
+    fn merge_merch_collision_is_safe_across_swedish_and_english_contexts() {
+        let glossary = Glossary::parse("merge = merch");
+
+        let swedish = suggest_glossary_candidates(
+            "Vi kan merge den här ändringen.",
+            "Vi kan merch den här ändringen.",
+            &glossary,
+        );
+        let english = suggest_glossary_candidates(
+            "We can merch this merge.",
+            "We can merge this merge.",
+            &glossary,
+        );
+
+        assert!(swedish
+            .iter()
+            .all(|candidate| candidate.kind != GlossarySuggestionKind::Alias));
+        assert!(english
+            .iter()
+            .all(|candidate| candidate.kind != GlossarySuggestionKind::Alias));
+    }
+
+    #[test]
+    fn deterministic_evaluation_reports_recall_safety_and_latency() {
+        struct EvaluationCase<'a> {
+            heard: &'a str,
+            corrected: &'a str,
+            expected_aliases: &'a [(&'a str, &'a str)],
+            glossary: &'a Glossary,
+            unsafe_case: bool,
+        }
+
+        let empty_glossary = Glossary::default();
+        let merge_glossary = Glossary::parse("merge = merch");
+        let magnus = [("Jille", "Gille")];
+        let lovable = [("Love a ball", "Lovable")];
+        let tooling = [("mördsa", "mergea"), ("klåd", "Claude")];
+        let unicode = [("Åmål", "Älmhult")];
+        let cases = [
+            EvaluationCase {
+                heard: "Magnus Jille arbetar här.",
+                corrected: "Magnus Gille arbetar här.",
+                expected_aliases: &magnus,
+                glossary: &empty_glossary,
+                unsafe_case: false,
+            },
+            EvaluationCase {
+                heard: "Vi använder Love a ball i dag.",
+                corrected: "Vi använder Lovable i dag.",
+                expected_aliases: &lovable,
+                glossary: &empty_glossary,
+                unsafe_case: false,
+            },
+            EvaluationCase {
+                heard: "Jag vill mördsa den här branschen med klåd i dag.",
+                corrected: "Jag vill mergea den här branschen med Claude i dag.",
+                expected_aliases: &tooling,
+                glossary: &empty_glossary,
+                unsafe_case: false,
+            },
+            EvaluationCase {
+                heard: "Vi såg räksmörgås nära Åmål.",
+                corrected: "Vi såg räksmörgås nära Älmhult.",
+                expected_aliases: &unicode,
+                glossary: &empty_glossary,
+                unsafe_case: false,
+            },
+            EvaluationCase {
+                heard: "Vi arbetar dag.",
+                corrected: "Vi arbetar Sagascript dag.",
+                expected_aliases: &[],
+                glossary: &empty_glossary,
+                unsafe_case: true,
+            },
+            EvaluationCase {
+                heard: "Vi arbetar Sagascript.",
+                corrected: "Vi arbetar.",
+                expected_aliases: &[],
+                glossary: &empty_glossary,
+                unsafe_case: true,
+            },
+            EvaluationCase {
+                heard: "Det här är en helt ny mening.",
+                corrected: "Nu skriver vi något totalt annorlunda.",
+                expected_aliases: &[],
+                glossary: &empty_glossary,
+                unsafe_case: true,
+            },
+            EvaluationCase {
+                heard: "Vi kan merge den här ändringen.",
+                corrected: "Vi kan merch den här ändringen.",
+                expected_aliases: &[],
+                glossary: &merge_glossary,
+                unsafe_case: true,
+            },
+        ];
+
+        let mut expected_count = 0usize;
+        let mut recovered_count = 0usize;
+        let mut unsafe_case_count = 0usize;
+        let mut unsafe_alias_count = 0usize;
+
+        for case in &cases {
+            let suggestions =
+                suggest_glossary_candidates(case.heard, case.corrected, case.glossary);
+            let aliases: Vec<_> = suggestions
+                .iter()
+                .filter(|candidate| candidate.kind == GlossarySuggestionKind::Alias)
+                .map(|candidate| (candidate.observed.as_str(), candidate.canonical.as_str()))
+                .collect();
+
+            expected_count += case.expected_aliases.len();
+            recovered_count += case
+                .expected_aliases
+                .iter()
+                .filter(|(observed, canonical)| aliases.contains(&(*observed, *canonical)))
+                .count();
+            if !case.unsafe_case {
+                assert_eq!(aliases, case.expected_aliases);
+            } else {
+                unsafe_case_count += 1;
+                unsafe_alias_count += aliases.len();
+                assert!(aliases.is_empty(), "unsafe case proposed {aliases:?}");
+            }
+        }
+
+        let recall = recovered_count as f64 / expected_count as f64;
+        let unsafe_alias_proposal_rate = unsafe_alias_count as f64 / unsafe_case_count as f64;
+        assert_eq!(recovered_count, expected_count);
+        assert_eq!(unsafe_alias_count, 0);
+
+        let mut timings = Vec::with_capacity(cases.len() * 128);
+        for _ in 0..128 {
+            for case in &cases {
+                let started = std::time::Instant::now();
+                std::hint::black_box(suggest_glossary_candidates(
+                    case.heard,
+                    case.corrected,
+                    case.glossary,
+                ));
+                timings.push(started.elapsed().as_nanos());
+            }
+        }
+        timings.sort_unstable();
+        let p50 = timings[(timings.len() - 1) * 50 / 100];
+        let p95 = timings[(timings.len() - 1) * 95 / 100];
+        assert!(p50 <= p95);
+        println!(
+            "glossary evaluation: recall={recall:.3}, unsafe_alias_rate={unsafe_alias_proposal_rate:.3}, p50={p50}ns, p95={p95}ns"
+        );
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/transcription/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/mod.rs
@@ -1,5 +1,6 @@
 pub mod diagnostics;
 pub mod glossary;
+pub mod glossary_suggestions;
 pub mod model;
 mod postprocess;
 pub mod whisper_backend;
@@ -12,4 +13,7 @@ pub use whisper_backend::{
     WARM_MODEL_CACHE_MAX_MODELS, WhisperBackend,
 };
 pub use glossary::{Glossary, GlossaryCorrection, GlossaryEntry};
+pub use glossary_suggestions::{
+    suggest_glossary_candidates, GlossarySuggestion, GlossarySuggestionKind,
+};
 pub use postprocess::normalize_nonspeech_markers;

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -75,6 +75,7 @@ pub struct AppController {
     last_error: Option<String>,
     model_ready: bool,
     active_hotkey_profile: Option<HotkeyProfile>,
+    training_recording: bool,
 }
 
 impl AppController {
@@ -101,6 +102,7 @@ impl AppController {
             last_error: None,
             model_ready: false,
             active_hotkey_profile: None,
+            training_recording: false,
         }
     }
 
@@ -176,6 +178,7 @@ impl AppController {
             }
             HotkeyMode::Toggle => {
                 if self.state.is_recording()
+                    && !self.training_recording
                     && self
                         .active_hotkey_profile
                         .as_ref()
@@ -195,7 +198,9 @@ impl AppController {
 
     /// Handle hotkey up event
     pub fn should_stop_on_key_up(&self) -> bool {
-        self.settings.hotkey_mode == HotkeyMode::PushToTalk && self.state.is_recording()
+        self.settings.hotkey_mode == HotkeyMode::PushToTalk
+            && self.state.is_recording()
+            && !self.training_recording
     }
 
     pub fn should_stop_profile_on_key_up(&self, shortcut: &str) -> bool {
@@ -251,12 +256,27 @@ impl AppController {
             "Recording profile selected"
         );
         self.active_hotkey_profile = Some(profile);
+        self.training_recording = false;
         self.state = AppState::Recording;
         self.recording_start = Some(Instant::now());
         self.last_error = None;
 
         info!("Recording started");
         Ok(true)
+    }
+
+    /// Start a Teach Sagascript recording that only the Teach UI may stop.
+    /// Global hotkey releases and toggle presses must not route this audio
+    /// through the normal dictation/auto-paste path.
+    pub fn start_training_recording_for_profile(
+        &mut self,
+        profile: HotkeyProfile,
+    ) -> Result<bool, DictationError> {
+        let started = self.start_recording_for_profile(profile)?;
+        if started {
+            self.training_recording = true;
+        }
+        Ok(started)
     }
 
     /// Stop recording and return the captured 16 kHz samples.
@@ -309,6 +329,7 @@ impl AppController {
         self.audio.clear_last_captured();
         self.state = AppState::Idle;
         self.active_hotkey_profile = None;
+        self.training_recording = false;
         self.logging.end_dictation_session();
     }
 
@@ -317,6 +338,7 @@ impl AppController {
         self.last_error = Some(error.to_string());
         self.state = AppState::Idle;
         self.active_hotkey_profile = None;
+        self.training_recording = false;
         self.logging.end_dictation_session();
     }
 
@@ -356,6 +378,7 @@ impl AppController {
             let _ = self.audio.stop_capture();
             self.state = AppState::Idle;
             self.active_hotkey_profile = None;
+            self.training_recording = false;
             self.logging.end_dictation_session();
             info!("Recording cancelled");
         }
@@ -610,6 +633,42 @@ mod tests {
         ctrl.state = AppState::Recording;
         let result = ctrl.handle_hotkey_down().unwrap();
         assert_eq!(result, HotkeyDownResult::StopRecording);
+    }
+
+    #[test]
+    fn training_recording_ignores_toggle_hotkey_stop() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Toggle;
+        ctrl.state = AppState::Recording;
+        ctrl.training_recording = true;
+
+        assert_eq!(
+            ctrl.handle_hotkey_down().unwrap(),
+            HotkeyDownResult::NoOp
+        );
+    }
+
+    #[test]
+    fn training_recording_ignores_push_to_talk_release() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
+        ctrl.state = AppState::Recording;
+        ctrl.training_recording = true;
+
+        assert!(!ctrl.should_stop_on_key_up());
+    }
+
+    #[test]
+    fn cancelling_training_recording_restores_normal_hotkey_lifecycle() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
+        ctrl.state = AppState::Recording;
+        ctrl.training_recording = true;
+
+        ctrl.cancel_recording();
+
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert!(!ctrl.training_recording);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -525,7 +525,7 @@ pub async fn start_training_recording(
         .into_iter()
         .find(|profile| profile.id == profile_id)
         .ok_or_else(|| format!("Unknown dictation profile '{profile_id}'"))?;
-    gui_start_recording_result(ctrl.start_recording_for_profile(profile))
+    gui_start_recording_result(ctrl.start_training_recording_for_profile(profile))
 }
 
 fn gui_start_recording_result(
@@ -559,7 +559,7 @@ pub async fn stop_and_transcribe(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
 ) -> Result<String, String> {
-    stop_and_transcribe_training(controller, whisper)
+    stop_and_transcribe_impl(controller, whisper, true)
         .await
         .map(|transcript| transcript.effective_text)
 }
@@ -575,18 +575,34 @@ pub async fn stop_and_transcribe_training(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
 ) -> Result<TrainingTranscript, String> {
+    stop_and_transcribe_impl(controller, whisper, false).await
+}
+
+fn not_recording_result(allow_empty: bool) -> Result<TrainingTranscript, String> {
+    if allow_empty {
+        Ok(TrainingTranscript {
+            raw_text: String::new(),
+            effective_text: String::new(),
+        })
+    } else {
+        Err("No training recording is active".to_string())
+    }
+}
+
+async fn stop_and_transcribe_impl(
+    controller: State<'_, SharedController>,
+    whisper: State<'_, SharedWhisper>,
+    allow_empty_not_recording: bool,
+) -> Result<TrainingTranscript, String> {
     let (audio, language, effective_model, opts, glossary) = {
         let mut ctrl = controller.lock().unwrap();
-        // Guard against a late/duplicate invoke racing the hotkey stop path
-        // (finding 3): if we're not recording, do nothing and return Ok-empty
-        // (NOT Err — an error would surface a misleading toast in the UI) so an
-        // in-flight transcription's state/last_error is not clobbered.
+        // A late/duplicate normal stop racing the hotkey path remains an
+        // Ok-empty no-op so it cannot clobber an in-flight transcription.
+        // Teach owns its recording lifecycle, so a missing recording there is
+        // an actionable UI error instead of a silently accepted empty result.
         let audio = match ctrl.stop_recording_guarded() {
             StopRecordingOutcome::NotRecording => {
-                return Ok(TrainingTranscript {
-                    raw_text: String::new(),
-                    effective_text: String::new(),
-                });
+                return not_recording_result(allow_empty_not_recording)
             }
             // Capture/resample failure (finding 4): the controller already
             // recorded the error and returned to Idle; surface the real error.
@@ -748,6 +764,24 @@ pub async fn transcribe_training_file(
         effective_text: apply_glossary(raw_text.clone(), &glossary),
         raw_text,
     })
+}
+
+#[cfg(test)]
+mod training_stop_tests {
+    use super::not_recording_result;
+
+    #[test]
+    fn duplicate_normal_stop_remains_a_noop() {
+        let result = not_recording_result(true).unwrap();
+        assert!(result.raw_text.is_empty());
+        assert!(result.effective_text.is_empty());
+    }
+
+    #[test]
+    fn training_stop_without_active_recording_is_an_error() {
+        let error = not_recording_result(false).unwrap_err();
+        assert!(error.contains("No training recording"));
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,14 +19,23 @@ use sagascript_core::audio::decoder;
 use sagascript_core::settings::{
     validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
 };
-use sagascript_core::transcription::Glossary;
+use sagascript_core::transcription::{
+    suggest_glossary_candidates, Glossary, GlossarySuggestion, GlossarySuggestionKind,
+};
 use sagascript_core::transcription::{model, FILE_TRANSCRIBE_BEAM, TranscribeOptions, WhisperBackend};
 
 /// Build the per-transcription options from the current settings. Resolves the
 /// VAD model path only when VAD is enabled and the model is present (otherwise
 /// VAD is silently skipped — whisper would fail on a missing model).
 pub(crate) fn build_transcribe_options(settings: &Settings) -> TranscribeOptions {
-    let prompt = Glossary::parse(&settings.initial_prompt).decoder_prompt();
+    build_transcribe_options_for_profile(settings, None)
+}
+
+pub(crate) fn build_transcribe_options_for_profile(
+    settings: &Settings,
+    profile_id: Option<&str>,
+) -> TranscribeOptions {
+    let prompt = Glossary::parse(&settings.effective_glossary_source(profile_id)).decoder_prompt();
     let vad_model_path = if settings.vad_enabled {
         let p = model::vad_model_path();
         if p.exists() {
@@ -89,6 +98,41 @@ mod glossary_options_tests {
             ..Settings::default()
         };
         assert_eq!(build_transcribe_options(&settings).prompt.as_deref(), Some("OpenRouter, merge"));
+    }
+
+    #[test]
+    fn live_options_include_only_the_selected_profile_glossary() {
+        let mut settings = Settings {
+            initial_prompt: "Codex = code x".to_string(),
+            hotkey_profiles: vec![
+                HotkeyProfile {
+                    id: "svenska".to_string(),
+                    name: "Svenska".to_string(),
+                    shortcut: "Control+Shift+Space".to_string(),
+                    language: Language::Swedish,
+                },
+                HotkeyProfile {
+                    id: "english".to_string(),
+                    name: "English".to_string(),
+                    shortcut: "Control+Option+Space".to_string(),
+                    language: Language::English,
+                },
+            ],
+            ..Settings::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("svenska".to_string(), "mergea = mördsa".to_string());
+        settings
+            .profile_glossaries
+            .insert("english".to_string(), "Lovable = love a ball".to_string());
+
+        assert_eq!(
+            build_transcribe_options_for_profile(&settings, Some("svenska"))
+                .prompt
+                .as_deref(),
+            Some("Codex, mergea")
+        );
     }
 
     #[test]
@@ -468,6 +512,22 @@ pub async fn start_recording(controller: State<'_, SharedController>) -> Result<
     gui_start_recording_result(ctrl.start_recording())
 }
 
+#[tauri::command]
+pub async fn start_training_recording(
+    controller: State<'_, SharedController>,
+    profile_id: String,
+) -> Result<(), String> {
+    let mut ctrl = controller.lock().unwrap();
+    ensure_known_profile(ctrl.settings(), &profile_id)?;
+    let profile = ctrl
+        .settings()
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| format!("Unknown dictation profile '{profile_id}'"))?;
+    gui_start_recording_result(ctrl.start_recording_for_profile(profile))
+}
+
 fn gui_start_recording_result(
     result: Result<bool, sagascript_core::error::DictationError>,
 ) -> Result<(), String> {
@@ -499,6 +559,22 @@ pub async fn stop_and_transcribe(
     controller: State<'_, SharedController>,
     whisper: State<'_, SharedWhisper>,
 ) -> Result<String, String> {
+    stop_and_transcribe_training(controller, whisper)
+        .await
+        .map(|transcript| transcript.effective_text)
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TrainingTranscript {
+    pub raw_text: String,
+    pub effective_text: String,
+}
+
+#[tauri::command]
+pub async fn stop_and_transcribe_training(
+    controller: State<'_, SharedController>,
+    whisper: State<'_, SharedWhisper>,
+) -> Result<TrainingTranscript, String> {
     let (audio, language, effective_model, opts, glossary) = {
         let mut ctrl = controller.lock().unwrap();
         // Guard against a late/duplicate invoke racing the hotkey stop path
@@ -506,24 +582,32 @@ pub async fn stop_and_transcribe(
         // (NOT Err — an error would surface a misleading toast in the UI) so an
         // in-flight transcription's state/last_error is not clobbered.
         let audio = match ctrl.stop_recording_guarded() {
-            StopRecordingOutcome::NotRecording => return Ok(String::new()),
+            StopRecordingOutcome::NotRecording => {
+                return Ok(TrainingTranscript {
+                    raw_text: String::new(),
+                    effective_text: String::new(),
+                });
+            }
             // Capture/resample failure (finding 4): the controller already
             // recorded the error and returned to Idle; surface the real error.
             StopRecordingOutcome::Failed(msg) => return Err(msg),
             StopRecordingOutcome::Stopped(audio) => audio,
         };
         let language = ctrl.language();
-        let effective_model = ctrl.settings().effective_model();
-        let opts = build_transcribe_options(ctrl.settings());
-        let glossary = Glossary::parse(&ctrl.settings().initial_prompt);
+        let effective_model = ctrl.settings().effective_model_for(language);
+        let profile_id = ctrl.active_hotkey_profile().map(|profile| profile.id.as_str());
+        let opts = build_transcribe_options_for_profile(ctrl.settings(), profile_id);
+        let glossary = Glossary::parse(&ctrl.settings().effective_glossary_source(profile_id));
         (audio, language, effective_model, opts, glossary)
     };
 
     if audio.is_empty() {
-        return controller
+        let error = "No audio captured".to_string();
+        let completion = controller
             .lock()
             .unwrap()
-            .finish_transcription(Err("No audio captured".to_string()));
+            .finish_transcription(Err(error.clone()));
+        return Err(completion.err().unwrap_or(error));
     }
 
     // Every outcome after recording stops must flow through
@@ -568,14 +652,102 @@ pub async fn stop_and_transcribe(
                 ))
             }
         }
-    }
-    .map(|text| apply_glossary(text, &glossary));
+    };
+
+    let training_result = result.map(|raw_text| TrainingTranscript {
+        effective_text: apply_glossary(raw_text.clone(), &glossary),
+        raw_text,
+    });
 
     // NOTE: auto-paste is NOT done here — enigo's macOS TIS APIs crash if
     // called from a tokio worker thread (SIGTRAP in dispatch_assert_queue).
     // The hotkey path in main.rs handles paste via run_on_main_thread(). This
     // command returns the text to the frontend for display instead.
-    controller.lock().unwrap().finish_transcription(result)
+    let completion = training_result
+        .as_ref()
+        .map(|transcript| transcript.effective_text.clone())
+        .map_err(Clone::clone);
+    controller.lock().unwrap().finish_transcription(completion)?;
+    training_result
+}
+
+#[tauri::command]
+pub async fn transcribe_training_file(
+    app: tauri::AppHandle,
+    controller: State<'_, SharedController>,
+    whisper: State<'_, SharedWhisper>,
+    file_path: String,
+    profile_id: String,
+) -> Result<TrainingTranscript, String> {
+    use tauri::Emitter;
+
+    let path = std::path::PathBuf::from(file_path);
+    let audio = tokio::task::spawn_blocking(move || decoder::decode_audio_file(&path))
+        .await
+        .map_err(|error| format!("Decode task failed: {error}"))?
+        .map_err(|error| error.to_string())?;
+    if audio.is_empty() {
+        return Err("No audio decoded from file".to_string());
+    }
+
+    let (language, effective_model, opts, glossary) = {
+        let ctrl = controller.lock().unwrap();
+        ensure_known_profile(ctrl.settings(), &profile_id)?;
+        let profile = ctrl
+            .settings()
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .find(|profile| profile.id == profile_id)
+            .expect("validated profile must exist");
+        (
+            profile.language,
+            ctrl.settings().effective_model_for(profile.language),
+            build_transcribe_options_for_profile(ctrl.settings(), Some(&profile_id)),
+            Glossary::parse(
+                &ctrl
+                    .settings()
+                    .effective_glossary_source(Some(&profile_id)),
+            ),
+        )
+    };
+
+    if whisper.needs_reload(effective_model) {
+        let _ = app.emit(crate::events::event::STATE_CHANGED, "loading_model");
+    }
+    if let Err(error) = whisper.ensure_model(effective_model) {
+        let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+        return Err(error.to_string());
+    }
+    let _ = app.emit(crate::events::event::STATE_CHANGED, "transcribing");
+
+    let whisper_ref = whisper.inner().clone();
+    let progress_app = app.clone();
+    let duration_seconds = (audio.len() / 16_000) as u64;
+    let timeout = Duration::from_secs((duration_seconds * 6).max(TRANSCRIPTION_TIMEOUT_SECS));
+    let mut task = tokio::task::spawn_blocking(move || {
+        whisper_ref.transcribe_sync_with_options(&audio, language, &opts, move |progress| {
+            let _ = progress_app.emit("transcription-progress", progress);
+        })
+    });
+
+    let result = match tokio::time::timeout(timeout, &mut task).await {
+        Ok(Ok(result)) => result.map_err(|error| error.to_string()),
+        Ok(Err(error)) => Err(format!("Transcription task failed: {error}")),
+        Err(_) => {
+            whisper.request_abort();
+            let _ = tokio::time::timeout(Duration::from_secs(ABORT_GRACE_SECS), &mut task).await;
+            Err(format!(
+                "Training transcription timed out after {}s",
+                timeout.as_secs()
+            ))
+        }
+    };
+    let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+
+    result.map(|raw_text| TrainingTranscript {
+        effective_text: apply_glossary(raw_text.clone(), &glossary),
+        raw_text,
+    })
 }
 
 #[tauri::command]
@@ -721,6 +893,297 @@ pub async fn set_initial_prompt(
     ctrl.settings_mut().initial_prompt = persisted.initial_prompt;
     info!("Initial prompt set ({} chars)", prompt.len());
     Ok(())
+}
+
+fn ensure_known_profile(settings: &Settings, profile_id: &str) -> Result<(), String> {
+    let profile = settings
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| format!("Unknown dictation profile '{profile_id}'"))?;
+    if profile.language == Language::Auto {
+        return Err(
+            "Teach Sagascript requires a profile with an explicit language".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn apply_reviewed_training_candidates(
+    settings: &mut Settings,
+    heard: &str,
+    corrected: &str,
+    profile_id: &str,
+    accepted: &[GlossarySuggestion],
+) -> Result<(), String> {
+    ensure_known_profile(settings, profile_id)?;
+    let effective = Glossary::parse(&settings.effective_glossary_source(Some(profile_id)));
+    let allowed = suggest_glossary_candidates(heard, corrected, &effective);
+    let mut matched = vec![false; allowed.len()];
+    for candidate in accepted {
+        validate_edited_training_candidate(candidate)?;
+        let canonical_key = training_term_key(&candidate.canonical);
+        let conflicts_with_existing_alias = effective.entries().iter().any(|entry| {
+            entry
+                .aliases
+                .iter()
+                .any(|alias| training_term_key(alias) == canonical_key)
+        });
+        let conflicts_with_reviewed_alias = accepted.iter().any(|other| {
+            other.kind == GlossarySuggestionKind::Alias
+                && training_term_key(&other.observed) == canonical_key
+        });
+        if conflicts_with_existing_alias || conflicts_with_reviewed_alias {
+            return Err(
+                "Edited preferred spelling conflicts with a personal dictionary alias"
+                    .to_string(),
+            );
+        }
+        let Some((index, _)) = allowed.iter().enumerate().find(|(index, original)| {
+            !matched[*index]
+                && original.observed == candidate.observed
+                && original.context == candidate.context
+                && match (original.kind, candidate.kind) {
+                    (GlossarySuggestionKind::Alias, GlossarySuggestionKind::Alias)
+                    | (GlossarySuggestionKind::Alias, GlossarySuggestionKind::HintOnly)
+                    | (GlossarySuggestionKind::HintOnly, GlossarySuggestionKind::HintOnly) => true,
+                    (GlossarySuggestionKind::HintOnly, GlossarySuggestionKind::Alias) => false,
+                }
+        }) else {
+            return Err(
+                "Dictionary suggestions changed; review the corrected transcript again"
+                    .to_string(),
+            );
+        };
+        matched[index] = true;
+    }
+
+    let source = settings
+        .profile_glossaries
+        .entry(profile_id.to_string())
+        .or_default();
+    let mut scoped = Glossary::parse(source);
+    for candidate in accepted {
+        match candidate.kind {
+            GlossarySuggestionKind::Alias => {
+                scoped.upsert(candidate.canonical.clone(), vec![candidate.observed.clone()]);
+            }
+            GlossarySuggestionKind::HintOnly => {
+                scoped.upsert(candidate.canonical.clone(), Vec::new());
+            }
+        }
+    }
+    *source = scoped.render();
+    Ok(())
+}
+
+fn training_term_key(value: &str) -> String {
+    value.chars().flat_map(char::to_lowercase).collect()
+}
+
+fn validate_edited_training_candidate(candidate: &GlossarySuggestion) -> Result<(), String> {
+    let canonical = candidate.canonical.trim();
+    if canonical.is_empty()
+        || canonical != candidate.canonical
+        || canonical.len() > 96
+        || canonical.split_whitespace().count() > 4
+        || canonical
+            .chars()
+            .any(|character| matches!(character, '\n' | '\r' | ',' | '=' | '|'))
+    {
+        return Err(
+            "Edited dictionary terms must be 1-4 words without glossary delimiters"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn suggest_training_glossary(
+    heard: String,
+    corrected: String,
+    profile_id: String,
+) -> Result<Vec<GlossarySuggestion>, String> {
+    let settings = sagascript_core::settings::store::load();
+    ensure_known_profile(&settings, &profile_id)?;
+    let glossary = Glossary::parse(&settings.effective_glossary_source(Some(&profile_id)));
+    Ok(suggest_glossary_candidates(&heard, &corrected, &glossary))
+}
+
+#[tauri::command]
+pub async fn apply_training_glossary(
+    controller: State<'_, SharedController>,
+    heard: String,
+    corrected: String,
+    profile_id: String,
+    accepted: Vec<GlossarySuggestion>,
+) -> Result<(), String> {
+    if accepted.is_empty() {
+        return Err("Select at least one dictionary suggestion".to_string());
+    }
+
+    let accepted_count = accepted.len();
+    let persisted = sagascript_core::settings::store::try_update(|settings| {
+        apply_reviewed_training_candidates(
+            settings,
+            &heard,
+            &corrected,
+            &profile_id,
+            &accepted,
+        )
+    })?;
+
+    controller.lock().unwrap().settings_mut().profile_glossaries = persisted.profile_glossaries;
+    info!(accepted_count, profile_id = %profile_id, "Applied reviewed training glossary suggestions");
+    Ok(())
+}
+
+#[cfg(test)]
+mod training_glossary_tests {
+    use super::*;
+
+    #[test]
+    fn reviewed_candidates_are_saved_only_to_the_selected_profile() {
+        let mut settings = Settings::default();
+        let heard = "Jag heter Magnus Jille.";
+        let corrected = "Jag heter Magnus Gille.";
+        let candidates = suggest_glossary_candidates(heard, corrected, &Glossary::default());
+
+        apply_reviewed_training_candidates(
+            &mut settings,
+            heard,
+            corrected,
+            "default",
+            &candidates,
+        )
+        .unwrap();
+
+        assert_eq!(settings.initial_prompt, "");
+        assert_eq!(
+            settings.profile_glossaries.get("default").map(String::as_str),
+            Some("Gille = Jille")
+        );
+    }
+
+    #[test]
+    fn fabricated_candidate_fails_without_mutating_settings() {
+        let mut settings = Settings::default();
+        let fabricated = GlossarySuggestion {
+            observed: "anything".to_string(),
+            canonical: "dangerous".to_string(),
+            kind: GlossarySuggestionKind::Alias,
+            context: "Magnus Jille".to_string(),
+        };
+
+        let error = apply_reviewed_training_candidates(
+            &mut settings,
+            "Magnus Jille",
+            "Magnus Gille",
+            "default",
+            &[fabricated],
+        )
+        .unwrap_err();
+
+        assert!(error.contains("review"));
+        assert!(settings.profile_glossaries.is_empty());
+    }
+
+    #[test]
+    fn reviewed_alias_can_be_edited_or_converted_to_a_hint() {
+        let heard = "Jag använder Love a ball idag.";
+        let corrected = "Jag använder Lovable idag.";
+        let original = suggest_glossary_candidates(heard, corrected, &Glossary::default())
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let mut edited = original.clone();
+        edited.canonical = "Lovable.dev".to_string();
+        let mut settings = Settings::default();
+        apply_reviewed_training_candidates(
+            &mut settings,
+            heard,
+            corrected,
+            "default",
+            &[edited],
+        )
+        .unwrap();
+        assert_eq!(
+            settings.profile_glossaries.get("default").map(String::as_str),
+            Some("Lovable.dev = Love a ball")
+        );
+
+        let mut as_hint = original;
+        as_hint.kind = GlossarySuggestionKind::HintOnly;
+        let mut settings = Settings::default();
+        apply_reviewed_training_candidates(
+            &mut settings,
+            heard,
+            corrected,
+            "default",
+            &[as_hint],
+        )
+        .unwrap();
+        assert_eq!(
+            settings.profile_glossaries.get("default").map(String::as_str),
+            Some("Lovable")
+        );
+    }
+
+    #[test]
+    fn auto_language_profile_fails_closed_without_mutation() {
+        let mut settings = Settings {
+            language: Language::Auto,
+            ..Default::default()
+        };
+        let heard = "Magnus Jille";
+        let corrected = "Magnus Gille";
+        let candidates = suggest_glossary_candidates(heard, corrected, &Glossary::default());
+
+        let error = apply_reviewed_training_candidates(
+            &mut settings,
+            heard,
+            corrected,
+            "default",
+            &candidates,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("explicit language"));
+        assert!(settings.profile_glossaries.is_empty());
+    }
+
+    #[test]
+    fn edited_canonical_cannot_shadow_an_existing_alias() {
+        let mut settings = Settings {
+            initial_prompt: "Existing = dangerous".to_string(),
+            ..Default::default()
+        };
+        let heard = "Magnus Jille";
+        let corrected = "Magnus Gille";
+        let mut candidate = suggest_glossary_candidates(
+            heard,
+            corrected,
+            &Glossary::parse(&settings.initial_prompt),
+        )
+        .into_iter()
+        .next()
+        .unwrap();
+        candidate.canonical = "Dangerous".to_string();
+
+        let error = apply_reviewed_training_candidates(
+            &mut settings,
+            heard,
+            corrected,
+            "default",
+            &[candidate],
+        )
+        .unwrap_err();
+
+        assert!(error.contains("conflicts"));
+        assert!(settings.profile_glossaries.is_empty());
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -661,7 +661,11 @@ fn main() {
                 if let Some(dir) = app_dir {
                     let legacy = dir.join("flowdictate-settings.json");
                     let new_path = dir.join("sagascript-settings.json");
-                    migrate_legacy_settings(&legacy, &new_path);
+                    migrate_legacy_settings_unless_overridden(
+                        &legacy,
+                        &new_path,
+                        sagascript_core::settings::store::settings_path_is_overridden(),
+                    );
                 }
             }
 
@@ -906,6 +910,17 @@ fn migrate_legacy_settings(legacy: &std::path::Path, new_path: &std::path::Path)
             new_path.display()
         ),
     }
+}
+
+fn migrate_legacy_settings_unless_overridden(
+    legacy: &std::path::Path,
+    new_path: &std::path::Path,
+    settings_path_is_overridden: bool,
+) {
+    if settings_path_is_overridden {
+        return;
+    }
+    migrate_legacy_settings(legacy, new_path);
 }
 
 /// Truncate transcription text for tray display, cutting on a char boundary.
@@ -1813,6 +1828,21 @@ mod tests {
         assert!(new_path.exists(), "new path should now hold the migrated settings");
         assert_eq!(std::fs::read_to_string(&new_path).unwrap(), r#"{"language":"sv"}"#);
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn overridden_settings_path_disables_flowdictate_migration() {
+        let dir = migrate_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let legacy = dir.join("flowdictate-settings.json");
+        let new_path = dir.join("sagascript-settings.json");
+        std::fs::write(&legacy, r#"{"language":"sv"}"#).unwrap();
+
+        migrate_legacy_settings_unless_overridden(&legacy, &new_path, true);
+
+        assert!(legacy.exists(), "override mode must not inspect or move legacy settings");
+        assert!(!new_path.exists());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -794,7 +794,10 @@ fn main() {
             commands::set_hotkey_profiles,
             commands::hotkey_status,
             commands::start_recording,
+            commands::start_training_recording,
             commands::stop_and_transcribe,
+            commands::stop_and_transcribe_training,
+            commands::transcribe_training_file,
             commands::cancel_recording,
             commands::is_model_downloaded,
             commands::get_model_info,
@@ -802,6 +805,8 @@ fn main() {
             commands::set_auto_paste,
             commands::set_show_overlay,
             commands::set_initial_prompt,
+            commands::suggest_training_glossary,
+            commands::apply_training_glossary,
             commands::set_beam_size,
             commands::set_temperature_fallback,
             commands::set_vad_enabled,
@@ -1158,11 +1163,14 @@ fn stop_recording_and_transcribe(
         // Extract what we need for transcription (lock briefly)
         let (language, effective_model, opts, glossary) = {
             let c = ctrl.lock().unwrap();
+            let profile_id = c.active_hotkey_profile().map(|profile| profile.id.as_str());
             (
                 c.language(),
                 c.settings().effective_model_for(c.language()),
-                commands::build_transcribe_options(c.settings()),
-                sagascript_core::transcription::Glossary::parse(&c.settings().initial_prompt),
+                commands::build_transcribe_options_for_profile(c.settings(), profile_id),
+                sagascript_core::transcription::Glossary::parse(
+                    &c.settings().effective_glossary_source(profile_id),
+                ),
             )
         };
 

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -22,7 +22,12 @@
     checkAccessibilityPermission,
     requestAccessibilityPermission,
     startRecording,
+    startTrainingRecording,
     stopAndTranscribe,
+    stopAndTranscribeTraining,
+    transcribeTrainingFile,
+    suggestTrainingGlossary,
+    applyTrainingGlossary,
     hotkeyStatus,
     type Settings,
     type BuildInfo,
@@ -32,6 +37,7 @@
     type LoadedModelInfo,
     type HotkeyStatus,
     type HotkeyProfile,
+    type GlossarySuggestion,
   } from "./api";
   import { listen } from "@tauri-apps/api/event";
   import { open } from "@tauri-apps/plugin-dialog";
@@ -41,7 +47,7 @@
   let buildInfo: BuildInfo | null = $state(null);
   let models: WhisperModel[] = $state([]);
   let loadedModel: LoadedModelInfo | null = $state(null);
-  let activeTab: "dictate" | "transcribe" | "settings" = $state("dictate");
+  let activeTab: "dictate" | "transcribe" | "teach" | "settings" = $state("dictate");
   let downloading: string | null = $state(null);
   let downloadingName: string = $state("");
   let downloadProgress: number = $state(0);
@@ -83,6 +89,30 @@
   let testTranscribing: boolean = $state(false);
   let testResult: string = $state("");
   let testError: string = $state("");
+
+  // Local, review-first personal dictionary training state
+  let teachProfileId: string = $state("default");
+  let teachRecording: boolean = $state(false);
+  let teachTranscribing: boolean = $state(false);
+  let teachRawText: string = $state("");
+  let teachEffectiveText: string = $state("");
+  let teachCorrectedText: string = $state("");
+  let teachSuggestions: GlossarySuggestion[] = $state([]);
+  let teachSelected: Record<number, boolean> = $state({});
+  let teachError: string = $state("");
+  let teachMessage: string = $state("");
+
+  function explicitTeachProfiles(current: Settings | null = settings): HotkeyProfile[] {
+    return current?.hotkey_profiles.filter((profile) => profile.language !== "auto") ?? [];
+  }
+
+  function chooseTeachProfile(current: Settings, preferred?: string): string {
+    const profiles = explicitTeachProfiles(current);
+    return profiles.find((profile) => profile.id === preferred)?.id
+      ?? profiles.find((profile) => profile.id === "default")?.id
+      ?? profiles[0]?.id
+      ?? "";
+  }
 
   // Transcribe tab state
   let supportedFormats: string[] = $state([]);
@@ -128,6 +158,7 @@
     listen("state-changed", async (event: any) => {
       if (event.payload !== "settings_reloaded") return;
       settings = await getSettings();
+      teachProfileId = chooseTeachProfile(settings, teachProfileId);
       models = await getModelInfo();
       loadedModel = await getLoadedModel();
     });
@@ -135,7 +166,7 @@
     // Listen for tab navigation from tray menu
     listen("navigate_tab", (event: any) => {
       const t = event.payload;
-      if (t === "dictate" || t === "transcribe" || t === "settings") {
+      if (t === "dictate" || t === "transcribe" || t === "teach" || t === "settings") {
         activeTab = t;
       }
     });
@@ -163,6 +194,7 @@
       initError = "";
       try {
         settings = await getSettings();
+        teachProfileId = chooseTeachProfile(settings);
         platform = await getPlatform();
         if (platform === "macos") {
           accessibilityGranted = await checkAccessibilityPermission();
@@ -178,7 +210,7 @@
         // Check URL params for initial tab
         const params = new URLSearchParams(window.location.search);
         const tab = params.get("tab");
-        if (tab === "dictate" || tab === "transcribe" || tab === "settings") {
+        if (tab === "dictate" || tab === "transcribe" || tab === "teach" || tab === "settings") {
           activeTab = tab;
         }
       } catch (e: any) {
@@ -345,6 +377,124 @@
     }
   }
 
+  async function onTeachRecord() {
+    teachError = "";
+    teachMessage = "";
+    if (teachRecording) {
+      teachRecording = false;
+      teachTranscribing = true;
+      try {
+        const transcript = await stopAndTranscribeTraining();
+        setTeachTranscript(transcript.raw_text, transcript.effective_text);
+      } catch (e: any) {
+        teachError = typeof e === "string" ? e : e?.message || "Transcription failed";
+      } finally {
+        teachTranscribing = false;
+      }
+    } else {
+      try {
+        await startTrainingRecording(teachProfileId);
+        teachRecording = true;
+        teachRawText = "";
+        teachEffectiveText = "";
+        teachCorrectedText = "";
+        teachSuggestions = [];
+        teachSelected = {};
+      } catch (e: any) {
+        teachError = typeof e === "string" ? e : e?.message || "Failed to start recording";
+      }
+    }
+  }
+
+  function setTeachTranscript(rawText: string, effectiveText: string) {
+    teachRawText = rawText;
+    teachEffectiveText = effectiveText;
+    teachCorrectedText = effectiveText;
+    teachSuggestions = [];
+    teachSelected = {};
+  }
+
+  async function onTeachPickFile() {
+    const extensions = supportedFormats.length > 0
+      ? supportedFormats
+      : ["wav", "mp3", "m4a", "mp4", "ogg", "flac"];
+    const file = await open({
+      multiple: false,
+      filters: [{ name: "Audio/Video", extensions }],
+    });
+    if (!file) return;
+
+    teachError = "";
+    teachMessage = "";
+    teachTranscribing = true;
+    try {
+      const transcript = await transcribeTrainingFile(file, teachProfileId);
+      setTeachTranscript(transcript.raw_text, transcript.effective_text);
+    } catch (e: any) {
+      teachError = typeof e === "string" ? e : e?.message || "Training import failed";
+    } finally {
+      teachTranscribing = false;
+    }
+  }
+
+  async function findTeachSuggestions() {
+    teachError = "";
+    teachMessage = "";
+    if (!teachEffectiveText.trim() || !teachCorrectedText.trim()) {
+      teachError = "Record and correct a transcript first.";
+      return;
+    }
+    try {
+      teachSuggestions = await suggestTrainingGlossary(
+        teachEffectiveText,
+        teachCorrectedText,
+        teachProfileId,
+      );
+      teachSelected = Object.fromEntries(teachSuggestions.map((_, index) => [index, true]));
+      if (teachSuggestions.length === 0) {
+        teachMessage = "No safe dictionary changes found. Broad or ambiguous edits are ignored.";
+      }
+    } catch (e: any) {
+      teachError = typeof e === "string" ? e : e?.message || "Could not analyze corrections";
+    }
+  }
+
+  function setTeachSuggestionSelected(index: number, selected: boolean) {
+    teachSelected = { ...teachSelected, [index]: selected };
+  }
+
+  function editTeachSuggestionCanonical(index: number, canonical: string) {
+    teachSuggestions = teachSuggestions.map((suggestion, candidateIndex) =>
+      candidateIndex === index ? { ...suggestion, canonical } : suggestion,
+    );
+  }
+
+  function editTeachSuggestionKind(index: number, kind: GlossarySuggestion["kind"]) {
+    teachSuggestions = teachSuggestions.map((suggestion, candidateIndex) =>
+      candidateIndex === index ? { ...suggestion, kind } : suggestion,
+    );
+  }
+
+  async function addTeachSuggestions() {
+    const accepted = teachSuggestions.filter((_, index) => teachSelected[index]);
+    teachError = "";
+    teachMessage = "";
+    try {
+      await applyTrainingGlossary(
+        teachEffectiveText,
+        teachCorrectedText,
+        teachProfileId,
+        accepted,
+      );
+      settings = await getSettings();
+      teachSuggestions = [];
+      teachSelected = {};
+      teachMessage = `Added ${accepted.length} reviewed ${accepted.length === 1 ? "entry" : "entries"} to this profile.`;
+    } catch (e: any) {
+      teachError = typeof e === "string" ? e : e?.message || "Could not save dictionary entries";
+    }
+  }
+
   async function handleFileTranscription(filePath: string) {
     if (transcribing) return;
     transcribing = true;
@@ -485,15 +635,21 @@
     );
     if (profileId === draftProfileId) {
       settings = { ...settings, hotkey_profiles: profiles };
+      teachProfileId = chooseTeachProfile(settings, teachProfileId);
       return;
     }
-    await applySetting(() => setHotkeyProfiles(profiles));
+    if (await applySetting(() => setHotkeyProfiles(profiles)) && settings) {
+      teachProfileId = chooseTeachProfile(settings, teachProfileId);
+    }
   }
 
   function addProfile() {
     if (!settings) return;
     let suffix = settings.hotkey_profiles.length + 1;
-    while (settings.hotkey_profiles.some((profile) => profile.id === `profile-${suffix}`)) suffix += 1;
+    while (
+      settings.hotkey_profiles.some((profile) => profile.id === `profile-${suffix}`)
+      || Object.hasOwn(settings.profile_glossaries, `profile-${suffix}`)
+    ) suffix += 1;
     const profile: HotkeyProfile = {
       id: `profile-${suffix}`,
       name: `Profile ${suffix}`,
@@ -501,6 +657,7 @@
       language: settings.language === "sv" ? "en" : "sv",
     };
     settings = { ...settings, hotkey_profiles: [...settings.hotkey_profiles, profile] };
+    teachProfileId = chooseTeachProfile(settings, teachProfileId);
     draftProfileId = profile.id;
     recordingProfileId = profile.id;
   }
@@ -509,11 +666,18 @@
     if (!settings || settings.hotkey_profiles.length <= 1) return;
     if (profileId === draftProfileId) {
       settings = { ...settings, hotkey_profiles: settings.hotkey_profiles.filter((profile) => profile.id !== profileId) };
+      teachProfileId = chooseTeachProfile(settings, teachProfileId);
       draftProfileId = null;
       recordingProfileId = null;
       return;
     }
-    await applySetting(() => setHotkeyProfiles(settings!.hotkey_profiles.filter((profile) => profile.id !== profileId)));
+    if (
+      await applySetting(() =>
+        setHotkeyProfiles(settings!.hotkey_profiles.filter((profile) => profile.id !== profileId)),
+      ) && settings
+    ) {
+      teachProfileId = chooseTeachProfile(settings, teachProfileId);
+    }
   }
 
   function languageLabel(lang: Language): string {
@@ -547,6 +711,9 @@
     </button>
     <button class="tab" class:active={activeTab === "transcribe"} onclick={() => (activeTab = "transcribe")}>
       Transcribe
+    </button>
+    <button class="tab" class:active={activeTab === "teach"} onclick={() => (activeTab = "teach")}>
+      Teach
     </button>
     <button class="tab" class:active={activeTab === "settings"} onclick={() => (activeTab = "settings")}>
       Language & Model
@@ -749,6 +916,129 @@
         {#if transcriptionResult}
           <div class="result-label">Result</div>
           <textarea class="transcribe-result" readonly>{transcriptionResult}</textarea>
+        {/if}
+
+      {:else if activeTab === "teach"}
+        <div class="teach-intro">
+          <div class="teach-title">Teach Sagascript your vocabulary</div>
+          <div class="hotkey-hint">
+            Speak naturally, correct the transcript, then review the safe local dictionary changes. This never changes model weights or sends audio to a cloud service.
+          </div>
+        </div>
+
+        <div class="field">
+          <label for="teach-profile">Save for profile</label>
+          <select id="teach-profile" bind:value={teachProfileId} disabled={teachRecording || teachTranscribing}>
+            {#if explicitTeachProfiles().length === 0}
+              <option value="">Create a profile with an explicit language first</option>
+            {/if}
+            {#each explicitTeachProfiles() as profile (profile.id)}
+              <option value={profile.id}>{profile.name} · {languageLabel(profile.language)}</option>
+            {/each}
+          </select>
+          <div class="hotkey-hint">Learned entries apply only when this dictation profile is active. Auto-detect profiles are excluded to avoid cross-language aliases.</div>
+        </div>
+
+        <button
+          class="test-record-btn"
+          class:recording={teachRecording}
+          class:transcribing={teachTranscribing}
+          onclick={onTeachRecord}
+          disabled={teachTranscribing || testRecording || !teachProfileId}
+        >
+          {#if teachTranscribing}
+            <div class="spinner small"></div>
+            Transcribing locally...
+          {:else if teachRecording}
+            <div class="recording-dot"></div>
+            Stop training recording
+          {:else}
+            Start training recording
+          {/if}
+        </button>
+        <button
+          class="teach-import-btn"
+          onclick={onTeachPickFile}
+          disabled={teachRecording || teachTranscribing || testRecording || !teachProfileId}
+        >
+          Import audio or video...
+        </button>
+
+        {#if teachError}
+          <div class="transcribe-error">{teachError}</div>
+        {/if}
+        {#if teachMessage}
+          <div class="teach-message">{teachMessage}</div>
+        {/if}
+
+        {#if teachEffectiveText}
+          <details class="teach-raw">
+            <summary>Show raw recognizer transcript</summary>
+            <div>{teachRawText}</div>
+          </details>
+
+          <div class="field teach-editor">
+            <label for="teach-correction">Correct the transcript</label>
+            <textarea
+              id="teach-correction"
+              class="transcribe-result"
+              bind:value={teachCorrectedText}
+              rows="6"
+            ></textarea>
+            <div class="hotkey-hint">Fix only the words you want Sagascript to learn. Punctuation, deletions and broad rewrites are ignored.</div>
+          </div>
+          <button class="primary teach-action" onclick={findTeachSuggestions}>
+            Find likely dictionary entries
+          </button>
+        {/if}
+
+        {#if teachSuggestions.length > 0}
+          <div class="result-label">Review suggestions</div>
+          <div class="hotkey-hint">Edit a preferred spelling here, or switch a replacement to a decoder-only hint. To change what was heard, edit the transcript above and analyze again.</div>
+          <div class="teach-suggestions">
+            {#each teachSuggestions as suggestion, index}
+              <div class="teach-suggestion">
+                <input
+                  type="checkbox"
+                  checked={teachSelected[index] ?? false}
+                  onchange={(event) => setTeachSuggestionSelected(index, (event.target as HTMLInputElement).checked)}
+                  aria-label={`Include ${suggestion.canonical}`}
+                />
+                <div class="teach-suggestion-body">
+                  <input
+                    class="teach-canonical"
+                    value={suggestion.canonical}
+                    oninput={(event) => editTeachSuggestionCanonical(index, (event.target as HTMLInputElement).value)}
+                    aria-label="Preferred spelling"
+                  />
+                  {#if suggestion.kind === "alias"}
+                    <span class="teach-alias"> heard as “{suggestion.observed}”</span>
+                  {:else}
+                    <span class="teach-alias"> decoder hint only</span>
+                  {/if}
+                  {#if suggestion.observed}
+                    <select
+                      class="teach-kind"
+                      value={suggestion.kind}
+                      onchange={(event) => editTeachSuggestionKind(index, (event.target as HTMLSelectElement).value as GlossarySuggestion["kind"])}
+                      aria-label="Dictionary entry type"
+                    >
+                      <option value="alias">Replace exact mishearing</option>
+                      <option value="hint_only">Decoder hint only</option>
+                    </select>
+                  {/if}
+                  <span class="teach-context">{suggestion.context}</span>
+                </div>
+              </div>
+            {/each}
+          </div>
+          <button
+            class="primary teach-action"
+            onclick={addTeachSuggestions}
+            disabled={!teachSuggestions.some((_, index) => teachSelected[index])}
+          >
+            Add selected to personal dictionary
+          </button>
         {/if}
 
       {:else if activeTab === "settings"}
@@ -1424,6 +1714,131 @@
 
   .transcribe-result:focus {
     border-color: var(--accent);
+  }
+
+  /* Teach tab */
+
+  .teach-intro {
+    margin-bottom: 18px;
+  }
+
+  .teach-title {
+    margin-bottom: 6px;
+    color: var(--text);
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  .teach-message {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .teach-raw {
+    margin-top: 14px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .teach-raw div {
+    margin-top: 6px;
+    padding: 8px 10px;
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+    white-space: pre-wrap;
+  }
+
+  .teach-editor {
+    margin-top: 14px;
+  }
+
+  .teach-editor .transcribe-result {
+    box-sizing: border-box;
+    max-height: 240px;
+  }
+
+  .teach-action {
+    width: 100%;
+    margin-top: 10px;
+  }
+
+  .teach-import-btn {
+    width: 100%;
+    margin-top: 8px;
+    padding: 9px 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--text-muted);
+  }
+
+  .teach-suggestions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .teach-suggestion {
+    display: flex;
+    align-items: flex-start;
+    gap: 9px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+    color: var(--text);
+    font-size: 13px;
+  }
+
+  .teach-suggestion input {
+    margin-top: 2px;
+    accent-color: var(--accent);
+  }
+
+  .teach-suggestion-body {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .teach-canonical,
+  .teach-kind {
+    box-sizing: border-box;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--bg);
+    color: var(--text);
+    font: inherit;
+  }
+
+  .teach-canonical {
+    width: 100%;
+    margin-bottom: 5px;
+    padding: 5px 7px;
+    font-weight: 600;
+  }
+
+  .teach-kind {
+    display: block;
+    width: 100%;
+    margin-top: 7px;
+    padding: 5px 7px;
+    font-size: 12px;
+  }
+
+  .teach-alias {
+    color: var(--text-muted);
+  }
+
+  .teach-context {
+    display: block;
+    margin-top: 3px;
+    color: var(--text-muted);
+    font-size: 11px;
   }
 
   /* Test dictation section */

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -23,6 +23,7 @@
     requestAccessibilityPermission,
     startRecording,
     startTrainingRecording,
+    cancelRecording,
     stopAndTranscribe,
     stopAndTranscribeTraining,
     transcribeTrainingFile,
@@ -403,6 +404,18 @@
       } catch (e: any) {
         teachError = typeof e === "string" ? e : e?.message || "Failed to start recording";
       }
+    }
+  }
+
+  async function onTeachCancel() {
+    teachError = "";
+    teachMessage = "";
+    try {
+      await cancelRecording();
+      teachRecording = false;
+      teachMessage = "Training recording cancelled.";
+    } catch (e: any) {
+      teachError = typeof e === "string" ? e : e?.message || "Failed to cancel recording";
     }
   }
 
@@ -956,6 +969,11 @@
             Start training recording
           {/if}
         </button>
+        {#if teachRecording}
+          <button class="teach-import-btn" onclick={onTeachCancel}>
+            Cancel training recording
+          </button>
+        {/if}
         <button
           class="teach-import-btn"
           onclick={onTeachPickFile}

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -983,11 +983,16 @@
               id="teach-correction"
               class="transcribe-result"
               bind:value={teachCorrectedText}
+              disabled={teachRecording || teachTranscribing}
               rows="6"
             ></textarea>
             <div class="hotkey-hint">Fix only the words you want Sagascript to learn. Punctuation, deletions and broad rewrites are ignored.</div>
           </div>
-          <button class="primary teach-action" onclick={findTeachSuggestions}>
+          <button
+            class="primary teach-action"
+            onclick={findTeachSuggestions}
+            disabled={teachRecording || teachTranscribing}
+          >
             Find likely dictionary entries
           </button>
         {/if}
@@ -1003,6 +1008,7 @@
                   checked={teachSelected[index] ?? false}
                   onchange={(event) => setTeachSuggestionSelected(index, (event.target as HTMLInputElement).checked)}
                   aria-label={`Include ${suggestion.canonical}`}
+                  disabled={teachRecording || teachTranscribing}
                 />
                 <div class="teach-suggestion-body">
                   <input
@@ -1010,6 +1016,7 @@
                     value={suggestion.canonical}
                     oninput={(event) => editTeachSuggestionCanonical(index, (event.target as HTMLInputElement).value)}
                     aria-label="Preferred spelling"
+                    disabled={teachRecording || teachTranscribing}
                   />
                   {#if suggestion.kind === "alias"}
                     <span class="teach-alias"> heard as “{suggestion.observed}”</span>
@@ -1022,6 +1029,7 @@
                       value={suggestion.kind}
                       onchange={(event) => editTeachSuggestionKind(index, (event.target as HTMLSelectElement).value as GlossarySuggestion["kind"])}
                       aria-label="Dictionary entry type"
+                      disabled={teachRecording || teachTranscribing}
                     >
                       <option value="alias">Replace exact mishearing</option>
                       <option value="hint_only">Decoder hint only</option>
@@ -1035,7 +1043,7 @@
           <button
             class="primary teach-action"
             onclick={addTeachSuggestions}
-            disabled={!teachSuggestions.some((_, index) => teachSelected[index])}
+            disabled={teachRecording || teachTranscribing || !teachSuggestions.some((_, index) => teachSelected[index])}
           >
             Add selected to personal dictionary
           </button>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -29,6 +29,7 @@ export interface Settings {
   hotkey: string;
   hotkey_profiles: HotkeyProfile[];
   initial_prompt: string;
+  profile_glossaries: Record<string, string>;
   beam_size: number;
   temperature_fallback: boolean;
   vad_enabled: boolean;
@@ -56,6 +57,18 @@ export interface HotkeyStatus {
   error: string | null;
   shortcut: string;
   shortcuts: string[];
+}
+
+export interface TrainingTranscript {
+  raw_text: string;
+  effective_text: string;
+}
+
+export interface GlossarySuggestion {
+  observed: string;
+  canonical: string;
+  kind: "alias" | "hint_only";
+  context: string;
 }
 
 export async function getState(): Promise<AppState> {
@@ -167,8 +180,40 @@ export async function startRecording(): Promise<void> {
   return invoke("start_recording");
 }
 
+export async function startTrainingRecording(profileId: string): Promise<void> {
+  return invoke("start_training_recording", { profileId });
+}
+
 export async function stopAndTranscribe(): Promise<string> {
   return invoke("stop_and_transcribe");
+}
+
+export async function stopAndTranscribeTraining(): Promise<TrainingTranscript> {
+  return invoke("stop_and_transcribe_training");
+}
+
+export async function transcribeTrainingFile(
+  filePath: string,
+  profileId: string
+): Promise<TrainingTranscript> {
+  return invoke("transcribe_training_file", { filePath, profileId });
+}
+
+export async function suggestTrainingGlossary(
+  heard: string,
+  corrected: string,
+  profileId: string
+): Promise<GlossarySuggestion[]> {
+  return invoke("suggest_training_glossary", { heard, corrected, profileId });
+}
+
+export async function applyTrainingGlossary(
+  heard: string,
+  corrected: string,
+  profileId: string,
+  accepted: GlossarySuggestion[]
+): Promise<void> {
+  return invoke("apply_training_glossary", { heard, corrected, profileId, accepted });
 }
 
 // -- Permission / platform queries (for onboarding) --

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -184,6 +184,10 @@ export async function startTrainingRecording(profileId: string): Promise<void> {
   return invoke("start_training_recording", { profileId });
 }
 
+export async function cancelRecording(): Promise<void> {
+  return invoke("cancel_recording");
+}
+
 export async function stopAndTranscribe(): Promise<string> {
   return invoke("stop_and_transcribe");
 }


### PR DESCRIPTION
## Summary

- add a local Teach Sagascript flow for recording or importing representative dictation
- derive conservative, reviewable glossary candidates from corrected transcripts
- expose the same dry-run and explicit-apply workflow through the CLI
- keep learned entries profile-scoped, atomic, local-only, and fail-closed

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npx svelte-check --tsconfig ./tsconfig.json`
- `npm run build`
- `npm run test:frontend`

Validation was rerun on the stacked #153 tip, which contains this branch unchanged.

Closes #151
