### PR TITLE
chore: prepare v1.1.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sagascript",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sagascript",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-autostart": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sagascript",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4050,7 +4050,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagascript"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "arboard",
  "block",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-cli"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "arboard",
  "clap",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "sagascript-core"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "cpal",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tauri::State;
+use tauri::{Manager, State};
 use tracing::{error, info, warn};
 
 /// Maximum time to wait for whisper inference before aborting (seconds)
@@ -260,6 +260,7 @@ fn set_language_for_controller(
 
 #[tauri::command]
 pub async fn set_onboarding_completed(
+    app: tauri::AppHandle,
     controller: State<'_, SharedController>,
 ) -> Result<(), String> {
     let persisted = sagascript_core::settings::store::update(|settings| {
@@ -267,6 +268,17 @@ pub async fn set_onboarding_completed(
     })?;
     let mut ctrl = controller.lock().unwrap();
     ctrl.settings_mut().has_completed_onboarding = persisted.has_completed_onboarding;
+    drop(ctrl);
+
+    // The frontend also hides itself after this command resolves, but doing it
+    // here closes the first-dictation race: once completion is persisted, no
+    // background hotkey work can briefly revive a still-visible onboarding
+    // window before the next JavaScript turn runs.
+    if let Some(window) = app.get_webview_window("settings") {
+        if let Err(error) = window.hide() {
+            warn!("Failed to hide completed onboarding window: {error}");
+        }
+    }
     info!("Onboarding marked as completed");
     Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,7 +46,7 @@ use tauri::{
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tracing::{error, info, warn};
 
-use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
+use app_controller::{AppController, AppState, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
 use sagascript_core::settings::HotkeyProfile;
 #[cfg(test)]
@@ -1000,8 +1000,17 @@ fn main() {
                 // "visible", so always run the full reveal path.
                 #[cfg(target_os = "macos")]
                 tauri::RunEvent::Reopen { .. } => {
-                    info!("Application reopen requested");
-                    open_settings_window(_app_handle, None);
+                    let state = {
+                        let ctrl: tauri::State<'_, SharedController> = _app_handle.state();
+                        let state = ctrl.lock().unwrap().state();
+                        state
+                    };
+                    if should_reveal_for_reopen(state) {
+                        info!("Application reopen requested");
+                        open_settings_window(_app_handle, None);
+                    } else {
+                        info!("Ignoring application reopen while dictation is {state:?}");
+                    }
                 }
                 _ => {}
             }
@@ -1230,6 +1239,10 @@ fn initial_window_request(
     } else {
         InitialWindowRequest::Settings
     }
+}
+
+fn should_reveal_for_reopen(state: AppState) -> bool {
+    !state.is_busy()
 }
 
 trait MainWindowVisibility {
@@ -1915,6 +1928,13 @@ mod tests {
             initial_window_request(true, GuiLaunchMode::Standard),
             InitialWindowRequest::Settings
         );
+    }
+
+    #[test]
+    fn dictation_state_never_turns_a_reopen_event_into_a_settings_window() {
+        assert!(should_reveal_for_reopen(AppState::Idle));
+        assert!(!should_reveal_for_reopen(AppState::Recording));
+        assert!(!should_reveal_for_reopen(AppState::Transcribing));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,7 +46,9 @@ use tauri::{
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tracing::{error, info, warn};
 
-use app_controller::{AppController, AppState, HotkeyDownResult, StopRecordingOutcome};
+#[cfg(any(target_os = "macos", test))]
+use app_controller::AppState;
+use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
 use sagascript_core::settings::HotkeyProfile;
 #[cfg(test)]
@@ -1241,6 +1243,7 @@ fn initial_window_request(
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn should_reveal_for_reopen(state: AppState) -> bool {
     !state.is_busy()
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1233,12 +1233,17 @@ fn initial_window_request(
 }
 
 trait MainWindowVisibility {
+    fn reset_to_normal_level(&self) -> Result<(), String>;
     fn unminimize(&self) -> Result<(), String>;
     fn show(&self) -> Result<(), String>;
     fn set_focus(&self) -> Result<(), String>;
 }
 
 impl MainWindowVisibility for tauri::WebviewWindow {
+    fn reset_to_normal_level(&self) -> Result<(), String> {
+        tauri::WebviewWindow::set_always_on_top(self, false).map_err(|error| error.to_string())
+    }
+
     fn unminimize(&self) -> Result<(), String> {
         tauri::WebviewWindow::unminimize(self).map_err(|error| error.to_string())
     }
@@ -1253,6 +1258,9 @@ impl MainWindowVisibility for tauri::WebviewWindow {
 }
 
 fn reveal_existing_main_window(window: &impl MainWindowVisibility) -> Result<(), String> {
+    if let Err(error) = window.reset_to_normal_level() {
+        warn!("Failed to restore normal main-window level: {error}");
+    }
     window
         .unminimize()
         .map_err(|error| format!("failed to restore main window: {error}"))?;
@@ -1308,6 +1316,7 @@ fn try_open_settings_window(app: &tauri::AppHandle, tab: Option<&str>) -> Result
         .inner_size(500.0, default_height)
         .min_inner_size(500.0, 400.0)
         .resizable(true)
+        .always_on_top(false)
         .center()
         .focused(true)
         .build()
@@ -1787,6 +1796,15 @@ mod tests {
     }
 
     impl MainWindowVisibility for MockMainWindow {
+        fn reset_to_normal_level(&self) -> Result<(), String> {
+            self.operations.borrow_mut().push("reset_to_normal_level");
+            if self.fail_at == Some("reset_to_normal_level") {
+                Err("window level failed".to_string())
+            } else {
+                Ok(())
+            }
+        }
+
         fn unminimize(&self) -> Result<(), String> {
             self.operations.borrow_mut().push("unminimize");
             if self.fail_at == Some("unminimize") {
@@ -1823,7 +1841,12 @@ mod tests {
 
         assert_eq!(
             *window.operations.borrow(),
-            ["unminimize", "show", "set_focus"]
+            [
+                "reset_to_normal_level",
+                "unminimize",
+                "show",
+                "set_focus"
+            ]
         );
     }
 
@@ -1838,7 +1861,30 @@ mod tests {
 
         assert!(error.contains("show main window"));
         assert!(error.contains("show failed"));
-        assert_eq!(*window.operations.borrow(), ["unminimize", "show"]);
+        assert_eq!(
+            *window.operations.borrow(),
+            ["reset_to_normal_level", "unminimize", "show"]
+        );
+    }
+
+    #[test]
+    fn main_window_reveal_continues_if_normal_window_level_cannot_be_restored() {
+        let window = MockMainWindow {
+            fail_at: Some("reset_to_normal_level"),
+            ..Default::default()
+        };
+
+        reveal_existing_main_window(&window).unwrap();
+
+        assert_eq!(
+            *window.operations.borrow(),
+            [
+                "reset_to_normal_level",
+                "unminimize",
+                "show",
+                "set_focus"
+            ]
+        );
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1233,6 +1233,7 @@ fn initial_window_request(
 }
 
 trait MainWindowVisibility {
+    fn activate_app(&self);
     fn reset_to_normal_level(&self) -> Result<(), String>;
     fn unminimize(&self) -> Result<(), String>;
     fn show(&self) -> Result<(), String>;
@@ -1240,6 +1241,16 @@ trait MainWindowVisibility {
 }
 
 impl MainWindowVisibility for tauri::WebviewWindow {
+    fn activate_app(&self) {
+        #[cfg(target_os = "macos")]
+        if let Err(error) = self
+            .app_handle()
+            .run_on_main_thread(platform::macos::activate_app)
+        {
+            warn!("Failed to schedule foreground application activation: {error}");
+        }
+    }
+
     fn reset_to_normal_level(&self) -> Result<(), String> {
         tauri::WebviewWindow::set_always_on_top(self, false).map_err(|error| error.to_string())
     }
@@ -1269,7 +1280,12 @@ fn reveal_existing_main_window(window: &impl MainWindowVisibility) -> Result<(),
         .map_err(|error| format!("failed to show main window: {error}"))?;
     window
         .set_focus()
-        .map_err(|error| format!("failed to focus main window: {error}"))
+        .map_err(|error| format!("failed to focus main window: {error}"))?;
+    // Queue activation after presentation. During initial `.setup()` a direct
+    // AppKit activation happens before Tauri's event loop is ready and macOS
+    // leaves the onboarding window behind the previously active application.
+    window.activate_app();
+    Ok(())
 }
 
 /// Open or focus the main window, optionally navigating to a specific tab.
@@ -1796,6 +1812,10 @@ mod tests {
     }
 
     impl MainWindowVisibility for MockMainWindow {
+        fn activate_app(&self) {
+            self.operations.borrow_mut().push("activate_app");
+        }
+
         fn reset_to_normal_level(&self) -> Result<(), String> {
             self.operations.borrow_mut().push("reset_to_normal_level");
             if self.fail_at == Some("reset_to_normal_level") {
@@ -1845,7 +1865,8 @@ mod tests {
                 "reset_to_normal_level",
                 "unminimize",
                 "show",
-                "set_focus"
+                "set_focus",
+                "activate_app"
             ]
         );
     }
@@ -1882,7 +1903,8 @@ mod tests {
                 "reset_to_normal_level",
                 "unminimize",
                 "show",
-                "set_focus"
+                "set_focus",
+                "activate_app"
             ]
         );
     }

--- a/src-tauri/src/paste/service.rs
+++ b/src-tauri/src/paste/service.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_os = "macos"))]
 use arboard::Clipboard;
+use std::borrow::Cow;
 #[cfg(target_os = "macos")]
 #[path = "macos_clipboard.rs"]
 mod macos_clipboard;
@@ -7,7 +8,7 @@ mod macos_clipboard;
 // the Control modifier unmapped (paste silently fails), so we shell out to
 // xdotool instead and don't depend on enigo there.
 #[cfg(not(target_os = "linux"))]
-use enigo::{Enigo, Keyboard, Settings as EnigoSettings, Key, Direction};
+use enigo::{Direction, Enigo, Key, Keyboard, Settings as EnigoSettings};
 use tracing::info;
 #[cfg(target_os = "macos")]
 use tracing::warn;
@@ -17,6 +18,14 @@ use sagascript_core::error::DictationError;
 /// Service for pasting transcribed text into the active application
 /// Uses clipboard + simulated Cmd+V (macOS) or Ctrl+V (Windows/Linux)
 pub struct PasteService;
+
+fn paste_payload(text: &str) -> Cow<'_, str> {
+    if text.is_empty() || text.chars().last().is_some_and(char::is_whitespace) {
+        Cow::Borrowed(text)
+    } else {
+        Cow::Owned(format!("{text} "))
+    }
+}
 
 impl PasteService {
     pub fn new() -> Self {
@@ -29,6 +38,7 @@ impl PasteService {
         if text.is_empty() {
             return Ok(());
         }
+        let text = paste_payload(text);
 
         #[cfg(not(target_os = "macos"))]
         let mut clipboard = Clipboard::new()
@@ -47,7 +57,7 @@ impl PasteService {
         // generation created by our clear, closing the race that a later
         // changeCount sample could accidentally attribute to another app.
         #[cfg(target_os = "macos")]
-        let owned_change_count = match macos_clipboard::set_temporary_text(text) {
+        let owned_change_count = match macos_clipboard::set_temporary_text(text.as_ref()) {
             Ok(generation) => generation,
             Err(error) => {
                 if let Some(snapshot) = saved_pasteboard {
@@ -67,7 +77,7 @@ impl PasteService {
 
         #[cfg(not(target_os = "macos"))]
         clipboard
-            .set_text(text)
+            .set_text(text.as_ref())
             .map_err(|e| DictationError::PasteError(format!("Failed to set clipboard: {e}")))?;
 
         info!("Text copied to clipboard ({} chars)", text.len());
@@ -130,7 +140,7 @@ fn validate_accessibility(trusted: bool) -> Result<(), DictationError> {
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
-    use super::validate_accessibility;
+    use super::{paste_payload, validate_accessibility};
     use sagascript_core::error::DictationError;
 
     #[test]
@@ -140,6 +150,19 @@ mod tests {
             Err(DictationError::AccessibilityPermissionDenied)
         ));
         assert!(validate_accessibility(true).is_ok());
+    }
+
+    #[test]
+    fn paste_payload_adds_one_separator_between_dictations() {
+        assert_eq!(paste_payload("Första meningen."), "Första meningen. ");
+        assert_eq!(paste_payload("Nästa fras"), "Nästa fras ");
+    }
+
+    #[test]
+    fn paste_payload_preserves_existing_trailing_whitespace() {
+        assert_eq!(paste_payload("Redan klart. "), "Redan klart. ");
+        assert_eq!(paste_payload("Ny rad\n"), "Ny rad\n");
+        assert_eq!(paste_payload(""), "");
     }
 }
 

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -24,6 +24,10 @@ fn accessibility_settings_command() -> Command {
     command
 }
 
+fn accessibility_request_prompts_user() -> bool {
+    false
+}
+
 fn interpret_open_result(result: io::Result<ExitStatus>) -> Result<(), String> {
     let status =
         result.map_err(|error| format!("Failed to open Accessibility settings: {error}"))?;
@@ -44,12 +48,17 @@ pub fn open_accessibility_settings() -> Result<(), String> {
     interpret_open_result(accessibility_settings_command().status())
 }
 
-/// Request Accessibility permission and bring the relevant System Settings
-/// pane forward. AXTrustedCheckOptionPrompt alone does not reliably navigate
-/// an already-running System Settings instance away from its current pane.
+/// Register the Accessibility check without showing macOS's redundant native
+/// alert, then bring the relevant System Settings pane forward directly. The
+/// onboarding UI already explains why access is needed and keeps an explicit
+/// button available if the user navigates away from the pane.
 pub fn request_accessibility_permission() -> Result<(), String> {
     let key = CFString::new("AXTrustedCheckOptionPrompt");
-    let value = CFBoolean::true_value();
+    let value = if accessibility_request_prompts_user() {
+        CFBoolean::true_value()
+    } else {
+        CFBoolean::false_value()
+    };
     let options = CFDictionary::from_CFType_pairs(&[(key, value)]);
 
     unsafe {
@@ -74,12 +83,18 @@ pub fn set_activation_policy_accessory() {
 #[cfg(test)]
 mod tests {
     use super::{
-        accessibility_settings_command, interpret_open_result, ACCESSIBILITY_SETTINGS_URL,
+        accessibility_request_prompts_user, accessibility_settings_command, interpret_open_result,
+        ACCESSIBILITY_SETTINGS_URL,
     };
     use std::ffi::OsStr;
     use std::io;
     use std::os::unix::process::ExitStatusExt;
     use std::process::ExitStatus;
+
+    #[test]
+    fn initial_accessibility_request_does_not_show_a_redundant_native_prompt() {
+        assert!(!accessibility_request_prompts_user());
+    }
 
     #[test]
     fn accessibility_request_opens_the_privacy_pane() {

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -80,6 +80,19 @@ pub fn set_activation_policy_accessory() {
     }
 }
 
+/// Bring the accessory application to the foreground before presenting a
+/// user-requested window. Accessory apps do not reliably activate when a
+/// window merely calls `show`/`set_focus`.
+#[allow(deprecated)]
+pub fn activate_app() {
+    use cocoa::appkit::{NSApp, NSApplication};
+    use cocoa::base::YES;
+
+    unsafe {
+        NSApp().activateIgnoringOtherApps_(YES);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
   "productName": "Sagascript",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "identifier": "ai.gille.sagascript",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- streamline macOS Accessibility onboarding without repeated native prompts
- reliably reveal Settings for explicit GUI opens while keeping background dictation unobtrusive
- preserve paste behavior when Accessibility is unavailable
- prepare the combined performance and onboarding release as v1.1.3

This branch starts from `main` after performance PRs #158, #161, and #160. It intentionally supersedes the older, unpublished v1.1.2 release candidate; the existing v1.1.2 tag and draft are left untouched.

## Verification

- `RELEASE_TAG=v1.1.3 npm run release:check`
- `npm run licenses:check`
- `npm run build`
- `npm run check`
- `npm run test:frontend` (30 passed)
- `cargo test --workspace` (612 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build -p sagascript-cli --no-default-features`
- `git diff --check`

The constituent macOS fixes previously passed signed-candidate live dictation checks. A new signed v1.1.3 artifact must still pass the clean-machine onboarding checklist before its draft release is published.

## Review

- Independent Anthropic review was attempted but did not run because the configured account had reached its session limit (zero inference).
- Independent local `qwen3-coder-next-80b` review of the exact branch diff: `NO_FINDINGS`.
