### PR TITLE
chore: record daily release download metrics

### DIFF
--- a/.github/workflows/download-metrics.yml
+++ b/.github/workflows/download-metrics.yml
@@ -1,0 +1,73 @@
+name: Download metrics
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: download-metrics
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Test snapshot normalizer
+        run: node --test scripts/test-record-release-downloads.mjs
+
+      - name: Fetch and normalize public release downloads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          captured_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            > "$RUNNER_TEMP/release-pages.json"
+          jq 'add' "$RUNNER_TEMP/release-pages.json" > "$RUNNER_TEMP/releases.json"
+          node scripts/record-release-downloads.mjs \
+            --input "$RUNNER_TEMP/releases.json" \
+            --output "$RUNNER_TEMP/snapshot.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --captured-at "$captured_at"
+          echo "SNAPSHOT_DATE=${captured_at%%T*}" >> "$GITHUB_ENV"
+
+      - name: Commit snapshot to metrics branch
+        run: |
+          if git ls-remote --exit-code --heads origin refs/heads/metrics/downloads > /dev/null; then
+            git fetch --no-tags origin refs/heads/metrics/downloads
+            git switch --detach FETCH_HEAD
+          else
+            status=$?
+            if [[ "$status" -ne 2 ]]; then
+              exit "$status"
+            fi
+            git switch -c metrics-downloads-data
+          fi
+
+          snapshot="metrics/downloads/${SNAPSHOT_DATE}.json"
+          mkdir -p "$(dirname "$snapshot")"
+          cp "$RUNNER_TEMP/snapshot.json" "$snapshot"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "$snapshot"
+          if git diff --cached --quiet; then
+            echo "Snapshot is already current for ${SNAPSHOT_DATE}."
+            exit 0
+          fi
+          git commit -m "metrics: record downloads ${SNAPSHOT_DATE}"
+          git push origin HEAD:refs/heads/metrics/downloads

--- a/metrics/downloads/2026-09-03.json
+++ b/metrics/downloads/2026-09-03.json
@@ -1,0 +1,470 @@
+{
+  "schema_version": 1,
+  "repository": "Magnus-Gille/sagascript",
+  "captured_at": "2026-09-03T13:44:08.000Z",
+  "snapshot_date": "2026-09-03",
+  "totals": {
+    "all_assets": 74,
+    "app_downloads": 61,
+    "dmg_downloads": 49,
+    "updater_downloads": 12,
+    "windows_downloads": 0
+  },
+  "releases": [
+    {
+      "tag_name": "v0.0.1",
+      "published_at": "2026-02-24T15:36:51.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "Sagascript-Setup.exe",
+          "content_type": "application/x-msdos-program",
+          "size": 4485453,
+          "download_count": 0
+        },
+        {
+          "name": "Sagascript-Setup.msi",
+          "content_type": "application/x-msdownload",
+          "size": 6823936,
+          "download_count": 0
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 17288794,
+          "download_count": 5
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.0",
+      "published_at": "2026-07-12T11:53:21.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 14878254,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16346877,
+          "download_count": 4
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 160302,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540357,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 702534,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.1",
+      "published_at": "2026-07-14T22:12:20.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 14869984,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16336925,
+          "download_count": 5
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 160303,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540357,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 702534,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.2",
+      "published_at": "2026-07-30T12:21:49.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 14884670,
+          "download_count": 0
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16352778,
+          "download_count": 4
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 161713,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540357,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 702534,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.4",
+      "published_at": "2026-07-31T15:23:07.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 14888560,
+          "download_count": 2
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16353493,
+          "download_count": 3
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 160577,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540357,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 702534,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.5",
+      "published_at": "2026-08-16T13:47:02.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 14959555,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16408391,
+          "download_count": 3
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 160579,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540504,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 703054,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.6",
+      "published_at": "2026-08-16T16:28:52.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 15018389,
+          "download_count": 0
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16469368,
+          "download_count": 1
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 161051,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540504,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 703054,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.7",
+      "published_at": "2026-08-17T16:32:41.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 15018831,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16473819,
+          "download_count": 1
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 161051,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540504,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 703054,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.8",
+      "published_at": "2026-08-18T08:10:47.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 15020321,
+          "download_count": 1
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16472542,
+          "download_count": 2
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 161052,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540548,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 703222,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.0.9",
+      "published_at": "2026-08-19T07:39:45.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 3
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 15314389,
+          "download_count": 2
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 16776955,
+          "download_count": 8
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 161054,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540595,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 703398,
+          "download_count": 0
+        }
+      ]
+    },
+    {
+      "tag_name": "v1.1.3",
+      "published_at": "2026-09-03T08:47:02.000Z",
+      "prerelease": false,
+      "assets": [
+        {
+          "name": "SHA256SUMS",
+          "content_type": "application/octet-stream",
+          "size": 169,
+          "download_count": 2
+        },
+        {
+          "name": "Sagascript.app.tar.gz",
+          "content_type": "application/gzip",
+          "size": 14182200,
+          "download_count": 3
+        },
+        {
+          "name": "Sagascript.dmg",
+          "content_type": "application/x-apple-diskimage",
+          "size": 14270149,
+          "download_count": 13
+        },
+        {
+          "name": "sbom-full.cdx.json",
+          "content_type": "application/json",
+          "size": 161659,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.cdx.json",
+          "content_type": "application/json",
+          "size": 540698,
+          "download_count": 0
+        },
+        {
+          "name": "sbom-rust.spdx.json",
+          "content_type": "application/json",
+          "size": 703753,
+          "download_count": 0
+        }
+      ]
+    }
+  ]
+}

--- a/metrics/downloads/README.md
+++ b/metrics/downloads/README.md
@@ -1,0 +1,12 @@
+# Release download metrics
+
+GitHub exposes cumulative counters for release assets, not unique users or the time of each
+download. The scheduled `download-metrics.yml` workflow therefore records one UTC snapshot
+per day so changes can be calculated from that point forward.
+
+The first snapshot is versioned with the implementation. Later snapshots are committed by
+`github-actions[bot]` to the dedicated `metrics/downloads` branch, keeping generated daily
+data off `main`.
+
+Each JSON file contains all public releases and assets plus convenience totals for Sagascript
+distribution files. Draft releases are excluded; public prereleases are included.

--- a/scripts/record-release-downloads.mjs
+++ b/scripts/record-release-downloads.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ISO_TIMESTAMP =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const compareStrings = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
+
+function isoTimestamp(value, label) {
+  if (typeof value !== "string") {
+    throw new TypeError(`${label} must be an ISO 8601 timestamp`);
+  }
+
+  const parts = value.match(ISO_TIMESTAMP);
+  const milliseconds = Date.parse(value);
+  if (!parts || !Number.isFinite(milliseconds)) {
+    throw new TypeError(`${label} must be an ISO 8601 timestamp with a time zone`);
+  }
+
+  const [, year, month, day, hour, minute, second] = parts.map(Number);
+  const calendarDate = new Date(Date.UTC(year, month - 1, day));
+  const validCalendarDate =
+    calendarDate.getUTCFullYear() === year &&
+    calendarDate.getUTCMonth() === month - 1 &&
+    calendarDate.getUTCDate() === day;
+  if (!validCalendarDate || hour > 23 || minute > 59 || second > 59) {
+    throw new TypeError(`${label} must be a valid ISO 8601 timestamp`);
+  }
+
+  return new Date(milliseconds).toISOString();
+}
+
+function nonNegativeInteger(value, label) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TypeError(`${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function normalizeAsset(asset, label) {
+  if (asset === null || typeof asset !== "object" || Array.isArray(asset)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+  if (typeof asset.name !== "string" || asset.name.length === 0) {
+    throw new TypeError(`${label}.name must be a non-empty string`);
+  }
+  if (typeof asset.content_type !== "string") {
+    throw new TypeError(`${label}.content_type must be a string`);
+  }
+
+  return {
+    name: asset.name,
+    content_type: asset.content_type,
+    size: nonNegativeInteger(asset.size, `${label}.size`),
+    download_count: nonNegativeInteger(asset.download_count, `${label}.download_count`),
+  };
+}
+
+function normalizeRelease(release, index) {
+  const label = `releases[${index}]`;
+  if (release === null || typeof release !== "object" || Array.isArray(release)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+  if (typeof release.tag_name !== "string" || release.tag_name.length === 0) {
+    throw new TypeError(`${label}.tag_name must be a non-empty string`);
+  }
+  if (typeof release.prerelease !== "boolean") {
+    throw new TypeError(`${label}.prerelease must be a boolean`);
+  }
+  if (!Array.isArray(release.assets)) {
+    throw new TypeError(`${label}.assets must be an array`);
+  }
+
+  return {
+    tag_name: release.tag_name,
+    published_at: isoTimestamp(release.published_at, `${label}.published_at`),
+    prerelease: release.prerelease,
+    assets: release.assets
+      .map((asset, assetIndex) => normalizeAsset(asset, `${label}.assets[${assetIndex}]`))
+      .sort((left, right) => compareStrings(left.name, right.name)),
+  };
+}
+
+function calculateTotals(releases) {
+  const totals = {
+    all_assets: 0,
+    app_downloads: 0,
+    dmg_downloads: 0,
+    updater_downloads: 0,
+    windows_downloads: 0,
+  };
+
+  for (const { assets } of releases) {
+    for (const asset of assets) {
+      const downloads = asset.download_count;
+      const windows = /\.(?:exe|msi)$/i.test(asset.name);
+      const dmg = asset.name === "Sagascript.dmg";
+      const updater = asset.name === "Sagascript.app.tar.gz";
+
+      totals.all_assets += downloads;
+      if (dmg) totals.dmg_downloads += downloads;
+      if (updater) totals.updater_downloads += downloads;
+      if (windows) totals.windows_downloads += downloads;
+      if (dmg || updater || windows) totals.app_downloads += downloads;
+    }
+  }
+
+  return totals;
+}
+
+export function createSnapshot(input, repository, capturedAt = new Date().toISOString()) {
+  if (!Array.isArray(input)) {
+    throw new TypeError("GitHub releases input must be an array");
+  }
+  if (typeof repository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(repository)) {
+    throw new TypeError("repository must have the form owner/repo");
+  }
+
+  const captured_at = isoTimestamp(capturedAt, "captured-at");
+  const releases = input
+    .filter((release) => release?.draft === false)
+    .map(normalizeRelease)
+    .sort(
+      (left, right) =>
+        compareStrings(left.published_at, right.published_at) ||
+        compareStrings(left.tag_name, right.tag_name),
+    );
+
+  return {
+    schema_version: 1,
+    repository,
+    captured_at,
+    snapshot_date: captured_at.slice(0, 10),
+    totals: calculateTotals(releases),
+    releases,
+  };
+}
+
+function parseArguments(arguments_) {
+  const allowed = new Set(["--input", "--output", "--repository", "--captured-at"]);
+  const required = ["--input", "--output", "--repository"];
+  const parsed = new Map();
+
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const flag = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!allowed.has(flag)) throw new Error(`Unknown flag: ${flag ?? "<missing>"}`);
+    if (parsed.has(flag)) throw new Error(`Duplicate flag: ${flag}`);
+    if (value === undefined || value.startsWith("--")) throw new Error(`Missing value for ${flag}`);
+    parsed.set(flag, value);
+  }
+
+  for (const flag of required) {
+    if (!parsed.has(flag)) throw new Error(`Missing required flag: ${flag}`);
+  }
+  return parsed;
+}
+
+function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const inputPath = arguments_.get("--input");
+  const outputPath = arguments_.get("--output");
+  const input = JSON.parse(readFileSync(inputPath, "utf8"));
+  const snapshot = createSnapshot(
+    input,
+    arguments_.get("--repository"),
+    arguments_.get("--captured-at") ?? new Date().toISOString(),
+  );
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/test-record-release-downloads.mjs
+++ b/scripts/test-record-release-downloads.mjs
@@ -110,14 +110,71 @@ test("rejects malformed timestamps and asset counters", () => {
   }
 });
 
-test("CLI rejects unknown flags", () => {
+test("rejects malformed repository, release, and asset fields", () => {
+  const capturedAt = "2026-09-03T00:00:00Z";
+  assert.throws(() => createSnapshot([], "missing-slash", capturedAt), /owner\/repo/);
+
+  for (const [input, expected] of [
+    [[release("", "2026-09-01T00:00:00Z")], /tag_name.*non-empty string/],
+    [
+      [release("v1", "2026-09-01T00:00:00Z", [], { prerelease: "false" })],
+      /prerelease.*boolean/,
+    ],
+    [[release("v1", "2026-09-01T00:00:00Z", {})], /assets.*array/],
+    [
+      [release("v1", "2026-09-01T00:00:00Z", [asset("", 1)])],
+      /assets\[0\]\.name.*non-empty string/,
+    ],
+    [
+      [
+        release("v1", "2026-09-01T00:00:00Z", [
+          asset("file", 1, { content_type: null }),
+        ]),
+      ],
+      /content_type.*string/,
+    ],
+  ]) {
+    assert.throws(() => createSnapshot(input, "owner/repo", capturedAt), expected);
+  }
+});
+
+test("CLI rejects unknown, missing, and duplicate flags", () => {
+  const run = (arguments_) =>
+    spawnSync(process.execPath, ["scripts/record-release-downloads.mjs", ...arguments_], {
+      cwd: new URL("..", import.meta.url),
+      encoding: "utf8",
+    });
+
+  const unknown = run(["--unknown", "value"]);
+  assert.notEqual(unknown.status, 0);
+  assert.match(unknown.stderr, /unknown flag.*--unknown/i);
+
+  const missing = run(["--input", "releases.json"]);
+  assert.notEqual(missing.status, 0);
+  assert.match(missing.stderr, /missing required flag.*--output/i);
+
+  const duplicate = run([
+    "--input",
+    "one.json",
+    "--input",
+    "two.json",
+    "--output",
+    "snapshot.json",
+    "--repository",
+    "owner/repo",
+  ]);
+  assert.notEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /duplicate flag.*--input/i);
+});
+
+test("CLI rejects missing flag values", () => {
   const result = spawnSync(
     process.execPath,
-    ["scripts/record-release-downloads.mjs", "--unknown", "value"],
+    ["scripts/record-release-downloads.mjs", "--input", "--output"],
     { cwd: new URL("..", import.meta.url), encoding: "utf8" },
   );
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /unknown flag.*--unknown/i);
+  assert.match(result.stderr, /missing value.*--input/i);
 });
 
 test("CLI writes pretty JSON with a trailing newline and creates parent directories", () => {

--- a/scripts/test-record-release-downloads.mjs
+++ b/scripts/test-record-release-downloads.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import { createSnapshot } from "./record-release-downloads.mjs";
+
+const asset = (name, downloadCount, overrides = {}) => ({
+  name,
+  content_type: "application/octet-stream",
+  size: 100,
+  download_count: downloadCount,
+  ...overrides,
+});
+
+const release = (tagName, publishedAt, assets = [], overrides = {}) => ({
+  tag_name: tagName,
+  published_at: publishedAt,
+  draft: false,
+  prerelease: false,
+  assets,
+  ...overrides,
+});
+
+test("normalizes public releases deterministically and totals download events", () => {
+  const snapshot = createSnapshot(
+    [
+      release("v2.0.0-beta", "2026-09-02T00:00:00Z", [asset("preview.txt", 11)], {
+        prerelease: true,
+      }),
+      release("v1.0.0", "2026-09-01T00:00:00Z", [
+        asset("Sagascript.dmg", 13),
+        asset("notes.txt", 7),
+        asset("Sagascript.app.tar.gz", 3),
+        asset("Sagascript-Setup.MSI", 2),
+        asset("Sagascript-Setup.exe", 5),
+      ]),
+      release("draft", "2026-08-01T00:00:00Z", [asset("Sagascript.dmg", 999)], {
+        draft: true,
+      }),
+    ],
+    "Magnus-Gille/sagascript",
+    "2026-09-03T23:45:00+02:00",
+  );
+
+  assert.equal(snapshot.captured_at, "2026-09-03T21:45:00.000Z");
+  assert.equal(snapshot.snapshot_date, "2026-09-03");
+  assert.deepEqual(snapshot.releases.map(({ tag_name }) => tag_name), [
+    "v1.0.0",
+    "v2.0.0-beta",
+  ]);
+  assert.equal(snapshot.releases[1].prerelease, true);
+  assert.deepEqual(snapshot.releases[0].assets.map(({ name }) => name), [
+    "Sagascript-Setup.MSI",
+    "Sagascript-Setup.exe",
+    "Sagascript.app.tar.gz",
+    "Sagascript.dmg",
+    "notes.txt",
+  ]);
+  assert.deepEqual(snapshot.totals, {
+    all_assets: 41,
+    app_downloads: 23,
+    dmg_downloads: 13,
+    updater_downloads: 3,
+    windows_downloads: 7,
+  });
+});
+
+test("sorts equal-time releases by tag name", () => {
+  const snapshot = createSnapshot(
+    [release("v2", "2026-09-01T00:00:00Z"), release("v1", "2026-09-01T00:00:00Z")],
+    "owner/repo",
+    "2026-09-03T00:00:00Z",
+  );
+  assert.deepEqual(snapshot.releases.map(({ tag_name }) => tag_name), ["v1", "v2"]);
+});
+
+test("rejects malformed timestamps and asset counters", () => {
+  assert.throws(
+    () => createSnapshot([], "owner/repo", "2026-09-03"),
+    /captured-at.*ISO 8601/i,
+  );
+  assert.throws(
+    () =>
+      createSnapshot(
+        [release("v1", "not-a-time")],
+        "owner/repo",
+        "2026-09-03T00:00:00Z",
+      ),
+    /published_at.*ISO 8601/i,
+  );
+
+  for (const [field, value] of [
+    ["size", -1],
+    ["size", 1.5],
+    ["download_count", -1],
+    ["download_count", "1"],
+  ]) {
+    assert.throws(
+      () =>
+        createSnapshot(
+          [release("v1", "2026-09-01T00:00:00Z", [asset("bad", 1, { [field]: value })])],
+          "owner/repo",
+          "2026-09-03T00:00:00Z",
+        ),
+      new RegExp(`${field}.*non-negative integer`, "i"),
+    );
+  }
+});
+
+test("CLI rejects unknown flags", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/record-release-downloads.mjs", "--unknown", "value"],
+    { cwd: new URL("..", import.meta.url), encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unknown flag.*--unknown/i);
+});
+
+test("CLI writes pretty JSON with a trailing newline and creates parent directories", () => {
+  const directory = mkdtempSync(join(tmpdir(), "sagascript-download-metrics-"));
+  try {
+    const input = join(directory, "releases.json");
+    const output = join(directory, "nested", "snapshot.json");
+    writeFileSync(input, JSON.stringify([release("v1", "2026-09-01T00:00:00Z")]), "utf8");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/record-release-downloads.mjs",
+        "--input",
+        input,
+        "--output",
+        output,
+        "--repository",
+        "owner/repo",
+        "--captured-at",
+        "2026-09-03T00:00:00Z",
+      ],
+      { cwd: new URL("..", import.meta.url), encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const contents = readFileSync(output, "utf8");
+    assert.match(contents, /^\{\n  "schema_version": 1,/);
+    assert.ok(contents.endsWith("\n"));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- record one normalized UTC snapshot of public GitHub release-asset counters each day
- keep generated history on the dedicated metrics/downloads branch
- include a verified 2026-09-03 baseline with 61 app download events
- validate, sort, and classify release data with a dependency-free Node script

## Verification

- node --test scripts/test-record-release-downloads.mjs — 5 passed
- actionlint .github/workflows/download-metrics.yml — passed
- node --check for implementation and tests — passed
- live paginated GitHub API response normalized successfully
- independent jq totals matched the generated baseline exactly

## Review status

Draft because the required independent cross-model review could not complete: restricted Claude Opus produced no output and was aborted; M5 qwen3-coder-next-80b timed out and was then busy. Conductor review found no actionable defects.