### PR TITLE
Externalize configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ sagascript download-model ggml-base.en
 sagascript config list
 sagascript config set language sv
 sagascript config get hotkey
+sagascript config path
+
+# Manage the external personal dictionary
+sagascript glossary path
+sagascript glossary add OpenRouter --alias 'open router'
 
 # Use one shortcut for English and another for Swedish
 sagascript config profiles create swedish --name Swedish --hotkey 'Option+Space' --language sv
@@ -140,6 +145,7 @@ for recording audio. Do not install an unsigned binary from an untrusted party.
 - [Installation guide](docs/installation.md) -- detailed install instructions for macOS and Windows
 - [Linux notes](docs/linux-notes.md) -- experimental Linux build, prerequisites, and known limitations
 - [Windows-specific notes](docs/windows-notes.md) -- feature comparison, known limitations, and troubleshooting
+- [Configuration files](docs/configuration.md) -- XDG paths, dotfiles, migration, and personal dictionaries
 - [Third-party notices](THIRD_PARTY_NOTICES.md) -- dependency and downloadable-model licenses
 - [Model sources and integrity manifest](docs/model-sources.md) -- pinned revisions, licenses, sizes, and SHA-256 checksums
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,56 @@
+# Configuration files
+
+Sagascript keeps its user-managed configuration in the XDG configuration
+directory on every Unix desktop, including macOS:
+
+```text
+${XDG_CONFIG_HOME:-$HOME/.config}/sagascript/
+├── sagascript-settings.json
+├── glossary.txt
+└── glossaries/
+    ├── default.txt
+    └── swedish.txt
+```
+
+`XDG_CONFIG_HOME` must be an absolute path. An unset, empty, or relative value
+falls back to `$HOME/.config`, as required by the XDG Base Directory
+Specification. Windows keeps the same file layout below its normal per-user
+configuration base when no XDG path is supplied.
+
+On macOS, `XDG_CONFIG_HOME` must be present in the app process environment.
+Finder, Dock, Spotlight, and login-item launches do not normally inherit values
+set only in shell startup files. Use the standard `$HOME/.config` location, or
+configure the variable for GUI processes as well, to keep GUI and CLI paths
+identical.
+
+The JSON file contains application settings and dictation profiles. The plain
+text glossary files contain one dictionary entry per line. `glossary.txt` is
+global; `glossaries/<profile-id>.txt` is combined only with that profile.
+
+Use the CLI to discover the effective paths rather than duplicating the
+resolution rules in scripts:
+
+```console
+sagascript config path
+sagascript glossary path
+sagascript glossary path --profile swedish
+```
+
+The GUI and CLI watch and update the same files. Atomic writes preserve
+user-managed symlinks, so the files can be checked into a dotfiles repository.
+
+## Overrides and migration
+
+`SAGASCRIPT_SETTINGS_PATH=/absolute/path/to/settings.json` selects one exact
+settings file for an isolated CLI session or test. A relative value is resolved
+from the process working directory and still disables normal-settings migration.
+Its sibling `glossary.txt` and `glossaries/` directory are used for that session.
+While this override is active, Sagascript does not inspect or migrate normal user
+settings.
+
+On the first launch after upgrading, Sagascript copies the existing macOS
+settings from `~/Library/Application Support/ai.gille.sagascript/` into the XDG
+directory. The old file remains available for rollback. Any embedded global or
+profile dictionaries are written to their new text files and removed from the
+JSON copy. Existing Accessibility authorization remains valid because the app's
+signed bundle identity does not change.

--- a/docs/personal-glossary.md
+++ b/docs/personal-glossary.md
@@ -1,13 +1,15 @@
 # Personal glossary architecture
 
-Sagascript keeps the persisted `initial_prompt` string as the backward-compatible
-source of truth for vocabulary guidance. Existing comma- or newline-separated
-terms continue to be passed to Whisper unchanged.
+Sagascript keeps the legacy `initial_prompt` setting as a backward-compatible
+in-memory interface for vocabulary guidance. Its persisted source is the
+human-editable `glossary.txt` file in the XDG configuration directory. Existing
+embedded comma- or newline-separated terms are migrated and continue to be
+passed to Whisper unchanged.
 
-New entries learned through **Teach Sagascript** are stored separately per
-dictation profile. At transcription time, the legacy global dictionary is
-combined with only the active profile's entries. Conflicting aliases still
-fail closed. This prevents a correction learned for one language/profile from
+New entries learned through **Teach Sagascript** are stored in
+`glossaries/<profile-id>.txt`. At transcription time, the global dictionary is
+combined with only the active profile's entries. Conflicting aliases still fail
+closed. This prevents a correction learned for one language/profile from
 silently rewriting another profile's output.
 
 Removing a profile makes its scoped entries inactive but does not silently
@@ -48,6 +50,7 @@ additional confidence-gated one-edit correction for plain single-word hints.
   compares the effective transcript with the user's correction, and applies
   only explicitly reviewed candidates to the selected profile.
 - **Transcribe → Extra context for this file** remains a one-run override.
+- `sagascript glossary path [--profile ID]` prints the exact external file.
 - `sagascript glossary list|add|remove|clear [--profile ID]` manages either the
   legacy global dictionary or one profile.
 - `sagascript glossary suggest training.wav --corrected corrected.txt --profile ID`
@@ -56,10 +59,13 @@ additional confidence-gated one-edit correction for plain single-word hints.
   atomically save the displayed candidates, or `--json` for machine-readable
   output. The selected profile must have an explicit language and its model
   must already be downloaded.
+- See [Configuration files](configuration.md) for the XDG layout, dotfiles,
+  migration, and path precedence.
 - Set `SAGASCRIPT_SETTINGS_PATH=/absolute/path/to/settings.json` to run an
-  isolated CLI session against that exact settings file. While the override is
-  active, Sagascript does not inspect or migrate legacy settings. This is
-  useful for automation, end-to-end tests, and disposable training profiles.
+  isolated CLI session against that exact settings file. Relative values resolve
+  from the process working directory. While the override is active, Sagascript
+  does not inspect or migrate legacy settings. This is useful for automation,
+  end-to-end tests, and disposable training profiles.
 - `sagascript config set initial_prompt ...` remains supported for scripts.
 
 The CLI exposes the complete review workflow without requiring an interactive

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -79,10 +79,12 @@ EXAMPLES:
     /// Reset one or all settings to defaults
     #[command(
         long_about = "\
-Reset a single setting or all settings to their default values.
+Reset a single application setting or all application settings to their default values.
 
 If KEY is provided, only that setting is reset. \
-If KEY is omitted, ALL settings are reset.",
+If KEY is omitted, all application settings are reset. External personal \
+dictionaries are preserved. Clear the global dictionary with `sagascript glossary \
+clear --yes`; repeat with `--profile ID` for each profile dictionary.",
         after_long_help = "\
 EXAMPLES:
   # Reset just the language
@@ -98,8 +100,8 @@ EXAMPLES:
 
     /// Print the settings file path
     #[command(long_about = "\
-Print the absolute path to the settings JSON file. Useful for manual \
-editing or backup.")]
+Print the absolute path to the settings JSON file. Use `sagascript glossary \
+path` for the separate personal dictionary.")]
     Path,
 
     /// Manage per-shortcut dictation language profiles
@@ -411,9 +413,17 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
         .map_err(DictationError::SettingsError)?;
         eprintln!("Reset {key} to {}", get_setting_value(&settings, key));
     } else {
-        let defaults = Settings::default();
-        settings::store::save(&defaults).map_err(DictationError::SettingsError)?;
-        eprintln!("All settings reset to defaults");
+        settings::store::update(|current| {
+            let initial_prompt = std::mem::take(&mut current.initial_prompt);
+            let profile_glossaries = std::mem::take(&mut current.profile_glossaries);
+            *current = Settings {
+                initial_prompt,
+                profile_glossaries,
+                ..Default::default()
+            };
+        })
+        .map_err(DictationError::SettingsError)?;
+        eprintln!("All application settings reset to defaults; personal dictionaries preserved");
     }
     Ok(())
 }

--- a/src-tauri/crates/sagascript-cli/src/glossary.rs
+++ b/src-tauri/crates/sagascript-cli/src/glossary.rs
@@ -22,6 +22,12 @@ pub struct GlossaryArgs {
 
 #[derive(Subcommand)]
 pub enum GlossaryAction {
+    /// Print the external personal-dictionary file path
+    Path {
+        /// Print this profile's dictionary path instead of the global path
+        #[arg(long)]
+        profile: Option<String>,
+    },
     /// List canonical terms and their explicit aliases
     List {
         /// Show entries saved only for this dictation profile
@@ -46,9 +52,9 @@ pub enum GlossaryAction {
         #[arg(long)]
         profile: Option<String>,
     },
-    /// Remove every personal dictionary entry
+    /// Remove every entry from the selected personal dictionary
     Clear {
-        /// Confirm destructive removal of the complete dictionary
+        /// Confirm destructive removal of the selected dictionary
         #[arg(long)]
         yes: bool,
         /// Clear this profile instead of the legacy global dictionary
@@ -76,6 +82,7 @@ pub enum GlossaryAction {
 
 pub fn run(args: GlossaryArgs) -> Result<(), DictationError> {
     match args.action {
+        GlossaryAction::Path { profile } => path(profile.as_deref()),
         GlossaryAction::List { profile } => list(profile.as_deref()),
         GlossaryAction::Add { term, aliases, profile } => {
             add(&term, &aliases, profile.as_deref())
@@ -86,6 +93,20 @@ pub fn run(args: GlossaryArgs) -> Result<(), DictationError> {
             suggest(&heard, &corrected, &profile, json, apply)
         }
     }
+}
+
+fn path(profile: Option<&str>) -> Result<(), DictationError> {
+    let path = match profile {
+        Some(profile) => {
+            let stored = settings::store::load();
+            validate_profile(&stored, profile)?;
+            settings::store::profile_glossary_path(profile)
+                .map_err(DictationError::SettingsError)?
+        }
+        None => settings::store::global_glossary_path(),
+    };
+    println!("{}", path.display());
+    Ok(())
 }
 
 fn list(profile: Option<&str>) -> Result<(), DictationError> {

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -364,7 +364,7 @@ EXAMPLES:
     /// Manage the persistent personal dictionary used by live and batch transcription
     #[command(
         long_about = "Add preferred spellings and optional exact mishearings. Plain terms prime Whisper; aliases also authorize deterministic local corrections before output.",
-        after_long_help = "EXAMPLES:\n  sagascript glossary list\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter'\n  sagascript glossary add merge --alias merch --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish --apply\n  sagascript glossary remove OpenRouter\n  sagascript glossary clear --yes"
+        after_long_help = "EXAMPLES:\n  sagascript glossary path\n  sagascript glossary path --profile swedish\n  sagascript glossary list\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter'\n  sagascript glossary add merge --alias merch --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish --apply\n  sagascript glossary remove OpenRouter\n  sagascript glossary clear --yes"
     )]
     Glossary(glossary::GlossaryArgs),
 
@@ -985,6 +985,27 @@ mod tests {
                     assert!(profile.is_none());
                 }
                 _ => panic!("expected glossary add"),
+            },
+            _ => panic!("expected Glossary"),
+        }
+    }
+
+    #[test]
+    fn parse_profile_glossary_path() {
+        let cli = Cli::try_parse_from([
+            "sagascript",
+            "glossary",
+            "path",
+            "--profile",
+            "swedish",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Command::Glossary(args) => match args.action {
+                glossary::GlossaryAction::Path { profile } => {
+                    assert_eq!(profile.as_deref(), Some("swedish"));
+                }
+                _ => panic!("expected glossary path"),
             },
             _ => panic!("expected Glossary"),
         }

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -684,25 +684,28 @@ mod tests {
     }
 
     #[test]
-    fn default_settings_path_uses_the_xdg_config_directory() {
-        let data_dir = PathBuf::from("/Users/example/Library/Application Support");
-        let home_dir = PathBuf::from("/Users/example");
+    fn default_settings_path_uses_the_platform_config_directory() {
+        let root = std::env::temp_dir().join("sagascript-location-test");
+        let data_dir = root.join("application-support");
+        let home_dir = root.join("home");
+        let expected_base = default_config_base(&home_dir, &data_dir);
         let (p, legacy) = settings_location(None, None, home_dir, data_dir.clone());
         assert_eq!(
             p,
-            PathBuf::from("/Users/example/.config/sagascript").join(SETTINGS_FILENAME)
+            expected_base.join(CONFIG_DIR_NAME).join(SETTINGS_FILENAME)
         );
         assert!(legacy.contains(&data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME)));
     }
 
     #[test]
     fn explicit_settings_path_disables_legacy_migration_sources() {
-        let isolated = PathBuf::from("/tmp/sagascript-cli-test/settings.json");
+        let root = std::env::temp_dir().join("sagascript-location-test");
+        let isolated = root.join("isolated").join("settings.json");
         let (path, legacy) = settings_location(
             Some(isolated.clone().into_os_string()),
             None,
-            PathBuf::from("/Users/example"),
-            PathBuf::from("/real/application-support"),
+            root.join("home"),
+            root.join("application-support"),
         );
 
         assert_eq!(path, isolated);
@@ -711,8 +714,10 @@ mod tests {
 
     #[test]
     fn empty_settings_path_override_uses_the_normal_location() {
-        let data_dir = PathBuf::from("/example/application-support");
-        let home_dir = PathBuf::from("/home/example");
+        let root = std::env::temp_dir().join("sagascript-location-test");
+        let data_dir = root.join("application-support");
+        let home_dir = root.join("home");
+        let expected_base = default_config_base(&home_dir, &data_dir);
         let (path, legacy) = settings_location(
             Some(OsString::new()),
             None,
@@ -722,25 +727,24 @@ mod tests {
 
         assert_eq!(
             path,
-            home_dir
-                .join(".config")
-                .join(CONFIG_DIR_NAME)
-                .join(SETTINGS_FILENAME)
+            expected_base.join(CONFIG_DIR_NAME).join(SETTINGS_FILENAME)
         );
         assert_eq!(legacy.len(), LEGACY_APP_IDENTIFIERS.len() + 2);
     }
 
     #[test]
     fn absolute_xdg_config_home_overrides_the_default() {
+        let root = std::env::temp_dir().join("sagascript-location-test");
+        let xdg_config_home = root.join("dotfiles-config");
         let (path, _) = settings_location(
             None,
-            Some(OsString::from("/dotfiles/config")),
-            PathBuf::from("/home/example"),
-            PathBuf::from("/example/application-support"),
+            Some(xdg_config_home.clone().into_os_string()),
+            root.join("home"),
+            root.join("application-support"),
         );
         assert_eq!(
             path,
-            PathBuf::from("/dotfiles/config")
+            xdg_config_home
                 .join(CONFIG_DIR_NAME)
                 .join(SETTINGS_FILENAME)
         );

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -10,7 +10,11 @@ use crate::settings::Settings;
 
 const APP_IDENTIFIER: &str = "ai.gille.sagascript";
 const LEGACY_APP_IDENTIFIERS: &[&str] = &["com.sagascript.app"];
+const CONFIG_DIR_NAME: &str = "sagascript";
 const SETTINGS_FILENAME: &str = "sagascript-settings.json";
+const GLOBAL_GLOSSARY_FILENAME: &str = "glossary.txt";
+const PROFILE_GLOSSARY_DIRNAME: &str = "glossaries";
+const XDG_CONFIG_HOME_ENV: &str = "XDG_CONFIG_HOME";
 /// Optional exact settings-file location for isolated CLI sessions and tests.
 ///
 /// When set, legacy settings migration is disabled so an isolated session can
@@ -39,6 +43,30 @@ pub fn settings_path() -> PathBuf {
     configured_settings_location().0
 }
 
+/// Returns the directory containing the user-managed configuration files.
+pub fn config_dir() -> PathBuf {
+    settings_path()
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Returns the global personal-dictionary file.
+pub fn global_glossary_path() -> PathBuf {
+    config_dir().join(GLOBAL_GLOSSARY_FILENAME)
+}
+
+/// Returns the personal-dictionary file for a profile.
+pub fn profile_glossary_path(profile_id: &str) -> Result<PathBuf, String> {
+    validate_profile_file_id(profile_id)?;
+    Ok(profile_glossary_dir().join(format!("{profile_id}.txt")))
+}
+
+/// Returns the directory containing profile-scoped personal dictionaries.
+pub fn profile_glossary_dir() -> PathBuf {
+    config_dir().join(PROFILE_GLOSSARY_DIRNAME)
+}
+
 /// Returns whether this process is using an explicit settings file.
 pub fn settings_path_is_overridden() -> bool {
     settings_override_path(std::env::var_os(SETTINGS_PATH_ENV)).is_some()
@@ -51,30 +79,67 @@ fn legacy_settings_paths() -> impl Iterator<Item = PathBuf> {
 fn configured_settings_location() -> (PathBuf, Vec<PathBuf>) {
     settings_location(
         std::env::var_os(SETTINGS_PATH_ENV),
+        std::env::var_os(XDG_CONFIG_HOME_ENV),
+        dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
         dirs::data_dir().unwrap_or_else(|| PathBuf::from(".")),
     )
 }
 
 fn settings_location(
     override_path: Option<OsString>,
+    xdg_config_home: Option<OsString>,
+    home_dir: PathBuf,
     data_dir: PathBuf,
 ) -> (PathBuf, Vec<PathBuf>) {
     if let Some(override_path) = settings_override_path(override_path) {
         return (override_path, Vec::new());
     }
 
-    let settings_path = data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME);
-    let legacy_paths = LEGACY_APP_IDENTIFIERS
-        .iter()
-        .map(|identifier| data_dir.join(identifier).join(SETTINGS_FILENAME))
-        .collect();
+    let config_base = absolute_nonempty_path(xdg_config_home)
+        .unwrap_or_else(|| default_config_base(&home_dir, &data_dir));
+    let settings_path = config_base.join(CONFIG_DIR_NAME).join(SETTINGS_FILENAME);
+    let mut legacy_paths = vec![data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME)];
+    legacy_paths.extend(
+        LEGACY_APP_IDENTIFIERS
+            .iter()
+            .map(|identifier| data_dir.join(identifier).join(SETTINGS_FILENAME)),
+    );
+    legacy_paths.push(
+        data_dir
+            .join(APP_IDENTIFIER)
+            .join("flowdictate-settings.json"),
+    );
     (settings_path, legacy_paths)
 }
 
 fn settings_override_path(value: Option<OsString>) -> Option<PathBuf> {
+    let path = value.filter(|value| !value.is_empty()).map(PathBuf::from)?;
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(path),
+        )
+    }
+}
+
+fn absolute_nonempty_path(value: Option<OsString>) -> Option<PathBuf> {
     value
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+}
+
+#[cfg(not(windows))]
+fn default_config_base(home_dir: &Path, _data_dir: &Path) -> PathBuf {
+    home_dir.join(".config")
+}
+
+#[cfg(windows)]
+fn default_config_base(_home_dir: &Path, data_dir: &Path) -> PathBuf {
+    data_dir.to_path_buf()
 }
 
 /// Caller must hold the destination's settings lock.
@@ -85,7 +150,7 @@ fn copy_legacy_settings(source: &Path, destination: &Path) -> Result<bool, Strin
     let parent = destination
         .parent()
         .ok_or_else(|| "Settings destination has no parent directory".to_string())?;
-    std::fs::create_dir_all(parent)
+    create_private_dir_all(parent)
         .map_err(|error| format!("Failed to create settings directory: {error}"))?;
     let contents = std::fs::read_to_string(source)
         .map_err(|error| format!("Failed to read legacy settings: {error}"))?;
@@ -96,17 +161,21 @@ fn copy_legacy_settings(source: &Path, destination: &Path) -> Result<bool, Strin
         .ok_or_else(|| "Legacy settings root is not an object".to_string())?;
     canonicalize_legacy_keys(object);
 
-    // Accessibility approval is tied to the signed bundle identity, not to
-    // user preferences. The new identity must be approved explicitly before
-    // auto-paste can be re-enabled.
-    object.insert("auto_paste".to_string(), serde_json::Value::Bool(false));
+    // Moving the current bundle's settings into the XDG directory preserves
+    // its TCC identity. Older bundle identifiers and FlowDictate do not.
+    let same_bundle_settings = source.file_name().and_then(|name| name.to_str())
+        == Some(SETTINGS_FILENAME)
+        && source
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            == Some(APP_IDENTIFIER);
+    if !same_bundle_settings {
+        object.insert("auto_paste".to_string(), serde_json::Value::Bool(false));
+    }
     let migrated = serde_json::to_string_pretty(&value)
         .map_err(|error| format!("Failed to serialize migrated settings: {error}"))?;
-    let tmp_path = destination.with_extension("json.tmp");
-    std::fs::write(&tmp_path, migrated)
-        .map_err(|error| format!("Failed to write migrated settings: {error}"))?;
-    std::fs::rename(&tmp_path, destination)
-        .map_err(|error| format!("Failed to install migrated settings: {error}"))?;
+    atomic_write(destination, migrated.as_bytes(), "migrated settings")?;
     Ok(true)
 }
 
@@ -145,15 +214,31 @@ fn migrate_legacy_identifier_settings_locked(
 /// Partial JSON files are handled by `#[serde(default)]` on Settings.
 pub fn load() -> Settings {
     let path = settings_path();
-    // Existing settings are installed with atomic rename, so a read needs no
-    // lock. Only the first-run missing-file path can migrate and must share the
-    // writers' lock for its existence recheck, write, and initial read.
-    if path.exists() {
-        return load_from(&path);
+    load_at_with_legacy_sources(&path, legacy_settings_paths())
+}
+
+fn load_at_with_legacy_sources(
+    path: &Path,
+    legacy_sources: impl IntoIterator<Item = PathBuf>,
+) -> Settings {
+    // Existing settings are installed with atomic rename, so an ordinary read
+    // needs no lock. Embedded dictionaries from older releases are the one
+    // exception: migrate those under the writer lock before returning.
+    if path.exists() && !has_embedded_glossary_fields(path) {
+        return load_from(path);
     }
-    with_settings_lock(&path, || {
-        migrate_legacy_identifier_settings_locked(&path, legacy_settings_paths());
-        Ok(load_from(&path))
+    with_settings_lock(path, || {
+        migrate_legacy_identifier_settings_locked(path, legacy_sources);
+        let settings = load_from(path);
+        if has_embedded_glossary_fields(path) {
+            if let Err(error) = save_to(path, &settings) {
+                tracing::warn!(
+                    "Failed to externalize personal dictionaries from {}: {error}",
+                    path.display()
+                );
+            }
+        }
+        Ok(settings)
     })
     .unwrap_or_else(|error| {
         tracing::warn!(
@@ -166,30 +251,40 @@ pub fn load() -> Settings {
 
 /// Load settings from a specific path. Returns defaults if missing or unreadable.
 pub fn load_from(path: &Path) -> Settings {
-    match std::fs::read_to_string(path) {
-        Ok(contents) => match serde_json::from_str::<serde_json::Value>(&contents).and_then(
-            |mut value| {
+    let mut settings = match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            match serde_json::from_str::<serde_json::Value>(&contents).and_then(|mut value| {
                 if let Some(map) = value.as_object_mut() {
                     canonicalize_legacy_keys(map);
                 }
                 serde_json::from_value(value)
-            },
-        ) {
-            Ok(settings) => settings,
-            Err(e) => {
-                // One wrong-typed field would otherwise silently reset ALL
-                // user settings to defaults with no diagnostic trail. We
-                // still fall back to defaults (self-healing contract), but
-                // now there's a log line to explain why.
-                tracing::warn!(
-                    "Failed to parse settings file at {}: {e} — falling back to defaults",
-                    path.display()
-                );
-                Settings::default()
+            }) {
+                Ok(settings) => settings,
+                Err(e) => {
+                    // One wrong-typed field would otherwise silently reset ALL
+                    // user settings to defaults with no diagnostic trail. We
+                    // still fall back to defaults (self-healing contract), but
+                    // now there's a log line to explain why.
+                    tracing::warn!(
+                        "Failed to parse settings file at {}: {e} — falling back to defaults",
+                        path.display()
+                    );
+                    Settings::default()
+                }
             }
-        },
+        }
         Err(_) => Settings::default(),
-    }
+    };
+    settings.profile_glossaries.retain(|profile_id, _| {
+        if let Err(error) = validate_profile_file_id(profile_id) {
+            tracing::warn!("Ignoring embedded {error}");
+            false
+        } else {
+            true
+        }
+    });
+    load_external_glossaries(path, &mut settings);
+    settings
 }
 
 /// Persist settings to disk using read-merge-write to preserve unknown or
@@ -284,7 +379,7 @@ where
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
-    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {e}"))?;
+    create_private_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {e}"))?;
 
     let lock_path = path.with_extension("json.lock");
     let lock_file = OpenOptions::new()
@@ -317,7 +412,7 @@ fn save_to(path: &Path, settings: &Settings) -> Result<(), String> {
         .unwrap_or_else(|| PathBuf::from("."));
 
     // Ensure directory exists
-    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {e}"))?;
+    create_private_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {e}"))?;
 
     // Read existing file to preserve non-settings keys
     let mut map: serde_json::Map<String, serde_json::Value> = if let Ok(contents) =
@@ -351,10 +446,19 @@ fn save_to(path: &Path, settings: &Settings) -> Result<(), String> {
     };
     canonicalize_legacy_keys(&mut map);
 
+    save_external_glossaries(path, settings)?;
+
+    // The personal dictionaries have human-editable files of their own.
+    // Remove the legacy embedded fields after their external writes succeed.
+    map.remove("initial_prompt");
+    map.remove("profile_glossaries");
+
     // Merge settings fields into the map
     let settings_value =
         serde_json::to_value(settings).map_err(|e| format!("Serialize error: {e}"))?;
-    if let serde_json::Value::Object(settings_map) = settings_value {
+    if let serde_json::Value::Object(mut settings_map) = settings_value {
+        settings_map.remove("initial_prompt");
+        settings_map.remove("profile_glossaries");
         for (k, v) in settings_map {
             map.insert(k, v);
         }
@@ -362,12 +466,204 @@ fn save_to(path: &Path, settings: &Settings) -> Result<(), String> {
 
     let json = serde_json::to_string_pretty(&map).map_err(|e| format!("Serialize error: {e}"))?;
 
-    // Atomic write: .tmp + rename
-    let tmp_path = path.with_extension("json.tmp");
-    std::fs::write(&tmp_path, &json).map_err(|e| format!("Failed to write settings: {e}"))?;
-    std::fs::rename(&tmp_path, path).map_err(|e| format!("Failed to rename settings file: {e}"))?;
+    atomic_write(path, json.as_bytes(), "settings")?;
 
     Ok(())
+}
+
+fn has_embedded_glossary_fields(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .and_then(|value| value.as_object().cloned())
+        .is_some_and(|map| {
+            map.contains_key("initial_prompt") || map.contains_key("profile_glossaries")
+        })
+}
+
+fn config_dir_for_settings(path: &Path) -> PathBuf {
+    path.parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn global_glossary_path_for_settings(path: &Path) -> PathBuf {
+    config_dir_for_settings(path).join(GLOBAL_GLOSSARY_FILENAME)
+}
+
+fn profile_glossary_dir_for_settings(path: &Path) -> PathBuf {
+    config_dir_for_settings(path).join(PROFILE_GLOSSARY_DIRNAME)
+}
+
+fn validate_profile_file_id(profile_id: &str) -> Result<(), String> {
+    if profile_id.is_empty()
+        || profile_id.len() > 32
+        || !profile_id.starts_with(|character: char| character.is_ascii_alphanumeric())
+        || !profile_id.chars().all(|character| {
+            character.is_ascii_lowercase()
+                || character.is_ascii_digit()
+                || matches!(character, '-' | '_')
+        })
+    {
+        return Err(format!(
+            "Invalid profile id '{profile_id}' for personal dictionary file"
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_glossary_file(contents: String) -> String {
+    contents.trim_end_matches(['\r', '\n']).to_string()
+}
+
+fn glossary_file_contents(source: &str) -> String {
+    let source = source.trim_end_matches(['\r', '\n']);
+    if source.is_empty() {
+        String::new()
+    } else {
+        format!("{source}\n")
+    }
+}
+
+fn load_external_glossaries(path: &Path, settings: &mut Settings) {
+    let global_path = global_glossary_path_for_settings(path);
+    match std::fs::read_to_string(&global_path) {
+        Ok(contents) => settings.initial_prompt = normalize_glossary_file(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => tracing::warn!(
+            "Failed to read global personal dictionary at {}: {error}",
+            global_path.display()
+        ),
+    }
+
+    let profile_dir = profile_glossary_dir_for_settings(path);
+    let entries = match std::fs::read_dir(&profile_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            tracing::warn!(
+                "Failed to read profile dictionary directory at {}: {error}",
+                profile_dir.display()
+            );
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        if entry_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            != Some("txt")
+        {
+            continue;
+        }
+        let Some(profile_id) = entry_path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        if let Err(error) = validate_profile_file_id(profile_id) {
+            tracing::warn!("Ignoring {error} ({})", entry_path.display());
+            continue;
+        }
+        match std::fs::read_to_string(&entry_path) {
+            Ok(contents) => {
+                settings
+                    .profile_glossaries
+                    .insert(profile_id.to_string(), normalize_glossary_file(contents));
+            }
+            Err(error) => tracing::warn!(
+                "Failed to read profile personal dictionary at {}: {error}",
+                entry_path.display()
+            ),
+        }
+    }
+}
+
+fn save_external_glossaries(path: &Path, settings: &Settings) -> Result<(), String> {
+    for profile_id in settings.profile_glossaries.keys() {
+        validate_profile_file_id(profile_id)?;
+    }
+
+    let global_path = global_glossary_path_for_settings(path);
+    atomic_write_if_changed(
+        &global_path,
+        glossary_file_contents(&settings.initial_prompt).as_bytes(),
+        "global personal dictionary",
+    )?;
+
+    let profile_dir = profile_glossary_dir_for_settings(path);
+    for (profile_id, source) in &settings.profile_glossaries {
+        let profile_path = profile_dir.join(format!("{profile_id}.txt"));
+        atomic_write_if_changed(
+            &profile_path,
+            glossary_file_contents(source).as_bytes(),
+            "profile personal dictionary",
+        )?;
+    }
+    Ok(())
+}
+
+fn atomic_write_if_changed(path: &Path, contents: &[u8], label: &str) -> Result<(), String> {
+    if std::fs::read(path).is_ok_and(|current| current == contents) {
+        return Ok(());
+    }
+    atomic_write(path, contents, label)
+}
+
+/// Atomically replace a regular file while preserving a user-managed symlink.
+fn atomic_write(path: &Path, contents: &[u8], label: &str) -> Result<(), String> {
+    let destination = match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let target = std::fs::read_link(path)
+                .map_err(|error| format!("Failed to resolve {label} symlink: {error}"))?;
+            let target = if target.is_absolute() {
+                target
+            } else {
+                path.parent().unwrap_or_else(|| Path::new(".")).join(target)
+            };
+            if target.exists() {
+                std::fs::canonicalize(&target).map_err(|error| {
+                    format!("Failed to canonicalize {label} symlink target: {error}")
+                })?
+            } else {
+                target
+            }
+        }
+        Ok(_) | Err(_) => path.to_path_buf(),
+    };
+
+    let parent = destination
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    create_private_dir_all(&parent)
+        .map_err(|error| format!("Failed to create {label} directory: {error}"))?;
+    let tmp_path = destination.with_extension(format!(
+        "{}.tmp",
+        destination
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("file")
+    ));
+    std::fs::write(&tmp_path, contents)
+        .map_err(|error| format!("Failed to write {label}: {error}"))?;
+    std::fs::rename(&tmp_path, &destination)
+        .map_err(|error| format!("Failed to install {label}: {error}"))?;
+    Ok(())
+}
+
+fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700).create(path)
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
 }
 
 #[cfg(test)]
@@ -388,17 +684,15 @@ mod tests {
     }
 
     #[test]
-    fn default_settings_path_is_under_app_data_dir() {
-        let data_dir = PathBuf::from("/example/application-support");
-        let (p, legacy) = settings_location(None, data_dir.clone());
-        assert!(p.ends_with(SETTINGS_FILENAME));
-        assert!(p.parent().unwrap().ends_with(APP_IDENTIFIER));
+    fn default_settings_path_uses_the_xdg_config_directory() {
+        let data_dir = PathBuf::from("/Users/example/Library/Application Support");
+        let home_dir = PathBuf::from("/Users/example");
+        let (p, legacy) = settings_location(None, None, home_dir, data_dir.clone());
         assert_eq!(
-            legacy,
-            vec![data_dir
-                .join(LEGACY_APP_IDENTIFIERS[0])
-                .join(SETTINGS_FILENAME)]
+            p,
+            PathBuf::from("/Users/example/.config/sagascript").join(SETTINGS_FILENAME)
         );
+        assert!(legacy.contains(&data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME)));
     }
 
     #[test]
@@ -406,6 +700,8 @@ mod tests {
         let isolated = PathBuf::from("/tmp/sagascript-cli-test/settings.json");
         let (path, legacy) = settings_location(
             Some(isolated.clone().into_os_string()),
+            None,
+            PathBuf::from("/Users/example"),
             PathBuf::from("/real/application-support"),
         );
 
@@ -416,13 +712,55 @@ mod tests {
     #[test]
     fn empty_settings_path_override_uses_the_normal_location() {
         let data_dir = PathBuf::from("/example/application-support");
-        let (path, legacy) = settings_location(Some(OsString::new()), data_dir.clone());
+        let home_dir = PathBuf::from("/home/example");
+        let (path, legacy) = settings_location(
+            Some(OsString::new()),
+            None,
+            home_dir.clone(),
+            data_dir.clone(),
+        );
 
         assert_eq!(
             path,
-            data_dir.join(APP_IDENTIFIER).join(SETTINGS_FILENAME)
+            home_dir
+                .join(".config")
+                .join(CONFIG_DIR_NAME)
+                .join(SETTINGS_FILENAME)
         );
-        assert_eq!(legacy.len(), LEGACY_APP_IDENTIFIERS.len());
+        assert_eq!(legacy.len(), LEGACY_APP_IDENTIFIERS.len() + 2);
+    }
+
+    #[test]
+    fn absolute_xdg_config_home_overrides_the_default() {
+        let (path, _) = settings_location(
+            None,
+            Some(OsString::from("/dotfiles/config")),
+            PathBuf::from("/home/example"),
+            PathBuf::from("/example/application-support"),
+        );
+        assert_eq!(
+            path,
+            PathBuf::from("/dotfiles/config")
+                .join(CONFIG_DIR_NAME)
+                .join(SETTINGS_FILENAME)
+        );
+    }
+
+    #[test]
+    fn relative_exact_override_remains_isolated_while_relative_xdg_is_ignored() {
+        let (path, legacy) = settings_location(
+            Some(OsString::from("relative/settings.json")),
+            Some(OsString::from("relative-config")),
+            PathBuf::from("/home/example"),
+            PathBuf::from("/example/application-support"),
+        );
+        assert_eq!(
+            path,
+            std::env::current_dir()
+                .unwrap()
+                .join("relative/settings.json")
+        );
+        assert!(legacy.is_empty());
     }
 
     #[test]
@@ -477,6 +815,130 @@ mod tests {
         assert_eq!(migrated["has_completed_onboarding"], true);
         assert!(migrated.get("hasCompletedOnboarding").is_none());
         assert_eq!(migrated["future_key"]["x"], 1);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn xdg_move_preserves_auto_paste_for_the_same_bundle_identity() {
+        let root =
+            std::env::temp_dir().join(format!("sagascript-xdg-migration-{}", uuid::Uuid::new_v4()));
+        let legacy = root.join(APP_IDENTIFIER).join(SETTINGS_FILENAME);
+        let destination = root.join("xdg").join(SETTINGS_FILENAME);
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(&legacy, r#"{"auto_paste":true}"#).unwrap();
+
+        assert!(copy_legacy_settings(&legacy, &destination).unwrap());
+        let migrated: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&destination).unwrap()).unwrap();
+        assert_eq!(migrated["auto_paste"], true);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn first_xdg_load_copies_settings_and_externalizes_embedded_glossaries() {
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-first-xdg-load-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let legacy = root
+            .join("application-support")
+            .join(APP_IDENTIFIER)
+            .join(SETTINGS_FILENAME);
+        let destination = root
+            .join("xdg")
+            .join(CONFIG_DIR_NAME)
+            .join(SETTINGS_FILENAME);
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(
+            &legacy,
+            r#"{"language":"sv","auto_paste":true,"initial_prompt":"OpenRouter = open router","profile_glossaries":{"swedish":"merge = merch"}}"#,
+        )
+        .unwrap();
+
+        let loaded = load_at_with_legacy_sources(&destination, [legacy.clone()]);
+
+        assert_eq!(loaded.language, Language::Swedish);
+        assert!(loaded.auto_paste);
+        assert_eq!(loaded.initial_prompt, "OpenRouter = open router");
+        assert_eq!(
+            loaded.profile_glossaries.get("swedish").map(String::as_str),
+            Some("merge = merch")
+        );
+        let raw: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&destination).unwrap()).unwrap();
+        assert!(raw.get("initial_prompt").is_none());
+        assert!(raw.get("profile_glossaries").is_none());
+        assert_eq!(
+            fs::read_to_string(destination.parent().unwrap().join("glossary.txt")).unwrap(),
+            "OpenRouter = open router\n"
+        );
+        assert_eq!(
+            fs::read_to_string(
+                destination
+                    .parent()
+                    .unwrap()
+                    .join("glossaries")
+                    .join("swedish.txt")
+            )
+            .unwrap(),
+            "merge = merch\n"
+        );
+        assert!(legacy.exists(), "rollback source must remain untouched");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn embedded_invalid_profile_dictionary_id_is_skipped_during_externalization() {
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-invalid-embedded-glossary-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let destination = root.join(CONFIG_DIR_NAME).join(SETTINGS_FILENAME);
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        fs::write(
+            &destination,
+            r#"{"language":"sv","profile_glossaries":{"Bad/Id":"unsafe","swedish":"merge = merch"}}"#,
+        )
+        .unwrap();
+
+        let loaded = load_at_with_legacy_sources(&destination, std::iter::empty());
+
+        assert!(!loaded.profile_glossaries.contains_key("Bad/Id"));
+        assert_eq!(
+            loaded.profile_glossaries.get("swedish").map(String::as_str),
+            Some("merge = merch")
+        );
+        let raw: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&destination).unwrap()).unwrap();
+        assert!(raw.get("profile_glossaries").is_none());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migration_writes_through_a_dangling_settings_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-dangling-settings-link-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let legacy = root.join("legacy").join(SETTINGS_FILENAME);
+        let target = root.join("dotfiles").join(SETTINGS_FILENAME);
+        let destination = root.join("config").join(SETTINGS_FILENAME);
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        fs::write(&legacy, r#"{"language":"sv"}"#).unwrap();
+        symlink(&target, &destination).unwrap();
+
+        assert!(copy_legacy_settings(&legacy, &destination).unwrap());
+        assert!(fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let migrated: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&target).unwrap()).unwrap();
+        assert_eq!(migrated["language"], "sv");
         let _ = fs::remove_dir_all(root);
     }
 
@@ -609,6 +1071,173 @@ mod tests {
             let reloaded = load_from(&path);
             assert_eq!(reloaded.hotkey, "Super+Q");
         });
+    }
+
+    #[test]
+    fn save_externalizes_global_and_profile_glossaries() {
+        with_temp_settings(|path| {
+            let mut settings = Settings {
+                initial_prompt: "OpenRouter = open router".to_string(),
+                ..Default::default()
+            };
+            settings
+                .profile_glossaries
+                .insert("swedish".to_string(), "merge = merch".to_string());
+
+            save_to(&path, &settings).unwrap();
+
+            let raw: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+            assert!(raw.get("initial_prompt").is_none());
+            assert!(raw.get("profile_glossaries").is_none());
+            assert_eq!(
+                fs::read_to_string(path.parent().unwrap().join("glossary.txt")).unwrap(),
+                "OpenRouter = open router\n"
+            );
+            assert_eq!(
+                fs::read_to_string(
+                    path.parent()
+                        .unwrap()
+                        .join("glossaries")
+                        .join("swedish.txt")
+                )
+                .unwrap(),
+                "merge = merch\n"
+            );
+
+            let loaded = load_from(&path);
+            assert_eq!(loaded.initial_prompt, "OpenRouter = open router");
+            assert_eq!(
+                loaded.profile_glossaries.get("swedish").map(String::as_str),
+                Some("merge = merch")
+            );
+        });
+    }
+
+    #[test]
+    fn external_glossary_files_override_legacy_embedded_values() {
+        with_temp_settings(|path| {
+            let dir = path.parent().unwrap();
+            fs::create_dir_all(dir.join("glossaries")).unwrap();
+            fs::write(
+                &path,
+                r#"{"initial_prompt":"legacy","profile_glossaries":{"swedish":"legacy scoped"}}"#,
+            )
+            .unwrap();
+            fs::write(dir.join("glossary.txt"), "external global\n").unwrap();
+            fs::write(
+                dir.join("glossaries").join("swedish.txt"),
+                "external scoped\n",
+            )
+            .unwrap();
+
+            let loaded = load_from(&path);
+            assert_eq!(loaded.initial_prompt, "external global");
+            assert_eq!(
+                loaded.profile_glossaries.get("swedish").map(String::as_str),
+                Some("external scoped")
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn glossary_save_preserves_a_dotfiles_symlink() {
+        use std::os::unix::fs::symlink;
+
+        with_temp_settings(|path| {
+            let dir = path.parent().unwrap();
+            let dotfiles_dir = dir.join("dotfiles");
+            fs::create_dir_all(&dotfiles_dir).unwrap();
+            let target = dotfiles_dir.join("glossary.txt");
+            fs::write(&target, "old\n").unwrap();
+            let link = dir.join("glossary.txt");
+            symlink(&target, &link).unwrap();
+
+            let settings = Settings {
+                initial_prompt: "new = knew".to_string(),
+                ..Default::default()
+            };
+            save_to(&path, &settings).unwrap();
+
+            assert!(fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink());
+            assert_eq!(fs::read_to_string(&target).unwrap(), "new = knew\n");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn settings_save_preserves_a_dotfiles_symlink() {
+        use std::os::unix::fs::symlink;
+
+        with_temp_settings(|path| {
+            let dir = path.parent().unwrap();
+            let target = dir.join("tracked-settings.json");
+            fs::write(&target, "{}\n").unwrap();
+            symlink(&target, &path).unwrap();
+
+            let settings = Settings {
+                language: Language::Swedish,
+                ..Default::default()
+            };
+            save_to(&path, &settings).unwrap();
+
+            assert!(fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink());
+            let raw: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&target).unwrap()).unwrap();
+            assert_eq!(raw["language"], "sv");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn newly_created_configuration_directory_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-private-config-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let path = root.join("config").join(SETTINGS_FILENAME);
+        save_to(&path, &Settings::default()).unwrap();
+        let mode = fs::metadata(path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unchanged_glossary_save_does_not_replace_the_file() {
+        use std::os::unix::fs::MetadataExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "sagascript-unchanged-glossary-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let settings_path = root.join(SETTINGS_FILENAME);
+        let glossary_path = root.join(GLOBAL_GLOSSARY_FILENAME);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&glossary_path, "OpenRouter = open router\n").unwrap();
+        let original_inode = fs::metadata(&glossary_path).unwrap().ino();
+        let settings = Settings {
+            initial_prompt: "OpenRouter = open router".to_string(),
+            ..Default::default()
+        };
+
+        save_to(&settings_path, &settings).unwrap();
+
+        assert_eq!(fs::metadata(&glossary_path).unwrap().ino(), original_inode);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -660,7 +660,7 @@ fn main() {
                 let app_dir = app.path().app_data_dir().ok();
                 if let Some(dir) = app_dir {
                     let legacy = dir.join("flowdictate-settings.json");
-                    let new_path = dir.join("sagascript-settings.json");
+                    let new_path = sagascript_core::settings::store::settings_path();
                     migrate_legacy_settings_unless_overridden(
                         &legacy,
                         &new_path,
@@ -1292,25 +1292,34 @@ fn stop_recording_and_transcribe(
     });
 }
 
-/// Whether a filesystem event may reflect creation or replacement of the settings file.
-fn settings_event_may_affect(
+/// Whether a filesystem event may reflect creation or replacement of a user
+/// configuration file.
+fn configuration_event_may_affect(
     event: &notify::Event,
     settings_path: &std::path::Path,
+    global_glossary_path: &std::path::Path,
+    profile_glossary_dir: &std::path::Path,
 ) -> bool {
-    let relevant_kind = matches!(
+    let created_or_modified = matches!(
         event.kind,
         notify::EventKind::Create(_) | notify::EventKind::Modify(_)
     );
+    let glossary_changed =
+        created_or_modified || matches!(event.kind, notify::EventKind::Remove(_));
 
-    relevant_kind
-        && event
-            .paths
-            .iter()
-            .any(|path| path == settings_path)
+    event.paths.iter().any(|path| {
+        (created_or_modified && path == settings_path)
+            || (glossary_changed
+                && (path == global_glossary_path
+                    || (path.parent() == Some(profile_glossary_dir)
+                        && path.extension().and_then(|extension| extension.to_str())
+                            == Some("txt"))))
+    })
 }
 
-/// Watch the settings file for external changes and hot-reload into the running app.
-/// Handles hotkey re-registration and emits a settings-changed event to the frontend.
+/// Watch settings and personal dictionaries for external changes and hot-reload
+/// them into the running app. Handles hotkey re-registration and emits a
+/// settings-changed event to the frontend.
 fn start_settings_watcher(app: tauri::AppHandle) {
     use notify::{Config, RecursiveMode, Watcher};
     #[cfg(not(target_os = "macos"))]
@@ -1320,6 +1329,8 @@ fn start_settings_watcher(app: tauri::AppHandle) {
     use std::sync::mpsc;
 
     let settings_path = sagascript_core::settings::store::settings_path();
+    let global_glossary_path = sagascript_core::settings::store::global_glossary_path();
+    let profile_glossary_dir = sagascript_core::settings::store::profile_glossary_dir();
     let watch_dir = match settings_path.parent() {
         Some(d) => d.to_path_buf(),
         None => {
@@ -1354,7 +1365,7 @@ fn start_settings_watcher(app: tauri::AppHandle) {
             }
         };
 
-        if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::Recursive) {
             error!("Failed to watch settings directory: {e}");
             return;
         }
@@ -1370,7 +1381,12 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                 }
             };
 
-            if !settings_event_may_affect(&event, &settings_path) {
+            if !configuration_event_may_affect(
+                &event,
+                &settings_path,
+                &global_glossary_path,
+                &profile_glossary_dir,
+            ) {
                 continue;
             }
 
@@ -1603,10 +1619,19 @@ mod tests {
         rx: &std::sync::mpsc::Receiver<notify::Result<notify::Event>>,
         settings_path: &std::path::Path,
     ) -> bool {
+        let global_glossary_path = settings_path.parent().unwrap().join("glossary.txt");
+        let profile_glossary_dir = settings_path.parent().unwrap().join("glossaries");
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) {
             match rx.recv_timeout(remaining) {
-                Ok(Ok(event)) if settings_event_may_affect(&event, settings_path) => {
+                Ok(Ok(event))
+                    if configuration_event_may_affect(
+                        &event,
+                        settings_path,
+                        &global_glossary_path,
+                        &profile_glossary_dir,
+                    ) =>
+                {
                     return true;
                 }
                 Ok(_) => continue,
@@ -1656,43 +1681,96 @@ mod tests {
     }
 
     #[test]
-    fn settings_event_filter_accepts_target_create_and_modify_events() {
+    fn configuration_event_filter_accepts_settings_and_glossary_changes() {
         use notify::event::{CreateKind, ModifyKind};
         use notify::{Event, EventKind};
 
         let watch_dir = std::path::Path::new("/tmp/sagascript");
         let settings_path = watch_dir.join("sagascript-settings.json");
+        let global_glossary_path = watch_dir.join("glossary.txt");
+        let profile_glossary_dir = watch_dir.join("glossaries");
 
         for kind in [
             EventKind::Create(CreateKind::Any),
             EventKind::Modify(ModifyKind::Any),
         ] {
-            let target_event = Event::new(kind).add_path(settings_path.clone());
-            assert!(settings_event_may_affect(&target_event, &settings_path));
+            for target in [
+                settings_path.clone(),
+                global_glossary_path.clone(),
+                profile_glossary_dir.join("swedish.txt"),
+            ] {
+                let target_event = Event::new(kind).add_path(target);
+                assert!(configuration_event_may_affect(
+                    &target_event,
+                    &settings_path,
+                    &global_glossary_path,
+                    &profile_glossary_dir,
+                ));
+            }
         }
     }
 
     #[test]
-    fn settings_event_filter_rejects_unrelated_and_non_mutating_events() {
+    fn configuration_event_filter_rejects_unrelated_and_non_mutating_events() {
         use notify::event::{AccessKind, ModifyKind, RemoveKind};
         use notify::{Event, EventKind};
 
         let watch_dir = std::path::Path::new("/tmp/sagascript");
         let settings_path = watch_dir.join("sagascript-settings.json");
+        let global_glossary_path = watch_dir.join("glossary.txt");
+        let profile_glossary_dir = watch_dir.join("glossaries");
         let unrelated = Event::new(EventKind::Modify(ModifyKind::Any))
             .add_path(watch_dir.join("settings.tmp"));
-        assert!(!settings_event_may_affect(&unrelated, &settings_path));
+        assert!(!configuration_event_may_affect(
+            &unrelated,
+            &settings_path,
+            &global_glossary_path,
+            &profile_glossary_dir,
+        ));
+
+        let unrelated_profile = Event::new(EventKind::Modify(ModifyKind::Any))
+            .add_path(profile_glossary_dir.join("notes.md"));
+        assert!(!configuration_event_may_affect(
+            &unrelated_profile,
+            &settings_path,
+            &global_glossary_path,
+            &profile_glossary_dir,
+        ));
 
         let remove = Event::new(EventKind::Remove(RemoveKind::Any))
             .add_path(settings_path.clone());
-        assert!(!settings_event_may_affect(&remove, &settings_path));
+        assert!(!configuration_event_may_affect(
+            &remove,
+            &settings_path,
+            &global_glossary_path,
+            &profile_glossary_dir,
+        ));
+
+        let remove_glossary = Event::new(EventKind::Remove(RemoveKind::Any))
+            .add_path(profile_glossary_dir.join("swedish.txt"));
+        assert!(configuration_event_may_affect(
+            &remove_glossary,
+            &settings_path,
+            &global_glossary_path,
+            &profile_glossary_dir,
+        ));
 
         let access = Event::new(EventKind::Access(AccessKind::Any))
             .add_path(settings_path.clone());
-        assert!(!settings_event_may_affect(&access, &settings_path));
+        assert!(!configuration_event_may_affect(
+            &access,
+            &settings_path,
+            &global_glossary_path,
+            &profile_glossary_dir,
+        ));
 
         let other = Event::new(EventKind::Other).add_path(settings_path.clone());
-        assert!(!settings_event_may_affect(&other, &settings_path));
+        assert!(!configuration_event_may_affect(
+            &other,
+            &settings_path,
+            &global_glossary_path,
+            &profile_glossary_dir,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- move user-managed settings to `${XDG_CONFIG_HOME:-$HOME/.config}/sagascript/`
- externalize the global and profile personal dictionaries into plain text files
- preserve and externalize legacy settings on first load without deleting rollback sources
- add CLI path discovery, GUI hot reload, atomic writes, and dotfiles symlink support
- document path precedence, macOS GUI environment behavior, migration, and reset semantics

## Stack

This PR is based on `codex/issue-151-teach-sagascript` because it externalizes the profile-scoped dictionaries introduced there. Review this PR as the delta from #151.

## Validation

- 559 Rust tests via `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npx svelte-check --tsconfig ./tsconfig.json` (0 errors, 0 warnings)
- `npm run build`
- `npm run test:frontend` (9 tests)
- manual absolute and relative `SAGASCRIPT_SETTINGS_PATH` workflows
- independent review by GPT-5.5 and Claude Opus 5

Closes #153
