### PR TITLE
docs: slim project agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,45 @@
 # Sagascript — project instructions
 
-## What this is
+Sagascript is a low-latency, privacy-first macOS dictation app built with Tauri v2,
+Rust, Svelte 5, and local Whisper inference.
 
-Sagascript is a low-latency, privacy-first macOS dictation app built with Tauri v2 (Rust backend + Svelte 5 frontend). It provides push-to-talk transcription using local Whisper models via whisper-rs (Metal + Core ML).
+## Product invariants
 
-## Golden rules
+- **CLI first:** every feature needs a CLI equivalent. Commands in
+  `src-tauri/crates/sagascript-cli/src/` define the source-of-truth capability surface;
+  discover the current inventory with `sagascript --help` rather than duplicating it here.
+- **Privacy first:** local transcription is the default; remote/cloud behavior is opt-in.
+- Optimize latency and perceived speed; keep the UI to the menu bar, settings, and indicator.
+- Make changes only on a task branch in a separate worktree; never edit the primary checkout.
+- Never read, print, modify, or commit `.env`, `.env.*`, or `secrets/**` without explicit
+  user authorization. Never hardcode secrets.
 
-- **CLI-first design**: Every feature must have a CLI equivalent. The GUI is a convenience layer on top of CLI commands. The CLI commands in `src-tauri/crates/sagascript-cli/src/` are the source of truth for what the app can do.
-- **Privacy-first**: Default to local transcription. Remote/cloud features are opt-in, never default.
-- Optimize for **latency** and **perceived speed**.
-- Keep UI minimal (menu bar + settings + indicator).
-- **Always work in worktrees**: When making changes, create a separate branch in a git worktree. Never modify the main working tree directly — unstaged changes leak across branches and interfere with parallel work.
-- **Sensitive files**: Never read, print, modify, or commit `.env`, `.env.*`, or `secrets/**` unless the user explicitly authorizes it.
+## Technical invariants
 
-## Code style
+- Use Svelte 5 runes such as `$state` and `$effect`, not legacy stores.
+- `enigo` and TIS/HIToolbox APIs must run on the macOS main thread; from async code use
+  `app_handle.run_on_main_thread()`.
+- Signed builds need the audio-input entitlement. Set the signing identity through
+  `APPLE_SIGNING_IDENTITY`, never in `tauri.conf.json`.
+- `cargo tauri dev` is unsigned and cannot validate TCC permission behavior. Use
+  `cargo tauri build --debug` for microphone or Accessibility permission testing.
 
-- Rust: prefer clarity over cleverness; keep modules small and testable.
-- Svelte 5: use runes (`$state`, `$effect`), not legacy stores.
-- No hardcoded secrets.
-- macOS threading: `enigo` and other TIS/HIToolbox APIs MUST run on the main thread — use `app_handle.run_on_main_thread()` from async contexts.
+## Code layout
 
-## macOS Signing & Entitlements
+- `src/`: Svelte frontend.
+- `src-tauri/src/`: Tauri shell and desktop integrations.
+- `src-tauri/crates/sagascript-core/src/`: transcription, audio, settings, and diarization.
+- `src-tauri/crates/sagascript-cli/src/`: canonical CLI commands.
+- The app crate and CLI crate both emit a binary named `sagascript`; `target/release/sagascript`
+  is whichever one was built most recently.
 
-- **Signing identity** is NOT in `tauri.conf.json` — set via `APPLE_SIGNING_IDENTITY` env var (see `.env`, gitignored).
-- **Entitlements.plist** grants `com.apple.security.device.audio-input` — required for mic access in signed builds.
-- `cargo tauri dev` produces an unsigned binary that can't do TCC permission checks — use `cargo tauri build --debug` for testing permissions.
-- Microphone permission API uses `AVCaptureDevice` via objc FFI (`macos_mic` module in `commands.rs`).
+## Verification
 
-## Local commands
+Run Rust commands from `src-tauri/`:
 
-- `cargo tauri dev` — build and run the app in dev mode.
-- `cargo check --workspace` — type-check Rust (from `src-tauri/`; bare `cargo check` covers only the app crate).
-- `cargo test --workspace` — run Rust unit tests across all three crates (from `src-tauri/`).
-- `cargo clippy --workspace --all-targets -- -D warnings` — lint Rust (from `src-tauri/`).
-- `cargo build -p sagascript-cli --no-default-features` — lean batch-transcribe CLI build (no cpal/ALSA, no diarization and its ONNX Runtime; ~8 MB vs ~31 MB default).
-- `npx svelte-check --tsconfig ./tsconfig.json` — type-check Svelte/TS.
-- `tail -f ~/Library/Logs/Sagascript/sagascript.log` — watch logs.
+- `cargo check --workspace`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo build -p sagascript-cli --no-default-features` for the lean batch CLI
 
-## CLI subcommands
-
-- `sagascript transcribe <file>` — transcribe audio/video file.
-- `sagascript record` — record from mic and transcribe.
-- `sagascript list-models` — list available whisper models.
-- `sagascript download-model <id>` — download a model.
-- `sagascript config list|get|set|reset|path` — manage settings.
-- `sagascript formats` — list supported audio formats.
-- `sagascript completions <shell>` — generate shell completions.
-- `sagascript manpages [--dir DIR]` — generate man pages.
-
-## Architecture
-
-```
-src/                            # Svelte 5 frontend (menu bar UI)
-src-tauri/                      # Rust workspace (root package = the Tauri app)
-  src/                          # App crate: GUI shell + desktop integrations
-    hotkey/                     # Global hotkey service
-    paste/                      # Paste-into-active-app service
-    platform/                   # Platform-specific code (macOS, Windows stubs)
-    logging/                    # Structured logging
-  crates/sagascript-core/src/   # Lib crate: transcription engine
-    audio/                      # Audio capture (`record` feature), decoding, resampling
-    transcription/              # Whisper backend, model management
-    settings/                   # Settings store (shared between CLI and GUI)
-    diarization/                # Speaker diarization (`diarization` feature)
-  crates/sagascript-cli/src/    # Lib + bin crate: CLI subcommands (clap)
-```
-
-Both the app crate and `sagascript-cli` produce a bin named `sagascript`;
-`target/release/sagascript` is whichever was built most recently.
+For frontend changes, run `npx svelte-check --tsconfig ./tsconfig.json` from the repo root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,5 @@
 
 # Claude Code adapter
 
-`AGENTS.md` is the canonical shared project guidance. Put only Claude Code-specific additions below; portable changes belong in `AGENTS.md`.
+`AGENTS.md` is the canonical shared project guidance. Put only genuinely Claude-specific
+additions here; portable project instructions belong in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- reduce project instructions to stable product and technical invariants
- keep AGENTS.md canonical and make CLAUDE.md a minimal import adapter
- remove duplicated command and architecture inventories that can be discovered from source

## Verification
- git diff --check
- global instruction audit: 0 errors, 0 warnings
- branch rebased on current origin/main