### PR TITLE
build: add Windows release candidate track

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -83,7 +83,14 @@ jobs:
             --beam 0 `
             --json `
             test-audio/norwegian-short-3s.mp3 > $stdout 2> $stderr
-          if ($LASTEXITCODE -ne 0) { throw "Transcription failed with exit code $LASTEXITCODE" }
+          if ($LASTEXITCODE -ne 0) {
+            $transcriptionExit = $LASTEXITCODE
+            Write-Host "Transcription stdout:"
+            if (Test-Path $stdout) { Get-Content $stdout }
+            Write-Host "Transcription stderr:"
+            if (Test-Path $stderr) { Get-Content $stderr }
+            throw "Transcription failed with exit code $transcriptionExit"
+          }
           python scripts/verify-json-cli-streams.py $stdout $stderr
           $result = Get-Content $stdout -Raw | ConvertFrom-Json
           if ($result.language -ne "no") { throw "Expected Norwegian result, got '$($result.language)'" }

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -96,6 +96,7 @@ jobs:
           if ($result.language -ne "no") { throw "Expected Norwegian result, got '$($result.language)'" }
           if ($result.text -notmatch "(?i)storting") { throw "Expected 'storting' in transcription" }
           if (-not $result.segments) { throw "Expected at least one transcription segment" }
+          Copy-Item $binary (Join-Path $env:RUNNER_TEMP "sagascript-cli.exe")
 
       - name: Build unsigned internal installers
         run: npx tauri build --ci --bundles nsis,msi --no-sign
@@ -104,14 +105,16 @@ jobs:
         shell: pwsh
         run: |
           $version = node -p "require('./package.json').version"
-          $native = "src-tauri\target\release\sagascript.exe"
+          $desktop = "src-tauri\target\release\sagascript.exe"
+          $cli = Join-Path $env:RUNNER_TEMP "sagascript-cli.exe"
           $nsis = Get-ChildItem "src-tauri\target\release\bundle\nsis" -Filter "*.exe" -File | Select-Object -First 1
           $msi = Get-ChildItem "src-tauri\target\release\bundle\msi" -Filter "*.msi" -File | Select-Object -First 1
           if (-not $nsis) { throw "Tauri did not produce an NSIS installer" }
           if (-not $msi) { throw "Tauri did not produce an MSI installer" }
 
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          Copy-Item $native "artifacts\Sagascript-Windows-x64.exe"
+          Copy-Item $desktop "artifacts\Sagascript-Windows-x64-Portable.exe"
+          Copy-Item $cli "artifacts\Sagascript-Windows-x64-CLI.exe"
           Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-x64-Setup.exe"
           Copy-Item $msi.FullName "artifacts\Sagascript-Windows-x64.msi"
           Copy-Item "docs\windows-release.md" "artifacts\README-Windows-Candidate.md"
@@ -119,10 +122,11 @@ jobs:
           Copy-Item "test-audio\norwegian-short-3s.mp3" "artifacts\norwegian-short-3s.mp3"
 
           ./scripts/verify-windows-release.ps1 `
-            -AppExe "artifacts\Sagascript-Windows-x64.exe" `
+            -CliExe "artifacts\Sagascript-Windows-x64-CLI.exe" `
             -ExpectedVersion $version `
             -Artifacts @(
-              "artifacts\Sagascript-Windows-x64.exe",
+              "artifacts\Sagascript-Windows-x64-Portable.exe",
+              "artifacts\Sagascript-Windows-x64-CLI.exe",
               "artifacts\Sagascript-Windows-x64-Setup.exe",
               "artifacts\Sagascript-Windows-x64.msi"
             ) `

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,0 +1,131 @@
+name: Windows Package Candidate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/windows-package.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/**"
+      - "src/**"
+      - "src-tauri/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-candidate:
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Cargo registry and target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~\.cargo\registry
+            ~\.cargo\git
+            src-tauri\target
+          key: windows-package-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json') }}
+          restore-keys: |
+            windows-package-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Verify release metadata and licenses
+        run: |
+          npm run release:check
+          npm run licenses:check
+
+      - name: Test frontend release surface
+        run: npm run test:frontend
+
+      - name: Build and check frontend
+        run: |
+          npm run build
+          npm run check
+
+      - name: Test and lint Rust workspace
+        working-directory: src-tauri
+        run: |
+          cargo test --workspace
+          cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Gate real Windows transcription
+        shell: pwsh
+        run: |
+          cargo build --release -p sagascript-cli --manifest-path src-tauri/Cargo.toml
+          $binary = "src-tauri\target\release\sagascript.exe"
+          $stdout = Join-Path $env:RUNNER_TEMP "transcription-smoke.json"
+          $stderr = Join-Path $env:RUNNER_TEMP "transcription-smoke.stderr"
+          & $binary download-model nb-whisper-tiny
+          if ($LASTEXITCODE -ne 0) { throw "Model download failed with exit code $LASTEXITCODE" }
+          & $binary transcribe `
+            --language no `
+            --model nb-whisper-tiny `
+            --beam 0 `
+            --json `
+            test-audio/norwegian-short-3s.mp3 > $stdout 2> $stderr
+          if ($LASTEXITCODE -ne 0) { throw "Transcription failed with exit code $LASTEXITCODE" }
+          python scripts/verify-json-cli-streams.py $stdout $stderr
+          $result = Get-Content $stdout -Raw | ConvertFrom-Json
+          if ($result.language -ne "no") { throw "Expected Norwegian result, got '$($result.language)'" }
+          if ($result.text -notmatch "(?i)storting") { throw "Expected 'storting' in transcription" }
+          if (-not $result.segments) { throw "Expected at least one transcription segment" }
+
+      - name: Build unsigned internal installers
+        run: npx tauri build --ci --bundles nsis,msi --no-sign
+
+      - name: Prepare and verify candidate artifacts
+        shell: pwsh
+        run: |
+          $version = node -p "require('./package.json').version"
+          $native = "src-tauri\target\release\sagascript.exe"
+          $nsis = Get-ChildItem "src-tauri\target\release\bundle\nsis" -Filter "*.exe" -File | Select-Object -First 1
+          $msi = Get-ChildItem "src-tauri\target\release\bundle\msi" -Filter "*.msi" -File | Select-Object -First 1
+          if (-not $nsis) { throw "Tauri did not produce an NSIS installer" }
+          if (-not $msi) { throw "Tauri did not produce an MSI installer" }
+
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          Copy-Item $native "artifacts\Sagascript-Windows-x64.exe"
+          Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-x64-Setup.exe"
+          Copy-Item $msi.FullName "artifacts\Sagascript-Windows-x64.msi"
+          Copy-Item "docs\windows-release.md" "artifacts\README-Windows-Candidate.md"
+          Copy-Item "scripts\accept-windows-candidate.ps1" "artifacts\accept-windows-candidate.ps1"
+          Copy-Item "test-audio\norwegian-short-3s.mp3" "artifacts\norwegian-short-3s.mp3"
+
+          ./scripts/verify-windows-release.ps1 `
+            -AppExe "artifacts\Sagascript-Windows-x64.exe" `
+            -ExpectedVersion $version `
+            -Artifacts @(
+              "artifacts\Sagascript-Windows-x64.exe",
+              "artifacts\Sagascript-Windows-x64-Setup.exe",
+              "artifacts\Sagascript-Windows-x64.msi"
+            ) `
+            -SignaturePolicy Internal `
+            -ChecksumOutput "artifacts\SHA256SUMS-Windows"
+
+      - name: Upload internal Windows candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64-unsigned-candidate
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ for recording audio. Do not install an unsigned binary from an untrusted party.
 - [Installation guide](docs/installation.md) -- detailed install instructions for macOS and Windows
 - [Linux notes](docs/linux-notes.md) -- experimental Linux build, prerequisites, and known limitations
 - [Windows-specific notes](docs/windows-notes.md) -- feature comparison, known limitations, and troubleshooting
+- [Windows release track](docs/windows-release.md) -- unsigned internal candidates, zero-cost Store path, and acceptance gates
 - [Configuration files](docs/configuration.md) -- XDG paths, dotfiles, migration, and personal dictionaries
 - [Third-party notices](THIRD_PARTY_NOTICES.md) -- dependency and downloadable-model licenses
 - [Model sources and integrity manifest](docs/model-sources.md) -- pinned revisions, licenses, sizes, and SHA-256 checksums

--- a/docs/windows-notes.md
+++ b/docs/windows-notes.md
@@ -5,6 +5,9 @@ and notarized macOS artifacts only; the project does not publish an unsigned
 Windows installer. CI coverage is useful development evidence, not a promise
 of production support.
 
+The active zero-cost release strategy, candidate workflow, and clean-machine
+acceptance checklist live in [Windows release track](windows-release.md).
+
 ## Differences from macOS
 
 | Feature | macOS | Windows |

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -1,0 +1,145 @@
+# Windows release track
+
+Sagascript's Windows build is a release candidate, not a public release. The
+candidate workflow intentionally produces **unsigned** x64 artifacts for
+testing on an owner-controlled Windows PC. Do not publish those artifacts or
+tell users to bypass SmartScreen.
+
+## Zero-cost distribution decision
+
+The intended public path is a Microsoft Store MSIX submission. Microsoft signs
+Store-distributed MSIX packages and provides the trusted installation and
+update path without a separate code-signing subscription. Tauri currently
+produces NSIS and MSI installers for Sagascript; MSIX packaging is a separate
+follow-up after the native Windows behavior passes acceptance.
+
+References:
+
+- [Choose a Windows distribution path](https://learn.microsoft.com/windows/apps/package-and-deploy/choose-distribution-path)
+- [Publish a first Windows app](https://learn.microsoft.com/windows/apps/package-and-deploy/publish-first-app)
+- [SmartScreen reputation for developers](https://learn.microsoft.com/windows/apps/package-and-deploy/smartscreen-reputation)
+
+Direct website/GitHub distribution remains blocked for a normal public release
+while the installers are unsigned. An unsigned build may be used only as a
+clearly labelled internal candidate on a known test machine.
+
+## Candidate workflow
+
+`.github/workflows/windows-package.yml` runs the release metadata, license,
+frontend, Rust, and real CPU-transcription gates on `windows-latest`. It then
+builds unsigned NSIS and MSI installers plus the native executable and uploads
+them as a short-lived GitHub Actions artifact. It never creates or modifies a
+GitHub Release.
+
+`scripts/verify-windows-release.ps1` validates the executable surface,
+signature state, and deterministic checksums. `Internal` signature policy
+allows only a valid signature or a genuinely unsigned artifact. The future
+public pipeline must use `Release`, which requires every executable artifact to
+have a valid Authenticode signature.
+
+After installing an internally accepted candidate on the test PC, run the
+bundled CLI acceptance helper against the exact installed executable (replace
+the placeholder with the path reported by the installer):
+
+```powershell
+.\accept-windows-candidate.ps1 `
+  -AppExe "C:\path-reported-by-installer\sagascript.exe" `
+  -ExpectedVersion "1.1.3"
+```
+
+The helper downloads the recommended Norwegian test engine, transcribes only
+the bundled public fixture, and writes `windows-acceptance.json`. It records
+machine and timing evidence but never records a private microphone sample or
+stores transcript text. The installed path remains an acceptance finding until
+it has been observed on Windows; do not add it to documentation or `PATH`
+promises merely because an installer default was expected.
+
+## Initial support boundary
+
+- Windows 11 on x86-64.
+- CPU transcription using the recommended small language-specific engine.
+- One installed desktop app with system-tray UI and the canonical CLI commands.
+- No ARM64 promise and no GPU-acceleration promise in the first release.
+- Windows 10 may work but is not release-supported until separately accepted.
+
+## Clean-machine acceptance
+
+Record the Windows edition/build, CPU, RAM, microphone, and exact candidate
+artifact checksums. Start from a machine with no prior Sagascript installation,
+settings, model directory, or running process.
+
+### Installation and identity
+
+- SmartScreen identifies the candidate as unsigned; test only after independently
+  matching `SHA256SUMS-Windows` from the workflow artifact.
+- NSIS installation completes without development tools.
+- MSI installation completes without development tools.
+- Only one installer format is selected for the eventual Store/MSIX conversion.
+- Start-menu entry, application icon, publisher placeholder, version, install
+  location, and uninstall entry are coherent.
+- Uninstall removes program files and shortcuts. Record whether user settings
+  and downloaded models are retained.
+
+### First run and daily dictation
+
+- First launch explains local processing and downloads exactly one recommended
+  speech engine for English, Swedish, or Norwegian.
+- Download progress, checksum failure, retry, cancellation, and low-disk/network
+  failure states are recoverable.
+- The S icon is visible in the Windows system tray in idle state.
+- `Control+Shift+Space` starts/stops push-to-talk without opening or focusing the
+  settings window.
+- Recording, loading, transcribing, and error states remain understandable in
+  the tray/indicator.
+- Microphone denial or the Windows desktop-microphone privacy switch produces an
+  actionable recovery message.
+- Auto-paste works in Notepad, Word, and a browser text field. Clipboard fallback
+  preserves the transcript when simulated paste is blocked.
+- A normal, non-elevated Sagascript process must not claim it can paste into an
+  elevated target process.
+- Two language profiles and two shortcuts can be used without restart.
+- Closing settings leaves the tray process running; Quit exits every process.
+- Sagascript never opens its main window merely because the first dictation ran.
+
+### Accuracy, latency, and resilience
+
+- Complete at least ten short utterances in each of English, Swedish, and
+  Norwegian, including two consecutive transcriptions.
+- Record cold and warm key-release-to-paste latency for each language.
+- A 60-second recording finishes without UI lockup or a permanently busy state.
+- Interruptions, no default microphone, sleep/wake, audio-device changes, and a
+  second launch fail safely.
+- CPU usage, memory, fan noise, and battery impact are acceptable with the
+  recommended model; larger models remain Advanced/unsupported if they are not.
+
+### CLI, updates, and upgrade
+
+- The installed `sagascript.exe --version` reports the GUI version and source
+  revision.
+- `--help`, `list-models`, `config`, file transcription, microphone recording,
+  JSON output, and PowerShell completions work from the installed binary.
+- Decide and document whether the installer adds Sagascript to `PATH`; do not
+  imply a bare `sagascript` command works until this is verified.
+- Check for Updates reports checking/current/available/error and opens the exact
+  stable release page without claiming it installed anything.
+- An upgrade candidate preserves settings, profiles, glossary, and downloaded
+  engines and does not create duplicate startup/tray entries.
+
+## Public-release gates
+
+Before removing the candidate warning:
+
+1. All automated Windows candidate checks pass without `continue-on-error`.
+2. Clean-machine acceptance is recorded against the exact commit and hashes.
+3. A Microsoft Store account and product identity are ready at no recurring
+   signing cost.
+4. The accepted installer is converted to MSIX and tested through Store flighting.
+5. Store certification passes and the Store-delivered package is installed on a
+   clean machine.
+6. The website Windows button points to the Store listing only after readback.
+
+Creating the Store product identity is an owner action. Do not store Microsoft
+passwords, session material, recovery codes, or signing credentials in this
+repository. The MSIX manifest's Store-assigned identity values must be copied
+from the exact Partner Center product record when that record exists; do not
+guess them in advance.

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -27,9 +27,12 @@ clearly labelled internal candidate on a known test machine.
 
 `.github/workflows/windows-package.yml` runs the release metadata, license,
 frontend, Rust, and real CPU-transcription gates on `windows-latest`. It then
-builds unsigned NSIS and MSI installers plus the native executable and uploads
-them as a short-lived GitHub Actions artifact. It never creates or modifies a
-GitHub Release.
+builds unsigned NSIS and MSI installers, a portable desktop executable, and a
+separate console CLI executable. It uploads them as one short-lived GitHub
+Actions artifact and never creates or modifies a GitHub Release. Windows GUI
+executables do not reliably expose redirected console output, so the candidate
+keeps the desktop and CLI launch surfaces explicit instead of pretending one
+file behaves identically in both contexts.
 
 `scripts/verify-windows-release.ps1` validates the executable surface,
 signature state, and deterministic checksums. `Internal` signature policy
@@ -38,12 +41,12 @@ public pipeline must use `Release`, which requires every executable artifact to
 have a valid Authenticode signature.
 
 After installing an internally accepted candidate on the test PC, run the
-bundled CLI acceptance helper against the exact installed executable (replace
-the placeholder with the path reported by the installer):
+bundled CLI acceptance helper against the CLI executable from the same workflow
+artifact:
 
 ```powershell
 .\accept-windows-candidate.ps1 `
-  -AppExe "C:\path-reported-by-installer\sagascript.exe" `
+  -CliExe ".\Sagascript-Windows-x64-CLI.exe" `
   -ExpectedVersion "1.1.3"
 ```
 
@@ -58,7 +61,9 @@ promises merely because an installer default was expected.
 
 - Windows 11 on x86-64.
 - CPU transcription using the recommended small language-specific engine.
-- One installed desktop app with system-tray UI and the canonical CLI commands.
+- One installed desktop app with system-tray UI plus a candidate CLI executable
+  exposing the canonical commands. Installer/PATH integration remains a public-
+  release decision.
 - No ARM64 promise and no GPU-acceleration promise in the first release.
 - Windows 10 may work but is not release-supported until separately accepted.
 
@@ -114,11 +119,12 @@ settings, model directory, or running process.
 
 ### CLI, updates, and upgrade
 
-- The installed `sagascript.exe --version` reports the GUI version and source
-  revision.
+- `Sagascript-Windows-x64-CLI.exe --version` reports the candidate version and
+  source revision.
 - `--help`, `list-models`, `config`, file transcription, microphone recording,
-  JSON output, and PowerShell completions work from the installed binary.
-- Decide and document whether the installer adds Sagascript to `PATH`; do not
+  JSON output, and PowerShell completions work from the candidate CLI binary.
+- Decide and document how the CLI is installed and whether it is added to
+  `PATH`; do not
   imply a bare `sagascript` command works until this is verified.
 - Check for Updates reports checking/current/available/error and opens the exact
   stable release page without claiming it installed anything.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "node scripts/build-frontend.mjs",
-    "test:frontend": "node --test scripts/test-*.mjs",
+    "test:frontend": "node scripts/run-frontend-tests.mjs",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "release:check": "node scripts/check-release.mjs",

--- a/scripts/accept-windows-candidate.ps1
+++ b/scripts/accept-windows-candidate.ps1
@@ -1,0 +1,131 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExe,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+
+    [string]$Fixture = (Join-Path $PSScriptRoot "norwegian-short-3s.mp3"),
+
+    [string]$OutputPath = (Join-Path (Get-Location).Path "windows-acceptance.json")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-NonemptyFile {
+    param([string]$Path, [string]$Label)
+
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($item.PSIsContainer -or $item.Length -le 0) {
+        throw "$Label must be a non-empty file: $Path"
+    }
+    return $item.FullName
+}
+
+function Invoke-Sagascript {
+    param([string]$Executable, [string[]]$Arguments)
+
+    $output = & $Executable @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "Sagascript $($Arguments -join ' ') failed with exit code $exitCode`n$($output -join "`n")"
+    }
+    return ($output -join "`n")
+}
+
+if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+    throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
+}
+
+$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$fixturePath = Resolve-NonemptyFile -Path $Fixture -Label "Fixture"
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
+$outputParent = [System.IO.Path]::GetDirectoryName($outputFullPath)
+if (-not [System.IO.Directory]::Exists($outputParent)) {
+    throw "Acceptance output directory does not exist: $outputParent"
+}
+
+$versionOutput = Invoke-Sagascript -Executable $appExePath -Arguments @("--version")
+$versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
+if ($versionOutput -notmatch $versionPattern) {
+    throw "Installed executable did not report expected version $ExpectedVersion`: $versionOutput"
+}
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("--help"))
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("list-models"))
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("config", "path"))
+
+$downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("download-model", "nb-whisper-tiny"))
+$downloadTimer.Stop()
+
+$transcriptTemp = Join-Path ([System.IO.Path]::GetTempPath()) ("sagascript-acceptance-{0}.json" -f [guid]::NewGuid())
+try {
+    $transcriptionTimer = [System.Diagnostics.Stopwatch]::StartNew()
+    & $appExePath transcribe `
+        --language no `
+        --model nb-whisper-tiny `
+        --beam 0 `
+        --json `
+        $fixturePath > $transcriptTemp
+    $transcriptionExit = $LASTEXITCODE
+    $transcriptionTimer.Stop()
+    if ($transcriptionExit -ne 0) {
+        throw "Installed-file transcription failed with exit code $transcriptionExit"
+    }
+
+    $result = Get-Content -LiteralPath $transcriptTemp -Raw | ConvertFrom-Json
+    if ($result.language -ne "no") {
+        throw "Expected Norwegian transcription result, got '$($result.language)'"
+    }
+    if ($result.text -notmatch "(?i)storting") {
+        throw "Expected 'storting' in the public-fixture transcript"
+    }
+    if (-not $result.segments) {
+        throw "Expected at least one transcription segment"
+    }
+
+    $os = Get-CimInstance Win32_OperatingSystem
+    $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+    $computer = Get-CimInstance Win32_ComputerSystem
+    $report = [ordered]@{
+        schema_version = 1
+        accepted_at_utc = [DateTime]::UtcNow.ToString("o")
+        expected_version = $ExpectedVersion
+        reported_version = $versionOutput.Trim()
+        source_fixture_sha256 = (Get-FileHash -LiteralPath $fixturePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        download_seconds = [Math]::Round($downloadTimer.Elapsed.TotalSeconds, 3)
+        transcription_seconds = [Math]::Round($transcriptionTimer.Elapsed.TotalSeconds, 3)
+        detected_language = $result.language
+        segment_count = @($result.segments).Count
+        windows = [ordered]@{
+            caption = $os.Caption
+            version = $os.Version
+            build_number = $os.BuildNumber
+            architecture = $os.OSArchitecture
+        }
+        hardware = [ordered]@{
+            processor = $cpu.Name.Trim()
+            logical_processors = $cpu.NumberOfLogicalProcessors
+            memory_gib = [Math]::Round($computer.TotalPhysicalMemory / 1GB, 2)
+        }
+        automated_cli_acceptance = "pass"
+        manual_gui_acceptance = "required"
+    }
+
+    $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText(
+        $outputFullPath,
+        (($report | ConvertTo-Json -Depth 5) + "`n"),
+        $utf8WithoutBom
+    )
+} finally {
+    Remove-Item -LiteralPath $transcriptTemp -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Automated installed-CLI acceptance passed"
+Write-Host "Evidence: $outputFullPath"
+Write-Host "Continue with the manual tray, microphone, hotkey, paste, focus, and uninstall checklist in README-Windows-Candidate.md"

--- a/scripts/accept-windows-candidate.ps1
+++ b/scripts/accept-windows-candidate.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string]$AppExe,
+    [string]$CliExe,
 
     [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
@@ -41,7 +41,7 @@ if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+
     throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
 }
 
-$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$cliExePath = Resolve-NonemptyFile -Path $CliExe -Label "CliExe"
 $fixturePath = Resolve-NonemptyFile -Path $Fixture -Label "Fixture"
 $outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
 $outputParent = [System.IO.Path]::GetDirectoryName($outputFullPath)
@@ -49,23 +49,23 @@ if (-not [System.IO.Directory]::Exists($outputParent)) {
     throw "Acceptance output directory does not exist: $outputParent"
 }
 
-$versionOutput = Invoke-Sagascript -Executable $appExePath -Arguments @("--version")
+$versionOutput = Invoke-Sagascript -Executable $cliExePath -Arguments @("--version")
 $versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
 if ($versionOutput -notmatch $versionPattern) {
-    throw "Installed executable did not report expected version $ExpectedVersion`: $versionOutput"
+    throw "CLI executable did not report expected version $ExpectedVersion`: $versionOutput"
 }
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("--help"))
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("list-models"))
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("config", "path"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("--help"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("list-models"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("config", "path"))
 
 $downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("download-model", "nb-whisper-tiny"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("download-model", "nb-whisper-tiny"))
 $downloadTimer.Stop()
 
 $transcriptTemp = Join-Path ([System.IO.Path]::GetTempPath()) ("sagascript-acceptance-{0}.json" -f [guid]::NewGuid())
 try {
     $transcriptionTimer = [System.Diagnostics.Stopwatch]::StartNew()
-    & $appExePath transcribe `
+    & $cliExePath transcribe `
         --language no `
         --model nb-whisper-tiny `
         --beam 0 `

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -18,6 +18,10 @@ function compareCodeUnits(a, b) {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+function normalizeNewlines(text) {
+  return text.replace(/\r\n?/g, "\n");
+}
+
 function npmInstallationError(pkg, installedVersion, directoryExists) {
   const path = relative(root, pkg.directory);
   if (!directoryExists) {
@@ -76,9 +80,20 @@ if (mode === "--test-npm-installation") {
   process.exit(0);
 }
 
+if (mode === "--test-newline-normalization") {
+  const lf = "first\nsecond\n";
+  for (const candidate of [lf, "first\r\nsecond\r\n", "first\rsecond\r"]) {
+    if (normalizeNewlines(candidate) !== lf) {
+      throw new Error("Generated notice comparison is not newline-stable");
+    }
+  }
+  console.log("newline normalization passed");
+  process.exit(0);
+}
+
 if (!new Set(["--check", "--write"]).has(mode)) {
   console.error(
-    "Usage: node scripts/generate-third-party-notices.mjs --check|--write|--test-sort|--test-npm-installation",
+    "Usage: node scripts/generate-third-party-notices.mjs --check|--write|--test-sort|--test-npm-installation|--test-newline-normalization",
   );
   process.exit(2);
 }
@@ -372,7 +387,7 @@ if (mode === "--write") {
   writeFileSync(outputPath, generated);
   console.log(`Wrote ${relative(root, outputPath)} (${rustPackages.length} Rust, ${npmPackages.length} npm packages)`);
 } else {
-  if (!existsSync(outputPath) || readFileSync(outputPath, "utf8") !== generated) {
+  if (!existsSync(outputPath) || normalizeNewlines(readFileSync(outputPath, "utf8")) !== generated) {
     console.error("THIRD_PARTY_NOTICES.md is stale; run npm run licenses:generate and review the diff");
     process.exit(1);
   }

--- a/scripts/run-frontend-tests.mjs
+++ b/scripts/run-frontend-tests.mjs
@@ -1,0 +1,26 @@
+import { readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDirectory = fileURLToPath(new URL(".", import.meta.url));
+const tests = readdirSync(scriptsDirectory)
+  .filter((name) => /^test-.*\.mjs$/.test(name))
+  .sort()
+  .map((name) => join(scriptsDirectory, name));
+
+if (tests.length === 0) {
+  console.error("No frontend tests found in scripts/");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, ["--test", ...tests], {
+  stdio: "inherit",
+});
+
+if (result.error) throw result.error;
+if (result.status === null) {
+  console.error(`Frontend tests terminated by signal ${result.signal ?? "unknown"}`);
+  process.exit(1);
+}
+process.exit(result.status);

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -21,6 +21,9 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /windows-x64-unsigned-candidate/);
   assert.match(workflow, /accept-windows-candidate\.ps1/);
   assert.match(workflow, /norwegian-short-3s\.mp3/);
+  assert.match(workflow, /Sagascript-Windows-x64-Portable\.exe/);
+  assert.match(workflow, /Sagascript-Windows-x64-CLI\.exe/);
+  assert.match(workflow, /-CliExe "artifacts\\Sagascript-Windows-x64-CLI\.exe"/);
   assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
 });
 

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../.github/workflows/windows-package.yml", import.meta.url),
+  "utf8",
+);
+const releaseGuide = await readFile(
+  new URL("../docs/windows-release.md", import.meta.url),
+  "utf8",
+);
+
+test("Windows candidate workflow stays non-publishing and explicitly unsigned", () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /permissions:\s*\n\s*contents: read/);
+  assert.match(workflow, /tauri build --ci --bundles nsis,msi --no-sign/);
+  assert.match(workflow, /SignaturePolicy Internal/);
+  assert.match(workflow, /windows-x64-unsigned-candidate/);
+  assert.match(workflow, /accept-windows-candidate\.ps1/);
+  assert.match(workflow, /norwegian-short-3s\.mp3/);
+  assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
+});
+
+test("Windows candidate makes real transcription a blocking gate", () => {
+  const gateStart = workflow.indexOf("name: Gate real Windows transcription");
+  const buildStart = workflow.indexOf("name: Build unsigned internal installers");
+  assert.ok(gateStart >= 0 && buildStart > gateStart);
+  const gate = workflow.slice(gateStart, buildStart);
+  assert.match(gate, /download-model nb-whisper-tiny/);
+  assert.match(gate, /verify-json-cli-streams\.py/);
+  assert.doesNotMatch(gate, /continue-on-error/);
+});
+
+test("Windows release guide forbids publishing unsigned candidates", () => {
+  assert.match(releaseGuide, /Do not publish those artifacts/);
+  assert.match(releaseGuide, /Microsoft Store MSIX/);
+  assert.match(releaseGuide, /Release[^\n]*requires every executable artifact/i);
+});

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const workflow = await readFile(
   new URL("../.github/workflows/windows-package.yml", import.meta.url),
@@ -36,4 +38,16 @@ test("Windows release guide forbids publishing unsigned candidates", () => {
   assert.match(releaseGuide, /Do not publish those artifacts/);
   assert.match(releaseGuide, /Microsoft Store MSIX/);
   assert.match(releaseGuide, /Release[^\n]*requires every executable artifact/i);
+});
+
+test("third-party notice comparison accepts Windows checkout line endings", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      fileURLToPath(new URL("./generate-third-party-notices.mjs", import.meta.url)),
+      "--test-newline-normalization",
+    ],
+    { encoding: "utf8" },
+  );
+  assert.match(output, /newline normalization passed/);
 });

--- a/scripts/verify-windows-release.ps1
+++ b/scripts/verify-windows-release.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string]$AppExe,
+    [string]$CliExe,
 
     [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
@@ -39,7 +39,7 @@ function Resolve-NonemptyFile {
     return $item.FullName
 }
 
-function Invoke-AppProbe {
+function Invoke-CliProbe {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Executable,
@@ -66,7 +66,7 @@ if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) 
     throw "Get-AuthenticodeSignature is unavailable; run this verifier on Windows"
 }
 
-$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$cliExePath = Resolve-NonemptyFile -Path $CliExe -Label "CliExe"
 $pathSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 $nameSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 $artifactByName = @{}
@@ -84,16 +84,16 @@ foreach ($artifact in $Artifacts) {
     $artifactByName[$basename] = $resolved
 }
 
-if (-not $pathSet.Contains($appExePath)) {
-    throw "AppExe must also appear in Artifacts: $appExePath"
+if (-not $pathSet.Contains($cliExePath)) {
+    throw "CliExe must also appear in Artifacts: $cliExePath"
 }
 
-$versionOutput = Invoke-AppProbe -Executable $appExePath -Argument "--version"
+$versionOutput = Invoke-CliProbe -Executable $cliExePath -Argument "--version"
 $versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
 if ($versionOutput -notmatch $versionPattern) {
     throw "Version output does not contain exact version '$ExpectedVersion': $versionOutput"
 }
-[void](Invoke-AppProbe -Executable $appExePath -Argument "--help")
+[void](Invoke-CliProbe -Executable $cliExePath -Argument "--help")
 Write-Host "Executable probes passed for Sagascript $ExpectedVersion"
 
 foreach ($basename in $artifactByName.Keys) {

--- a/scripts/verify-windows-release.ps1
+++ b/scripts/verify-windows-release.ps1
@@ -1,0 +1,141 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExe,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$Artifacts,
+
+    [ValidateSet("Internal", "Release")]
+    [string]$SignaturePolicy = "Internal",
+
+    [string]$ChecksumOutput = "SHA256SUMS-Windows"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-NonemptyFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label
+    )
+
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($item.PSIsContainer) {
+        throw "$Label is not a file: $Path"
+    }
+    if ($item.Length -le 0) {
+        throw "$Label is empty: $Path"
+    }
+    return $item.FullName
+}
+
+function Invoke-AppProbe {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Executable,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Argument
+    )
+
+    $output = & $Executable $Argument 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "'$Executable $Argument' exited with code $exitCode"
+    }
+    return ($output -join "`n")
+}
+
+if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+    throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
+}
+if ($Artifacts.Count -eq 0) {
+    throw "Artifacts must contain at least one file"
+}
+if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) {
+    throw "Get-AuthenticodeSignature is unavailable; run this verifier on Windows"
+}
+
+$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$pathSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+$nameSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+$artifactByName = @{}
+
+foreach ($artifact in $Artifacts) {
+    $resolved = Resolve-NonemptyFile -Path $artifact -Label "Artifact"
+    if (-not $pathSet.Add($resolved)) {
+        throw "Duplicate artifact path after resolution: $resolved"
+    }
+
+    $basename = [System.IO.Path]::GetFileName($resolved)
+    if (-not $nameSet.Add($basename)) {
+        throw "Duplicate artifact basename: $basename"
+    }
+    $artifactByName[$basename] = $resolved
+}
+
+if (-not $pathSet.Contains($appExePath)) {
+    throw "AppExe must also appear in Artifacts: $appExePath"
+}
+
+$versionOutput = Invoke-AppProbe -Executable $appExePath -Argument "--version"
+$versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
+if ($versionOutput -notmatch $versionPattern) {
+    throw "Version output does not contain exact version '$ExpectedVersion': $versionOutput"
+}
+[void](Invoke-AppProbe -Executable $appExePath -Argument "--help")
+Write-Host "Executable probes passed for Sagascript $ExpectedVersion"
+
+foreach ($basename in $artifactByName.Keys) {
+    $artifactPath = $artifactByName[$basename]
+    $signature = Get-AuthenticodeSignature -FilePath $artifactPath -ErrorAction Stop
+    $status = $signature.Status.ToString()
+    $valid = $status -eq "Valid"
+    $allowedInternal = $valid -or $status -eq "NotSigned"
+
+    if ($SignaturePolicy -eq "Release" -and -not $valid) {
+        throw "Release artifact '$basename' does not have a valid Authenticode signature (status: $status)"
+    }
+    if ($SignaturePolicy -eq "Internal" -and -not $allowedInternal) {
+        throw "Internal artifact '$basename' has an unsafe signature state: $status"
+    }
+}
+Write-Host "Authenticode checks passed under $SignaturePolicy policy"
+
+$sortedNames = [string[]]$artifactByName.Keys
+[Array]::Sort($sortedNames, [System.StringComparer]::OrdinalIgnoreCase)
+$checksumLines = foreach ($basename in $sortedNames) {
+    $hash = (Get-FileHash -LiteralPath $artifactByName[$basename] -Algorithm SHA256).Hash.ToLowerInvariant()
+    "$hash  $basename"
+}
+
+if ([System.IO.Path]::IsPathRooted($ChecksumOutput)) {
+    $checksumPath = [System.IO.Path]::GetFullPath($ChecksumOutput)
+} else {
+    $checksumPath = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $ChecksumOutput))
+}
+$checksumParent = [System.IO.Path]::GetDirectoryName($checksumPath)
+if (-not [System.IO.Directory]::Exists($checksumParent)) {
+    throw "Checksum output directory does not exist: $checksumParent"
+}
+
+# Windows PowerShell 5.1's UTF8 encoding adds a BOM, so use .NET directly.
+$utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText(
+    $checksumPath,
+    (($checksumLines -join "`n") + "`n"),
+    $utf8WithoutBom
+)
+
+Write-Host "Verified $($Artifacts.Count) Windows artifacts"
+Write-Host "Checksums: $checksumPath"

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -25,6 +25,9 @@ pub const NATIVE_LOG_SUPPRESSION: &str =
 pub const DEFAULT_CLI_LOG_FILTER: &str =
     "warn,whisper_rs::whisper_logging_hook=error,whisper_rs::ggml_logging_hook=error";
 
+#[cfg(target_os = "windows")]
+const WINDOWS_INFERENCE_STACK_BYTES: usize = 16 * 1024 * 1024;
+
 /// Preserve an application's requested log level without accidentally opting
 /// into noisy native Whisper/GGML diagnostics. Native logging is enabled only
 /// when the filter names `whisper_rs` explicitly.
@@ -457,9 +460,10 @@ pub fn run(cli: Cli) {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
 
     let result = match cli.command.unwrap() {
-        Command::Transcribe(args) => transcribe::run(args),
+        Command::Transcribe(args) =>
+            run_inference_command("transcribe", move || transcribe::run(args)),
         #[cfg(feature = "record")]
-        Command::Record(args) => record::run(args),
+        Command::Record(args) => run_inference_command("record", move || record::run(args)),
         Command::ListModels(args) => models::list(args),
         Command::DownloadModel(args) => rt.block_on(models::download(args)),
         Command::DeleteModel(args) => models::delete(args),
@@ -490,6 +494,39 @@ pub fn run(cli: Cli) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }
+}
+
+#[cfg(target_os = "windows")]
+fn run_inference_command(
+    command: &'static str,
+    task: impl FnOnce() -> Result<(), sagascript_core::error::DictationError> + Send + 'static,
+) -> Result<(), sagascript_core::error::DictationError> {
+    // MSVC executables start with a much smaller main-thread stack than the
+    // worker threads used by the desktop app. Whisper inference exhausted it
+    // with STATUS_STACK_OVERFLOW (0xC00000FD) in the real Windows CI gate.
+    std::thread::Builder::new()
+        .name(format!("sagascript-cli-{command}"))
+        .stack_size(WINDOWS_INFERENCE_STACK_BYTES)
+        .spawn(task)
+        .map_err(|error| {
+            sagascript_core::error::DictationError::ApplicationLaunchError(format!(
+                "Failed to start Windows {command} worker: {error}"
+            ))
+        })?
+        .join()
+        .map_err(|_| {
+            sagascript_core::error::DictationError::TranscriptionFailed(format!(
+                "Windows {command} worker terminated unexpectedly"
+            ))
+        })?
+}
+
+#[cfg(not(target_os = "windows"))]
+fn run_inference_command(
+    _command: &'static str,
+    task: impl FnOnce() -> Result<(), sagascript_core::error::DictationError>,
+) -> Result<(), sagascript_core::error::DictationError> {
+    task()
 }
 
 fn formats() {
@@ -561,6 +598,21 @@ fn render_manpage_tree(cmd: &clap::Command, dir: &PathBuf) -> Result<(), io::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_inference_command_has_a_large_named_worker_stack() {
+        run_inference_command("stack-test", || {
+            let stack_probe = [0_u8; 4 * 1024 * 1024];
+            assert_eq!(
+                std::thread::current().name(),
+                Some("sagascript-cli-stack-test")
+            );
+            std::hint::black_box(&stack_probe);
+            Ok(())
+        })
+        .unwrap();
+    }
 
     #[test]
     fn log_filter_suppresses_native_diagnostics_by_default() {


### PR DESCRIPTION
## Summary

- add a non-publishing Windows x64 candidate workflow for NSIS, MSI, and the native executable
- make real local Norwegian transcription a blocking Windows CI gate
- verify CLI/version, Authenticode state, and deterministic SHA-256 manifests
- add an installed-machine acceptance helper and clean Windows 11 checklist
- document the zero-cost public path through Microsoft Store/MSIX

## Safety boundary

The workflow uploads a short-lived, explicitly unsigned internal artifact. It does not create a GitHub Release and the artifacts must not be publicly distributed.

## Verification

- `actionlint .github/workflows/windows-package.yml`
- PowerShell syntax parsing for both new scripts
- verifier positive and negative paths
- `npm run release:check`
- `npm run licenses:check`
- `npm run test:frontend`
- `npm run check`
- `npm run build`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build -p sagascript-cli --no-default-features`
- workspace tests pass with the unchanged headless macOS pasteboard integration test excluded

## Next gate

Download this PR's `windows-x64-unsigned-candidate` Actions artifact and run the documented clean-machine acceptance on the owner-controlled Windows 11 test PC.
