### PR TITLE
feat: support bare F13–F24 hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ existing object shape.
 Sagascript needs the following permissions (macOS will prompt you on first use):
 
 - **Microphone** -- for recording audio
-- **Accessibility** -- for pasting transcriptions into the active app
+- **Accessibility** -- for pasting transcriptions into the active app and for
+  bare F13–F24 shortcuts
 Official macOS releases are Developer ID signed and notarized. If a downloaded
 release asks you to bypass Gatekeeper, do not run it; report the artifact.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,28 @@ sagascript glossary path --profile swedish
 The GUI and CLI watch and update the same files. Atomic writes preserve
 user-managed symlinks, so the files can be checked into a dotfiles repository.
 
+## Extended function-key shortcuts
+
+Bare F13–F24 shortcuts are supported on macOS and Windows. Ordinary keys and
+F1–F12 still require a modifier. Linux keeps accepting previously valid
+modified F13–F24 configurations, but bare extended function keys remain
+unsupported by the current backend.
+
+On macOS, bare F13–F24 use an AppKit event monitor and therefore require the
+installed Sagascript app to have Accessibility permission. This is an explicit
+product/privacy tradeoff: macOS delivers every system KeyDown/KeyUp event to
+the monitor callback, but Sagascript immediately discards any event that is not
+one unmodified F13–F24 scalar. Non-matching events are not logged, stored, or
+sent anywhere. The monitor exists only for the lifetime of the app process.
+Users who do not want this access can continue using a modified shortcut.
+
+The native path covers the whole range rather than only F21–F24 because a
+runtime probe of the locked `global-hotkey` 0.7.0 Carbon path on macOS 26.6.2
+(build 25G83) found that bare F13–F20 all reached `RegisterEventHotKey` but were
+rejected there; F21–F24 failed earlier as unknown scancodes. The source mapping
+for F13–F20 therefore did not provide a working permission-free registration
+path. This probe was run on 2026-09-04 before adopting the AppKit monitor.
+
 ## Overrides and migration
 
 `SAGASCRIPT_SETTINGS_PATH=/absolute/path/to/settings.json` selects one exact

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,8 @@ Download the latest `.dmg` from the [Releases page](https://github.com/Magnus-Gi
 3. Launch Sagascript -- it will appear in your menu bar
 4. Grant permissions when prompted:
    - **Microphone** -- for recording audio
-   - **Accessibility** -- for pasting transcriptions into the active app
+   - **Accessibility** -- for pasting transcriptions into the active app and
+     for bare F13–F24 shortcuts
 
 To make the app's CLI available in your shell, create this link once:
 

--- a/scripts/test-hotkey-shortcuts.mjs
+++ b/scripts/test-hotkey-shortcuts.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canUseBareHotkey,
+  supportedBareFunctionKeyRange,
+  tauriKeyName,
+} from "../src/lib/hotkey.js";
+
+test("F13 through F24 may omit modifiers on macOS", () => {
+  for (const key of ["F13", "F14", "F19", "F20", "F21", "F24"]) {
+    assert.equal(canUseBareHotkey(key, "macos"), true, key);
+  }
+
+  for (const key of ["F1", "F12", "F25", "Space", "A"]) {
+    assert.equal(canUseBareHotkey(key, "macos"), false, key);
+  }
+});
+
+test("Windows may use bare F13 through F24 while Linux rejects unsupported mappings", () => {
+  assert.equal(canUseBareHotkey("F13", "windows"), true);
+  assert.equal(canUseBareHotkey("F24", "windows"), true);
+  assert.equal(canUseBareHotkey("F25", "windows"), false);
+  assert.equal(canUseBareHotkey("F13", "linux"), false);
+  assert.equal(canUseBareHotkey("F24", "linux"), false);
+});
+
+test("the keyboard event mapper accepts exactly F1 through F24", () => {
+  assert.equal(tauriKeyName("F1"), "F1");
+  assert.equal(tauriKeyName("F13"), "F13");
+  assert.equal(tauriKeyName("F24"), "F24");
+  assert.equal(tauriKeyName("F0"), null);
+  assert.equal(tauriKeyName("F25"), null);
+  assert.equal(tauriKeyName("F99"), null);
+  assert.equal(tauriKeyName("f13"), null);
+  assert.equal(tauriKeyName("F١٣"), null);
+});
+
+test("the bare-key range shown in Settings matches registration support", () => {
+  assert.equal(supportedBareFunctionKeyRange("macos"), "F13–F24");
+  assert.equal(supportedBareFunctionKeyRange("windows"), "F13–F24");
+  assert.equal(supportedBareFunctionKeyRange("linux"), null);
+});
+
+test("malformed extended function keys never qualify as bare shortcuts", () => {
+  for (const key of ["F013", "F13a", "F25", "F-13", "13", " F13 "]) {
+    assert.equal(canUseBareHotkey(key, "macos"), false, key);
+  }
+});

--- a/scripts/test-hotkey-shortcuts.mjs
+++ b/scripts/test-hotkey-shortcuts.mjs
@@ -32,7 +32,8 @@ test("the keyboard event mapper accepts exactly F1 through F24", () => {
   assert.equal(tauriKeyName("F0"), null);
   assert.equal(tauriKeyName("F25"), null);
   assert.equal(tauriKeyName("F99"), null);
-  assert.equal(tauriKeyName("f13"), null);
+  assert.equal(tauriKeyName("f13"), "F13");
+  assert.equal(tauriKeyName(" F24 "), "F24");
   assert.equal(tauriKeyName("F١٣"), null);
 });
 
@@ -43,7 +44,8 @@ test("the bare-key range shown in Settings matches registration support", () => 
 });
 
 test("malformed extended function keys never qualify as bare shortcuts", () => {
-  for (const key of ["F013", "F13a", "F25", "F-13", "13", " F13 "]) {
+  for (const key of ["F013", "F13a", "F25", "F-13", "13"]) {
     assert.equal(canUseBareHotkey(key, "macos"), false, key);
   }
+  assert.equal(canUseBareHotkey(" F13 ", "macos"), true);
 });

--- a/scripts/test-hotkey-shortcuts.mjs
+++ b/scripts/test-hotkey-shortcuts.mjs
@@ -44,7 +44,7 @@ test("the bare-key range shown in Settings matches registration support", () => 
 });
 
 test("malformed extended function keys never qualify as bare shortcuts", () => {
-  for (const key of ["F013", "F13a", "F25", "F-13", "13"]) {
+  for (const key of ["F013", "F0013", "F13a", "F25", "F-13", "13"]) {
     assert.equal(canUseBareHotkey(key, "macos"), false, key);
   }
   assert.equal(canUseBareHotkey(" F13 ", "macos"), true);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4054,6 +4054,7 @@ version = "1.1.3"
 dependencies = [
  "arboard",
  "block",
+ "block2",
  "chrono",
  "cocoa",
  "core-foundation 0.10.1",
@@ -4062,6 +4063,7 @@ dependencies = [
  "fs2",
  "notify",
  "objc",
+ "objc2-app-kit",
  "objc2-foundation",
  "reqwest 0.12.28",
  "sagascript-cli",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,7 +65,9 @@ enigo = { version = "0.6", features = ["serde"] }
 core-foundation = "0.10"
 cocoa = "0.26"
 objc = "0.2"
+objc2-app-kit = { version = "0.3.2", features = ["block2", "NSEvent"] }
 objc2-foundation = "0.3.2"
+block2 = "0.6"
 block = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -355,11 +355,16 @@ fn setting_warning(key: &str, settings: &Settings) -> Option<&'static str> {
 }
 
 fn bare_extended_hotkey_warning(shortcut: &str) -> Option<&'static str> {
+    // Strict parity with src/lib/hotkey.js (/^F(\d{1,2})$/i): at most two
+    // ASCII digits, so "F013" never warns as a bare extended key.
     let normalized = shortcut.trim().to_ascii_lowercase();
-    let is_bare_extended = normalized
-        .strip_prefix('f')
-        .and_then(|number| number.parse::<u8>().ok())
-        .is_some_and(|number| (13..=24).contains(&number));
+    let digits = normalized.strip_prefix('f')?;
+    let is_bare_extended = !digits.is_empty()
+        && digits.len() <= 2
+        && digits.bytes().all(|b| b.is_ascii_digit())
+        && digits
+            .parse::<u8>()
+            .is_ok_and(|number| (13..=24).contains(&number));
     (cfg!(target_os = "macos") && is_bare_extended).then_some(
         "bare F13-F24 requires Accessibility approval for the installed Sagascript app",
     )
@@ -844,5 +849,6 @@ mod tests {
         assert!(warning.contains("Accessibility approval"));
 
         assert!(bare_extended_hotkey_warning("Shift+F24").is_none());
+        assert!(bare_extended_hotkey_warning("F013").is_none());
     }
 }

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -56,7 +56,7 @@ Valid values per key:
   show_overlay         true, false
   auto_paste           true, false (enabling requires Accessibility approval for the installed GUI)
   auto_select_model    true, false
-  hotkey               Modifier+Key (e.g. Control+Shift+Space, Option+Space)
+  hotkey               Modifier+Key; bare F13-F24 on macOS (Accessibility) or Windows
   initial_prompt       Personal dictionary text; aliases use TERM = ALIAS | ALIAS
   beam_size            Integer >= 0 (0 = greedy/fast, 5 = beam search/accurate)
   temperature_fallback true, false
@@ -66,6 +66,7 @@ EXAMPLES:
   sagascript config set language sv
   sagascript config set whisper_model kb-whisper-base
   sagascript config set hotkey 'Option+Space'
+  sagascript config set hotkey F13
   sagascript config set auto_paste false
   sagascript config set initial_prompt $'OpenRouter = open router | open vrouter\\nmerge = merch'"
     )]
@@ -175,6 +176,7 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
         }
         ProfileAction::Create { id, name, hotkey, language } => {
             let language = parse_enum_value::<Language>(&language, "language")?;
+            let hotkey_warning = bare_extended_hotkey_warning(&hotkey);
             let mut profiles = settings::store::load().resolved_hotkey_profiles();
             if profiles.iter().any(|profile| profile.id == id) {
                 return Err(DictationError::SettingsError(format!("Profile '{id}' already exists")));
@@ -182,12 +184,18 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             profiles.push(HotkeyProfile { id: id.clone(), name, shortcut: hotkey, language });
             persist_profiles(profiles)?;
             eprintln!("Created profile {id}");
+            if let Some(warning) = hotkey_warning {
+                eprintln!("Warning: {warning}");
+            }
             Ok(())
         }
         ProfileAction::Update { id, name, hotkey, language } => {
             if name.is_none() && hotkey.is_none() && language.is_none() {
                 return Err(DictationError::SettingsError("Specify at least one of --name, --hotkey, or --language".to_string()));
             }
+            let hotkey_warning = hotkey
+                .as_deref()
+                .and_then(bare_extended_hotkey_warning);
             let language = language.as_deref().map(|value| parse_enum_value::<Language>(value, "language")).transpose()?;
             let mut profiles = settings::store::load().resolved_hotkey_profiles();
             let profile = profiles.iter_mut().find(|profile| profile.id == id).ok_or_else(|| DictationError::SettingsError(format!("Unknown profile '{id}'")))?;
@@ -196,6 +204,9 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             if let Some(language) = language { profile.language = language; }
             persist_profiles(profiles)?;
             eprintln!("Updated profile {id}");
+            if let Some(warning) = hotkey_warning {
+                eprintln!("Warning: {warning}");
+            }
             Ok(())
         }
         ProfileAction::Remove { id } => {
@@ -331,9 +342,26 @@ fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
 }
 
 fn setting_warning(key: &str, settings: &Settings) -> Option<&'static str> {
-    (key == "auto_paste" && settings.auto_paste).then_some(
-        "auto-paste requires Accessibility approval for the installed Sagascript app; \
-         until it is granted, the GUI will keep or reset auto-paste to false",
+    if key == "auto_paste" && settings.auto_paste {
+        Some(
+            "auto-paste requires Accessibility approval for the installed Sagascript app; \
+             until it is granted, the GUI will keep or reset auto-paste to false",
+        )
+    } else if key == "hotkey" {
+        bare_extended_hotkey_warning(&settings.hotkey)
+    } else {
+        None
+    }
+}
+
+fn bare_extended_hotkey_warning(shortcut: &str) -> Option<&'static str> {
+    let normalized = shortcut.trim().to_ascii_lowercase();
+    let is_bare_extended = normalized
+        .strip_prefix('f')
+        .and_then(|number| number.parse::<u8>().ok())
+        .is_some_and(|number| (13..=24).contains(&number));
+    (cfg!(target_os = "macos") && is_bare_extended).then_some(
+        "bare F13-F24 requires Accessibility approval for the installed Sagascript app",
     )
 }
 
@@ -581,6 +609,23 @@ mod tests {
         assert!(err.to_string().contains("modifier is required"));
     }
 
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn apply_setting_value_accepts_bare_extended_function_key() {
+        let mut settings = Settings::default();
+        apply_setting_value(&mut settings, "hotkey", "F13").unwrap();
+        assert_eq!(settings.hotkey, "F13");
+        assert_eq!(settings.resolved_hotkey_profiles()[0].shortcut, "F13");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn apply_setting_value_accepts_bare_f24_on_macos() {
+        let mut settings = Settings::default();
+        apply_setting_value(&mut settings, "hotkey", "F24").unwrap();
+        assert_eq!(settings.hotkey, "F24");
+    }
+
     #[test]
     fn validate_hotkey_rejects_unknown_key() {
         let err = validate_hotkey("Control+FooBar").unwrap_err();
@@ -785,5 +830,19 @@ mod tests {
         };
         assert!(setting_warning("auto_paste", &disabled).is_none());
         assert!(setting_warning("show_overlay", &Settings::default()).is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bare_extended_hotkey_warns_about_gui_accessibility_requirement() {
+        let settings = Settings {
+            hotkey: "F24".to_string(),
+            ..Default::default()
+        };
+        let warning = setting_warning("hotkey", &settings).unwrap();
+        assert!(warning.contains("F13-F24"));
+        assert!(warning.contains("Accessibility approval"));
+
+        assert!(bare_extended_hotkey_warning("Shift+F24").is_none());
     }
 }

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -348,7 +348,7 @@ Available setting keys:
   show_overlay       Show recording overlay (true/false)
   auto_paste         Auto-paste transcription result (true/false)
   auto_select_model  Auto-select best model for language (true/false)
-  hotkey             Global hotkey shortcut (e.g. Control+Shift+Space)",
+  hotkey             Modifier+Key; bare F13-F24 on macOS (Accessibility) or Windows",
         after_long_help = "\
 EXAMPLES:
   # Show all settings with current and default values
@@ -362,6 +362,7 @@ EXAMPLES:
 
   # Change the global hotkey
   sagascript config set hotkey 'Option+Space'
+  sagascript config set hotkey F13
 
   # Reset a single setting to its default
   sagascript config reset language

--- a/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
@@ -354,10 +354,7 @@ fn validate_hotkey_for_platform(value: &str, platform: HotkeyPlatform) -> Result
             {
                 Some("F21-F24 are supported without modifiers on macOS, but the modified forms cannot be registered reliably")
             }
-            HotkeyPlatform::Other => Some(
-                "F13-F24 are not supported by the current Linux global-hotkey backend",
-            ),
-            HotkeyPlatform::MacOS | HotkeyPlatform::Windows => None,
+            HotkeyPlatform::MacOS | HotkeyPlatform::Windows | HotkeyPlatform::Other => None,
         };
         if let Some(error) = unsupported_error {
             return Err(format!("Invalid hotkey '{}': {}.", value, error));
@@ -534,11 +531,18 @@ mod tests {
     }
 
     #[test]
-    fn linux_rejects_extended_function_keys_missing_from_its_backend_mapping() {
-        for shortcut in ["F13", "Control+F20", "F24"] {
+    fn linux_preserves_modified_extended_function_keys_but_rejects_bare_ones() {
+        for shortcut in ["Control+F13", "Shift+F20", "Alt+F24"] {
+            assert!(
+                validate_hotkey_for_platform(shortcut, HotkeyPlatform::Other).is_ok(),
+                "modified shortcut should remain valid on Linux: {shortcut}"
+            );
+        }
+
+        for shortcut in ["F13", "F24"] {
             let error = validate_hotkey_for_platform(shortcut, HotkeyPlatform::Other).unwrap_err();
             assert!(
-                error.contains("not supported by the current Linux global-hotkey backend"),
+                error.contains("modifier is required"),
                 "unexpected error for {shortcut}: {error}"
             );
         }

--- a/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/hotkey.rs
@@ -18,11 +18,14 @@ pub fn canonical_hotkey(value: &str) -> Result<String, String> {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum HotkeyPlatform {
     MacOS,
+    Windows,
     Other,
 }
 
 const CURRENT_PLATFORM: HotkeyPlatform = if cfg!(target_os = "macos") {
     HotkeyPlatform::MacOS
+} else if cfg!(target_os = "windows") {
+    HotkeyPlatform::Windows
 } else {
     HotkeyPlatform::Other
 };
@@ -337,11 +340,50 @@ fn validate_hotkey_for_platform(value: &str, platform: HotkeyPlatform) -> Result
         }
     }
 
-    if modifier_tokens.is_empty() {
+    let function_key_number = key
+        .strip_prefix('f')
+        .and_then(|number| number.parse::<u8>().ok());
+
+    // Reject parsed keys that cannot reach either the platform shortcut
+    // backend or Sagascript's native macOS bare-function-key monitor.
+    if function_key_number.is_some_and(|number| (13..=24).contains(&number)) {
+        let unsupported_error = match platform {
+            HotkeyPlatform::MacOS
+                if !modifier_tokens.is_empty()
+                    && function_key_number.is_some_and(|number| number >= 21) =>
+            {
+                Some("F21-F24 are supported without modifiers on macOS, but the modified forms cannot be registered reliably")
+            }
+            HotkeyPlatform::Other => Some(
+                "F13-F24 are not supported by the current Linux global-hotkey backend",
+            ),
+            HotkeyPlatform::MacOS | HotkeyPlatform::Windows => None,
+        };
+        if let Some(error) = unsupported_error {
+            return Err(format!("Invalid hotkey '{}': {}.", value, error));
+        }
+    }
+
+    let bare_function_key_range = match platform {
+        HotkeyPlatform::MacOS => Some(13..=24),
+        HotkeyPlatform::Windows => Some(13..=24),
+        HotkeyPlatform::Other => None,
+    };
+    let is_allowed_bare_function_key = modifier_tokens.is_empty()
+        && function_key_number.is_some_and(|number| {
+            bare_function_key_range.is_some_and(|range| range.contains(&number))
+        });
+
+    if modifier_tokens.is_empty() && !is_allowed_bare_function_key {
         return Err(format!(
             "Invalid hotkey '{}': at least one modifier is required. \
-             Example: 'Control+Space', 'Option+Space'",
-            value
+             Example: 'Control+Space', 'Option+Space'. {} may be used without modifiers.",
+            value,
+            match platform {
+                HotkeyPlatform::MacOS => "F13-F24",
+                HotkeyPlatform::Windows => "F13-F24",
+                HotkeyPlatform::Other => "No keys",
+            }
         ));
     }
 
@@ -454,5 +496,66 @@ mod tests {
             canonical_hotkey_for_platform("CmdOrCtrl+Space", HotkeyPlatform::MacOS),
             canonical_hotkey_for_platform("Command+Space", HotkeyPlatform::MacOS)
         );
+        assert_eq!(
+            canonical_hotkey_for_platform("F13", HotkeyPlatform::MacOS),
+            canonical_hotkey_for_platform("f13", HotkeyPlatform::MacOS)
+        );
+    }
+
+    #[test]
+    fn bare_extended_function_keys_follow_platform_registration_support() {
+        for shortcut in ["F13", "f17", "F20", "F21", "F24"] {
+            assert!(
+                validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).is_ok(),
+                "macOS should accept {shortcut} without a modifier"
+            );
+        }
+
+        for shortcut in ["F13", "f20", "F21", "F24"] {
+            assert!(
+                validate_hotkey_for_platform(shortcut, HotkeyPlatform::Windows).is_ok(),
+                "Windows should accept {shortcut} without a modifier"
+            );
+        }
+    }
+
+    #[test]
+    fn macos_only_accepts_f21_through_f24_without_modifiers() {
+        for shortcut in ["Shift+F21", "Control+f22", "Shift+F23", "Command+F24"] {
+            let error = validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).unwrap_err();
+            assert!(
+                error.contains("supported without modifiers on macOS"),
+                "unexpected error for {shortcut}: {error}"
+            );
+        }
+
+        assert!(validate_hotkey_for_platform("F24", HotkeyPlatform::MacOS).is_ok());
+        assert!(validate_hotkey_for_platform("Control+F24", HotkeyPlatform::Windows).is_ok());
+    }
+
+    #[test]
+    fn linux_rejects_extended_function_keys_missing_from_its_backend_mapping() {
+        for shortcut in ["F13", "Control+F20", "F24"] {
+            let error = validate_hotkey_for_platform(shortcut, HotkeyPlatform::Other).unwrap_err();
+            assert!(
+                error.contains("not supported by the current Linux global-hotkey backend"),
+                "unexpected error for {shortcut}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_bare_keys_and_f1_through_f12_still_require_modifiers() {
+        for shortcut in ["Space", "A", "7", "F1", "f12", "ArrowUp"] {
+            let error = validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).unwrap_err();
+            assert!(
+                error.contains("modifier is required"),
+                "unexpected error for {shortcut}: {error}"
+            );
+        }
+
+        for shortcut in ["Control+Space", "Option+A", "Shift+F12"] {
+            assert!(validate_hotkey_for_platform(shortcut, HotkeyPlatform::MacOS).is_ok());
+        }
     }
 }

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -1382,6 +1382,12 @@ mod tests {
             profile("two", "shift+alt+KeyA", Language::Swedish),
         ];
         assert!(Settings::validate_hotkey_profiles(&duplicate_aliases).is_err());
+
+        let duplicate_bare_function_keys = vec![
+            profile("one", "F13", Language::English),
+            profile("two", "f13", Language::Swedish),
+        ];
+        assert!(Settings::validate_hotkey_profiles(&duplicate_bare_function_keys).is_err());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -374,7 +374,10 @@ pub async fn set_hotkey_profiles(
         .into_iter()
         .map(|profile| profile.shortcut)
         .collect();
-    if new_shortcuts == old_shortcuts {
+    if new_shortcuts == old_shortcuts
+        && old_operational.matches(&new_shortcuts)
+        && !health.is_failed()
+    {
         let persisted = sagascript_core::settings::store::try_update(|settings| {
             settings.replace_hotkey_profiles(profiles.clone())?;
             Ok(())
@@ -502,6 +505,22 @@ pub async fn set_hotkey_profiles(
 
     info!("Hotkey profiles changed: {} registered", new_shortcuts.len());
     Ok(())
+}
+
+/// Retry the shortcuts currently persisted on disk.
+///
+/// This is used after macOS grants Accessibility while the app is already
+/// running. Reading the file again matters for CLI-driven changes: the file
+/// can contain a requested bare F-key while the controller deliberately keeps
+/// the previous operational shortcut after registration failed closed.
+#[tauri::command]
+pub async fn retry_hotkey_registration(
+    app: tauri::AppHandle,
+    controller: State<'_, SharedController>,
+    health: State<'_, HotkeyHealth>,
+) -> Result<(), String> {
+    let profiles = sagascript_core::settings::store::load().resolved_hotkey_profiles();
+    set_hotkey_profiles(app, controller, health, profiles).await
 }
 
 /// Current hotkey registration health — whether the last registration

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -513,12 +513,34 @@ pub async fn set_hotkey_profiles(
 /// running. Reading the file again matters for CLI-driven changes: the file
 /// can contain a requested bare F-key while the controller deliberately keeps
 /// the previous operational shortcut after registration failed closed.
+///
+/// If the AppKit event monitor itself was never installed (setup failure),
+/// reinstall it here on the macOS main thread before re-registering, so a
+/// retry can recover without an app restart. Install and registration
+/// failures still surface through the normal health path below.
 #[tauri::command]
 pub async fn retry_hotkey_registration(
     app: tauri::AppHandle,
     controller: State<'_, SharedController>,
     health: State<'_, HotkeyHealth>,
 ) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    if !crate::hotkey::bare_function_key_monitor_installed() {
+        let app_for_install = app.clone();
+        let (installed_tx, installed_rx) = std::sync::mpsc::channel();
+        app.run_on_main_thread(move || {
+            let result =
+                crate::hotkey::install_bare_function_key_monitor(&app_for_install);
+            let _ = installed_tx.send(result);
+        })
+        .map_err(|error| error.to_string())?;
+        // The main thread runs the install promptly; a disconnected channel
+        // means the app is shutting down, so fall through and let the
+        // registration attempt below report the monitor as unavailable.
+        if let Ok(Err(error)) = installed_rx.recv() {
+            tracing::warn!("F13-F24 event monitor reinstall failed: {error}");
+        }
+    }
     let profiles = sagascript_core::settings::store::load().resolved_hotkey_profiles();
     set_hotkey_profiles(app, controller, health, profiles).await
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -349,8 +349,6 @@ pub async fn set_hotkey_profiles(
     profiles: Vec<HotkeyProfile>,
 ) -> Result<(), String> {
     use tauri::Emitter;
-    use tauri_plugin_global_shortcut::GlobalShortcutExt;
-
     Settings::validate_hotkey_profiles(&profiles)?;
     let new_shortcuts: Vec<String> = profiles.iter().map(|profile| profile.shortcut.clone()).collect();
     let new_primary = profiles
@@ -394,7 +392,7 @@ pub async fn set_hotkey_profiles(
     }
 
     if let OperationalHotkey::Registered(old_shortcuts) = &old_operational {
-        if let Err(error) = app.global_shortcut().unregister_multiple(old_shortcuts.iter().map(String::as_str)) {
+        if let Err(error) = crate::hotkey::unregister_shortcuts(&app, old_shortcuts) {
             error!("Failed to unregister operational hotkeys: {error}");
             let change = health.record(
                 &old_shortcut,
@@ -413,8 +411,8 @@ pub async fn set_hotkey_profiles(
         }
     }
 
-    if let Err(error) = app.global_shortcut().register_multiple(new_shortcuts.iter().map(String::as_str)) {
-        if let Err(cleanup_error) = app.global_shortcut().unregister_multiple(new_shortcuts.iter().map(String::as_str)) {
+    if let Err(error) = crate::hotkey::register_shortcuts(&app, &new_shortcuts) {
+        if let Err(cleanup_error) = crate::hotkey::unregister_shortcuts(&app, &new_shortcuts) {
             let change = health.record(
                 &old_shortcut,
                 Some(format!("new registration failed: {error}; partial registration cleanup failed: {cleanup_error}; operational state is unknown")),
@@ -426,10 +424,7 @@ pub async fn set_hotkey_profiles(
             return Err(format!("Failed to register hotkey profiles: {error}; cleanup failed: {cleanup_error}"));
         }
         let change = match &old_operational {
-            OperationalHotkey::Registered(old_shortcuts) => match app
-                .global_shortcut()
-                .register_multiple(old_shortcuts.iter().map(String::as_str))
-            {
+            OperationalHotkey::Registered(old_shortcuts) => match crate::hotkey::register_shortcuts(&app, old_shortcuts) {
                 Ok(()) => health.record(&old_shortcut, None, old_operational.clone()),
                 Err(rollback_error) => {
                     health.record(
@@ -464,13 +459,12 @@ pub async fn set_hotkey_profiles(
     }) {
         Ok(settings) => settings,
         Err(save_error) => {
-            let unregister_error = app.global_shortcut().unregister_multiple(new_shortcuts.iter().map(String::as_str)).err();
+            let unregister_error = crate::hotkey::unregister_shortcuts(&app, &new_shortcuts).err();
             let rollback_error = if unregister_error.is_none() {
                 match &old_operational {
-                    OperationalHotkey::Registered(old_shortcuts) => app
-                        .global_shortcut()
-                        .register_multiple(old_shortcuts.iter().map(String::as_str))
-                        .err(),
+                    OperationalHotkey::Registered(old_shortcuts) => {
+                        crate::hotkey::register_shortcuts(&app, old_shortcuts).err()
+                    }
                     OperationalHotkey::Inactive => None,
                     OperationalHotkey::Unknown => unreachable!("unknown state returned above"),
                 }

--- a/src-tauri/src/hotkey/health.rs
+++ b/src-tauri/src/hotkey/health.rs
@@ -41,6 +41,10 @@ impl OperationalHotkey {
     pub fn registered_many(shortcuts: &[String]) -> Self {
         Self::Registered(shortcuts.to_vec())
     }
+
+    pub fn matches(&self, shortcuts: &[String]) -> bool {
+        matches!(self, Self::Registered(registered) if registered == shortcuts)
+    }
 }
 
 /// Process-wide hotkey registration health.
@@ -242,6 +246,17 @@ mod tests {
 
         assert_eq!(h.status().shortcuts, shortcuts);
         assert_eq!(h.operational_hotkey(), OperationalHotkey::Registered(shortcuts));
+    }
+
+    #[test]
+    fn operational_match_requires_the_complete_registered_shortcut_set() {
+        let shortcuts = vec!["F13".to_string(), "Control+Space".to_string()];
+        let operational = OperationalHotkey::registered_many(&shortcuts);
+
+        assert!(operational.matches(&shortcuts));
+        assert!(!operational.matches(&["F13".to_string()]));
+        assert!(!OperationalHotkey::Inactive.matches(&shortcuts));
+        assert!(!OperationalHotkey::Unknown.matches(&shortcuts));
     }
 
     #[test]

--- a/src-tauri/src/hotkey/macos_bare.rs
+++ b/src-tauri/src/hotkey/macos_bare.rs
@@ -1,0 +1,172 @@
+use std::mem;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use block2::RcBlock;
+use objc2_app_kit::{
+    NSEvent, NSEventMask, NSEventModifierFlags, NSEventType, NSF13FunctionKey, NSF24FunctionKey,
+};
+use tauri::{AppHandle, Manager};
+
+use super::{BareHotkeyState, HotkeyHealth, OperationalHotkey};
+
+static MONITOR_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+pub fn bare_function_key_monitor_installed() -> bool {
+    MONITOR_INSTALLED.load(Ordering::Acquire)
+}
+
+fn function_key_from_scalar(scalar: u32, modifiers: NSEventModifierFlags) -> Option<String> {
+    let disallowed_modifiers = NSEventModifierFlags::Shift
+        | NSEventModifierFlags::Control
+        | NSEventModifierFlags::Option
+        | NSEventModifierFlags::Command;
+    if modifiers.intersects(disallowed_modifiers) {
+        return None;
+    }
+
+    (NSF13FunctionKey..=NSF24FunctionKey)
+        .contains(&scalar)
+        .then(|| format!("F{}", scalar - NSF13FunctionKey + 13))
+}
+
+fn bare_function_key(event: &NSEvent) -> Option<String> {
+    let characters = event.charactersIgnoringModifiers()?;
+    let characters = characters.to_string();
+    let mut characters = characters.chars();
+    let scalar = characters.next()? as u32;
+    if characters.next().is_some() {
+        return None;
+    }
+
+    function_key_from_scalar(scalar, event.modifierFlags())
+}
+
+fn shortcut_is_operational(app: &AppHandle, shortcut: &str) -> bool {
+    let health: tauri::State<'_, HotkeyHealth> = app.state();
+    shortcut_is_registered(shortcut, &health.operational_hotkey())
+}
+
+fn shortcut_is_registered(shortcut: &str, operational: &OperationalHotkey) -> bool {
+    let Ok(target) = sagascript_core::settings::canonical_hotkey(shortcut) else {
+        return false;
+    };
+    match operational {
+        OperationalHotkey::Registered(shortcuts) => shortcuts.iter().any(|registered| {
+            sagascript_core::settings::canonical_hotkey(registered).as_deref()
+                == Ok(target.as_str())
+        }),
+        OperationalHotkey::Inactive | OperationalHotkey::Unknown => false,
+    }
+}
+
+fn dispatch_event(app: &AppHandle, event: &NSEvent) {
+    let state = match event.r#type() {
+        NSEventType::KeyDown if !event.isARepeat() => BareHotkeyState::Pressed,
+        NSEventType::KeyUp => BareHotkeyState::Released,
+        _ => return,
+    };
+    if let Some(shortcut) = bare_function_key(event) {
+        if shortcut_is_operational(app, &shortcut) {
+            crate::handle_hotkey_event(app, &shortcut, state);
+        }
+    }
+}
+
+/// Install process-lifetime AppKit monitors for unmodified F13-F24 events.
+///
+/// AppKit delivers events for other applications to the global monitor and
+/// events targeting Sagascript to the local monitor, so both are required.
+/// This function is called from Tauri setup, which runs on the macOS main
+/// thread. Monitor tokens are intentionally retained for the process lifetime.
+pub fn install_bare_function_key_monitor(app: &AppHandle) -> Result<(), String> {
+    if MONITOR_INSTALLED.swap(true, Ordering::AcqRel) {
+        return Ok(());
+    }
+
+    let mask = NSEventMask::KeyDown | NSEventMask::KeyUp;
+    let global_app = app.clone();
+    let global_handler = RcBlock::new(move |event: NonNull<NSEvent>| {
+        // SAFETY: AppKit supplies a valid NSEvent for the duration of the block.
+        dispatch_event(&global_app, unsafe { event.as_ref() });
+    });
+    let Some(global_monitor) =
+        NSEvent::addGlobalMonitorForEventsMatchingMask_handler(mask, &global_handler)
+    else {
+        MONITOR_INSTALLED.store(false, Ordering::Release);
+        return Err("macOS did not create the global F13-F24 event monitor".to_string());
+    };
+
+    let local_app = app.clone();
+    let local_handler = RcBlock::new(move |event: NonNull<NSEvent>| -> *mut NSEvent {
+        // SAFETY: AppKit supplies a valid NSEvent for the duration of the block.
+        dispatch_event(&local_app, unsafe { event.as_ref() });
+        event.as_ptr()
+    });
+    // SAFETY: Returning the unchanged event pointer preserves AppKit's event
+    // dispatch contract; neither the pointer nor the reference escapes.
+    let local_monitor =
+        unsafe { NSEvent::addLocalMonitorForEventsMatchingMask_handler(mask, &local_handler) };
+    let Some(local_monitor) = local_monitor else {
+        // SAFETY: `global_monitor` is the token returned by the matching AppKit API.
+        unsafe { NSEvent::removeMonitor(&global_monitor) };
+        MONITOR_INSTALLED.store(false, Ordering::Release);
+        return Err("macOS did not create the local F13-F24 event monitor".to_string());
+    };
+
+    mem::forget(global_monitor);
+    mem::forget(local_monitor);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{function_key_from_scalar, shortcut_is_registered};
+    use crate::hotkey::OperationalHotkey;
+    use objc2_app_kit::{NSEventModifierFlags, NSF13FunctionKey, NSF24FunctionKey};
+
+    #[test]
+    fn maps_the_complete_private_use_function_key_range() {
+        for number in 13_u32..=24 {
+            let scalar = NSF13FunctionKey + number - 13;
+            assert_eq!(
+                function_key_from_scalar(scalar, NSEventModifierFlags::empty()),
+                Some(format!("F{number}"))
+            );
+        }
+        assert_eq!(
+            function_key_from_scalar(NSF13FunctionKey - 1, NSEventModifierFlags::empty()),
+            None
+        );
+        assert_eq!(
+            function_key_from_scalar(NSF24FunctionKey + 1, NSEventModifierFlags::empty()),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_user_modifiers_but_allows_the_function_flag() {
+        for modifier in [
+            NSEventModifierFlags::Shift,
+            NSEventModifierFlags::Control,
+            NSEventModifierFlags::Option,
+            NSEventModifierFlags::Command,
+        ] {
+            assert_eq!(function_key_from_scalar(NSF13FunctionKey, modifier), None);
+        }
+        assert_eq!(
+            function_key_from_scalar(NSF24FunctionKey, NSEventModifierFlags::Function),
+            Some("F24".to_string())
+        );
+    }
+
+    #[test]
+    fn dispatch_requires_the_exact_shortcut_to_be_operational() {
+        let registered =
+            OperationalHotkey::registered_many(&[" f13 ".to_string(), "Control+Space".to_string()]);
+        assert!(shortcut_is_registered("F13", &registered));
+        assert!(!shortcut_is_registered("F14", &registered));
+        assert!(!shortcut_is_registered("F13", &OperationalHotkey::Inactive));
+        assert!(!shortcut_is_registered("F13", &OperationalHotkey::Unknown));
+    }
+}

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -1,5 +1,19 @@
 pub mod health;
+mod registration;
 pub mod service;
 
+#[cfg(target_os = "macos")]
+mod macos_bare;
+
 pub use health::{HotkeyHealth, HotkeyStatus, OperationalHotkey};
+pub use registration::{register_shortcuts, unregister_shortcuts};
 pub use service::HotkeyService;
+
+#[cfg(target_os = "macos")]
+pub use macos_bare::{bare_function_key_monitor_installed, install_bare_function_key_monitor};
+
+#[derive(Clone, Copy)]
+pub enum BareHotkeyState {
+    Pressed,
+    Released,
+}

--- a/src-tauri/src/hotkey/registration.rs
+++ b/src-tauri/src/hotkey/registration.rs
@@ -1,0 +1,105 @@
+use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+fn is_bare_extended_function_key(shortcut: &str) -> bool {
+    let normalized = shortcut.trim().to_ascii_lowercase();
+    normalized
+        .strip_prefix('f')
+        .and_then(|number| number.parse::<u8>().ok())
+        .is_some_and(|number| (13..=24).contains(&number))
+}
+
+fn uses_native_macos_monitor(shortcut: &str) -> bool {
+    cfg!(target_os = "macos") && is_bare_extended_function_key(shortcut)
+}
+
+fn plugin_shortcuts(shortcuts: &[String]) -> Vec<&str> {
+    shortcuts
+        .iter()
+        .map(String::as_str)
+        .filter(|shortcut| !uses_native_macos_monitor(shortcut))
+        .collect()
+}
+
+pub fn register_shortcuts(app: &tauri::AppHandle, shortcuts: &[String]) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let native_monitor_error = if shortcuts
+        .iter()
+        .any(|shortcut| uses_native_macos_monitor(shortcut))
+    {
+        if !super::bare_function_key_monitor_installed() {
+            Some("The macOS F13-F24 event monitor is unavailable; restart Sagascript".to_string())
+        } else if !crate::platform::macos::is_accessibility_trusted() {
+            Some(
+                "Bare F13-F24 shortcuts require Accessibility permission on macOS. Open Sagascript Settings and approve Accessibility first"
+                    .to_string(),
+            )
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let plugin_shortcuts = plugin_shortcuts(shortcuts);
+    if !plugin_shortcuts.is_empty() {
+        app.global_shortcut()
+            .register_multiple(plugin_shortcuts)
+            .map_err(|error| error.to_string())?;
+    }
+
+    #[cfg(target_os = "macos")]
+    if let Some(error) = native_monitor_error {
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+pub fn unregister_shortcuts(app: &tauri::AppHandle, shortcuts: &[String]) -> Result<(), String> {
+    let plugin_shortcuts = plugin_shortcuts(shortcuts);
+    if plugin_shortcuts.is_empty() {
+        Ok(())
+    } else {
+        app.global_shortcut()
+            .unregister_multiple(plugin_shortcuts)
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_bare_extended_function_key, plugin_shortcuts};
+
+    #[test]
+    fn identifies_exactly_bare_f13_through_f24() {
+        for shortcut in ["F13", "f20", " F24 "] {
+            assert!(is_bare_extended_function_key(shortcut), "{shortcut}");
+        }
+        for shortcut in ["F12", "F25", "Shift+F13", "F13+F14", "Space"] {
+            assert!(!is_bare_extended_function_key(shortcut), "{shortcut}");
+        }
+    }
+
+    #[test]
+    fn non_macos_builds_leave_shortcuts_for_the_plugin() {
+        if !cfg!(target_os = "macos") {
+            let shortcuts = vec!["F13".to_string(), "Control+Space".to_string()];
+            assert_eq!(plugin_shortcuts(&shortcuts), vec!["F13", "Control+Space"]);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_routes_only_bare_extended_function_keys_around_the_plugin() {
+        let shortcuts = vec![
+            "F13".to_string(),
+            " f24 ".to_string(),
+            "Shift+F13".to_string(),
+            "Control+Space".to_string(),
+        ];
+        assert_eq!(
+            plugin_shortcuts(&shortcuts),
+            vec!["Shift+F13", "Control+Space"]
+        );
+    }
+}

--- a/src-tauri/src/hotkey/registration.rs
+++ b/src-tauri/src/hotkey/registration.rs
@@ -40,16 +40,16 @@ pub fn register_shortcuts(app: &tauri::AppHandle, shortcuts: &[String]) -> Resul
         None
     };
 
+    #[cfg(target_os = "macos")]
+    if let Some(error) = native_monitor_error {
+        return Err(error);
+    }
+
     let plugin_shortcuts = plugin_shortcuts(shortcuts);
     if !plugin_shortcuts.is_empty() {
         app.global_shortcut()
             .register_multiple(plugin_shortcuts)
             .map_err(|error| error.to_string())?;
-    }
-
-    #[cfg(target_os = "macos")]
-    if let Some(error) = native_monitor_error {
-        return Err(error);
     }
 
     Ok(())

--- a/src-tauri/src/hotkey/registration.rs
+++ b/src-tauri/src/hotkey/registration.rs
@@ -1,11 +1,19 @@
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
-fn is_bare_extended_function_key(shortcut: &str) -> bool {
+fn bare_extended_function_key_number(shortcut: &str) -> Option<u8> {
+    // Strict parity with src/lib/hotkey.js canUseBareHotkey (/^F(\d{1,2})$/i):
+    // at most two ASCII digits, so "F013" or "F1a" never qualify.
     let normalized = shortcut.trim().to_ascii_lowercase();
-    normalized
-        .strip_prefix('f')
-        .and_then(|number| number.parse::<u8>().ok())
-        .is_some_and(|number| (13..=24).contains(&number))
+    let digits = normalized.strip_prefix('f')?;
+    if digits.is_empty() || digits.len() > 2 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let number: u8 = digits.parse().ok()?;
+    (13..=24).contains(&number).then_some(number)
+}
+
+fn is_bare_extended_function_key(shortcut: &str) -> bool {
+    bare_extended_function_key_number(shortcut).is_some()
 }
 
 fn uses_native_macos_monitor(shortcut: &str) -> bool {
@@ -75,7 +83,9 @@ mod tests {
         for shortcut in ["F13", "f20", " F24 "] {
             assert!(is_bare_extended_function_key(shortcut), "{shortcut}");
         }
-        for shortcut in ["F12", "F25", "Shift+F13", "F13+F14", "Space"] {
+        for shortcut in [
+            "F12", "F25", "Shift+F13", "F13+F14", "Space", "F013", "F0013", "F1a",
+        ] {
             assert!(!is_bare_extended_function_key(shortcut), "{shortcut}");
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -966,6 +966,7 @@ fn main() {
             commands::set_hotkey_mode,
             commands::set_hotkey,
             commands::set_hotkey_profiles,
+            commands::retry_hotkey_registration,
             commands::hotkey_status,
             commands::start_recording,
             commands::start_training_recording,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -43,7 +43,7 @@ use tauri::{
     tray::TrayIconBuilder,
     Emitter, Manager,
 };
-use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+use tauri_plugin_global_shortcut::ShortcutState;
 use tracing::{error, info, warn};
 
 #[cfg(any(target_os = "macos", test))]
@@ -451,6 +451,65 @@ fn acquire_gui_instance_guard_at(path: &Path) -> Result<GuiInstanceGuard, GuiIns
     }
 }
 
+fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::BareHotkeyState) {
+    let ctrl: tauri::State<'_, SharedController> = app.state();
+
+    match state {
+        hotkey::BareHotkeyState::Pressed => {
+            info!("Hotkey pressed: {shortcut}");
+            let (result, active_profile) = {
+                let mut c = ctrl.lock().unwrap();
+                let profile = c
+                    .settings()
+                    .hotkey_profile_for_shortcut(shortcut)
+                    .or_else(|| {
+                        (shortcut == SAFE_FALLBACK_HOTKEY)
+                            .then(|| c.settings().resolved_hotkey_profiles()[0].clone())
+                    });
+                let result = match profile {
+                    Some(profile) => match c.handle_hotkey_down_for_profile(profile) {
+                        Ok(result) => result,
+                        Err(error) => {
+                            error!("Hotkey down error: {error}");
+                            HotkeyDownResult::NoOp
+                        }
+                    },
+                    None => {
+                        warn!("Ignoring unconfigured shortcut event: {shortcut}");
+                        HotkeyDownResult::NoOp
+                    }
+                };
+                (result, c.active_hotkey_profile().cloned())
+            };
+            match result {
+                HotkeyDownResult::StartedRecording => {
+                    let show_overlay = {
+                        let c = ctrl.lock().unwrap();
+                        c.settings().show_overlay
+                    };
+                    let _ = app.emit(events::event::STATE_CHANGED, "recording");
+                    if let Some(profile) = active_profile {
+                        select_profile_menu(app, &profile);
+                        let _ = app.emit(events::event::ACTIVE_HOTKEY_PROFILE_CHANGED, profile);
+                    }
+                    update_tray_status(app, "recording");
+                    if show_overlay {
+                        overlay::show(app);
+                    }
+                }
+                HotkeyDownResult::StopRecording => {
+                    stop_recording_and_transcribe(app, &ctrl);
+                }
+                HotkeyDownResult::NoOp => {}
+            }
+        }
+        hotkey::BareHotkeyState::Released => {
+            info!("Hotkey released: {shortcut}");
+            handle_hotkey_release(app, &ctrl, shortcut);
+        }
+    }
+}
+
 fn main() {
     let gui_launch_mode = gui_launch_mode(std::env::args_os());
 
@@ -515,63 +574,11 @@ fn main() {
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
                 .with_handler(move |app, shortcut, event| {
-                    let ctrl: tauri::State<'_, SharedController> = app.state();
-
-                    match event.state {
-                        ShortcutState::Pressed => {
-                            info!("Hotkey pressed: {shortcut}");
-                            let (result, active_profile) = {
-                                let mut c = ctrl.lock().unwrap();
-                                let profile = c
-                                    .settings()
-                                    .hotkey_profile_for_shortcut(&shortcut.to_string())
-                                    .or_else(|| {
-                                        (shortcut.to_string() == SAFE_FALLBACK_HOTKEY).then(|| {
-                                            c.settings().resolved_hotkey_profiles()[0].clone()
-                                        })
-                                    });
-                                let result = match profile {
-                                    Some(profile) => match c.handle_hotkey_down_for_profile(profile) {
-                                        Ok(r) => r,
-                                        Err(e) => {
-                                            error!("Hotkey down error: {e}");
-                                            HotkeyDownResult::NoOp
-                                        }
-                                    },
-                                    None => {
-                                        warn!("Ignoring unconfigured shortcut event: {shortcut}");
-                                        HotkeyDownResult::NoOp
-                                    }
-                                };
-                                (result, c.active_hotkey_profile().cloned())
-                            };
-                            match result {
-                                HotkeyDownResult::StartedRecording => {
-                                    let show_overlay = {
-                                        let c = ctrl.lock().unwrap();
-                                        c.settings().show_overlay
-                                    };
-                                    let _ = app.emit(events::event::STATE_CHANGED, "recording");
-                                    if let Some(profile) = active_profile {
-                                        select_profile_menu(app, &profile);
-                                        let _ = app.emit(events::event::ACTIVE_HOTKEY_PROFILE_CHANGED, profile);
-                                    }
-                                    update_tray_status(app, "recording");
-                                    if show_overlay {
-                                        overlay::show(app);
-                                    }
-                                }
-                                HotkeyDownResult::StopRecording => {
-                                    stop_recording_and_transcribe(app, &ctrl);
-                                }
-                                HotkeyDownResult::NoOp => {}
-                            }
-                        }
-                        ShortcutState::Released => {
-                            info!("Hotkey released: {shortcut}");
-                            handle_hotkey_release(app, &ctrl, &shortcut.to_string());
-                        }
-                    }
+                    let state = match event.state {
+                        ShortcutState::Pressed => hotkey::BareHotkeyState::Pressed,
+                        ShortcutState::Released => hotkey::BareHotkeyState::Released,
+                    };
+                    handle_hotkey_event(app, &shortcut.to_string(), state);
                 })
                 .build(),
         )
@@ -593,7 +600,12 @@ fn main() {
         .setup(move |app| {
             // Hide from dock on macOS (tray-only app)
             #[cfg(target_os = "macos")]
-            platform::macos::set_activation_policy_accessory();
+            {
+                platform::macos::set_activation_policy_accessory();
+                if let Err(error) = hotkey::install_bare_function_key_monitor(app.handle()) {
+                    error!("Failed to install F13-F24 event monitor: {error}");
+                }
+            }
 
             // Read every configured dictation profile and register its shortcut.
             let profiles = {
@@ -625,14 +637,11 @@ fn main() {
                     "Refusing invalid saved hotkey profiles: {error}; trying safe fallback '{SAFE_FALLBACK_HOTKEY}'"
                 );
             }
-            let registration_error = app
-                .global_shortcut()
-                .register_multiple(registration_shortcuts.iter().map(String::as_str))
+            let registration_error = hotkey::register_shortcuts(app.handle(), &registration_shortcuts)
                 .err()
                 .map(|error| error.to_string());
             let cleanup_error = registration_error.as_ref().and_then(|_| {
-                app.global_shortcut()
-                    .unregister_multiple(registration_shortcuts.iter().map(String::as_str))
+                hotkey::unregister_shortcuts(app.handle(), &registration_shortcuts)
                     .err()
                     .map(|error| error.to_string())
             });
@@ -1709,9 +1718,10 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                 let validation_error = sagascript_core::settings::Settings::validate_hotkey_profiles(&new_profiles).err();
                 let unregister_error = if validation_error.is_none() {
                     match &old_operational {
-                        hotkey::OperationalHotkey::Registered(shortcuts) => app
-                            .global_shortcut()
-                            .unregister_multiple(shortcuts.iter().map(String::as_str))
+                        hotkey::OperationalHotkey::Registered(shortcuts) => hotkey::unregister_shortcuts(
+                            &app,
+                            shortcuts,
+                        )
                             .err()
                             .map(|error| error.to_string()),
                         hotkey::OperationalHotkey::Inactive => None,
@@ -1734,13 +1744,13 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                     new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
                     health.record(&old_settings.hotkey, Some(format!("failed to unregister previous hotkeys: {error}")), hotkey::OperationalHotkey::Unknown)
                 } else {
-                    match app.global_shortcut().register_multiple(new_shortcuts.iter().map(String::as_str)) {
+                    match hotkey::register_shortcuts(&app, &new_shortcuts) {
                         Ok(()) => health.record(&new_settings.hotkey, None, hotkey::OperationalHotkey::registered_many(&new_shortcuts)),
                         Err(error) => {
                             new_settings.hotkey = old_settings.hotkey.clone();
                             new_settings.language = old_settings.language;
                             new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
-                            match app.global_shortcut().unregister_multiple(new_shortcuts.iter().map(String::as_str)) {
+                            match hotkey::unregister_shortcuts(&app, &new_shortcuts) {
                                 Err(cleanup_error) => health.record(
                                     &old_settings.hotkey,
                                     Some(format!("failed to register new hotkey profiles: {error}; partial-registration cleanup failed: {cleanup_error}")),
@@ -1748,7 +1758,7 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                                 ),
                                 Ok(()) => {
                                     let restored = match &old_operational {
-                                        hotkey::OperationalHotkey::Registered(shortcuts) => app.global_shortcut().register_multiple(shortcuts.iter().map(String::as_str)).is_ok(),
+                                        hotkey::OperationalHotkey::Registered(shortcuts) => hotkey::register_shortcuts(&app, shortcuts).is_ok(),
                                         hotkey::OperationalHotkey::Inactive => true,
                                         hotkey::OperationalHotkey::Unknown => false,
                                     };

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -17,6 +17,7 @@
     openMicrophoneSettings,
     checkAccessibilityPermission,
     requestAccessibilityPermission,
+    retryHotkeyRegistration,
     openAccessibilitySettings,
     setAutoPaste,
     setOnboardingCompleted,
@@ -206,6 +207,11 @@
             accessibilityGranted = true;
             accessibilityChecking = false;
             stopPoll();
+            try {
+              await retryHotkeyRegistration();
+            } catch (e: any) {
+              accessibilityError = `Accessibility was granted, but the saved dictation shortcut could not be registered: ${typeof e === "string" ? e : e?.message ?? "unknown error"}`;
+            }
           }
         } catch (e: any) {
           if (!isCurrent()) return;

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -219,7 +219,12 @@
         const status = await hotkeyStatus();
         hotkeyStatusOk = status.ok;
         hotkeyStatusError = status.error ?? "";
-        if (platform === "macos" && accessibilityGranted && !status.ok) {
+        if (
+          platform === "macos" &&
+          accessibilityGranted &&
+          !status.ok &&
+          configuredShortcutsUseBareHotkey()
+        ) {
           await refreshHotkeyRegistration();
         }
 
@@ -316,8 +321,21 @@
     return false;
   }
 
-  async function refreshHotkeyRegistration(): Promise<void> {
-    try {
+  function configuredShortcutsUseBareHotkey(): boolean {
+    // Only bare F13–F24 registrations depend on the macOS Accessibility
+    // grant, so only those benefit from an automatic retry on Settings
+    // open. Retrying other failures (e.g. shortcut-in-use) would just churn
+    // unregister/register without helping. Gated on shortcut content, not
+    // on backend error text, to avoid fragile string coupling.
+    if (!settings) return false;
+    const shortcuts = [
+      settings.hotkey,
+      ...settings.hotkey_profiles.map((profile) => profile.shortcut),
+    ];
+    return shortcuts.some((shortcut) => canUseBareHotkey(shortcut, platform));
+  }
+
+  async function refreshHotkeyRegistration(): Promise<void> {    try {
       await retryHotkeyRegistration();
       settings = await getSettings();
       await refreshProfileModels(settings.hotkey_profiles);

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -21,6 +21,7 @@
     getPlatform,
     checkAccessibilityPermission,
     requestAccessibilityPermission,
+    retryHotkeyRegistration,
     startRecording,
     stopAndTranscribe,
     hotkeyStatus,
@@ -218,6 +219,9 @@
         const status = await hotkeyStatus();
         hotkeyStatusOk = status.ok;
         hotkeyStatusError = status.error ?? "";
+        if (platform === "macos" && accessibilityGranted && !status.ok) {
+          await refreshHotkeyRegistration();
+        }
 
         // Check URL params for initial tab
         const params = new URLSearchParams(window.location.search);
@@ -304,9 +308,27 @@
     // minute; no unbounded timer survives after this explicit attempt.
     for (let attempt = 0; attempt < 60; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      if (await checkAccessibilityPermission()) return true;
+      if (await checkAccessibilityPermission()) {
+        await refreshHotkeyRegistration();
+        return true;
+      }
     }
     return false;
+  }
+
+  async function refreshHotkeyRegistration(): Promise<void> {
+    try {
+      await retryHotkeyRegistration();
+      settings = await getSettings();
+      await refreshProfileModels(settings.hotkey_profiles);
+    } catch (error) {
+      // The registration-health response below contains the backend's full
+      // diagnostic and keeps the failure visible in Settings.
+      console.warn("Failed to retry hotkey registration", error);
+    }
+    const status = await hotkeyStatus();
+    hotkeyStatusOk = status.ok;
+    hotkeyStatusError = status.error ?? "";
   }
 
   async function onShowOverlayToggle() {
@@ -718,11 +740,11 @@
             <div class="hotkey-error">{hotkeyError}</div>
           {:else if !hotkeyStatusOk}
             <div class="hotkey-error">
-              ⚠ Not registered{hotkeyStatusError ? `: ${hotkeyStatusError}` : ""}{#if !hotkeyStatusError.includes("Accessibility")} — this shortcut may already be in use by another app. Try a different combination.{/if}
+              ⚠ Not registered{hotkeyStatusError ? `: ${hotkeyStatusError}` : ""}{#if platform === "macos"} — check Accessibility permission or whether another app uses this shortcut.{:else} — this shortcut may already be in use by another app. Try a different combination.{/if}
             </div>
           {/if}
           <div class="hotkey-hint">
-            Each shortcut selects its language. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission.{/if}
+            Each shortcut selects its language. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission: macOS sends keyboard events to Sagascript, which immediately ignores everything except bare F13–F24 and never stores or sends them.{/if}
           </div>
         </div>
 

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -40,6 +40,11 @@
     retainTestRecordingOwnership,
     type BackendDictationState,
   } from "./dictation-ui-state";
+  import {
+    canUseBareHotkey,
+    supportedBareFunctionKeyRange,
+    tauriKeyName,
+  } from "./hotkey.js";
 
   let settings: Settings | null = $state(null);
   let buildInfo: BuildInfo | null = $state(null);
@@ -68,6 +73,7 @@
 
   // Hotkey recorder state
   let recordingProfileId: string | null = $state(null);
+  let hotkeyCaptureGeneration = 0;
   let draftProfileId: string | null = $state(null);
   let hotkeyError: string = $state("");
   let hotkeyRecorderEl: HTMLButtonElement | undefined = $state();
@@ -449,28 +455,6 @@
     }
   }
 
-  /** Map DOM key names to Tauri global-shortcut format */
-  function tauriKeyName(key: string): string | null {
-    if (key === " ") return "Space";
-    if (key === "Meta") return null; // modifier only
-    if (key === "Control") return null;
-    if (key === "Alt") return null;
-    if (key === "Shift") return null;
-    // F-keys
-    if (/^F\d{1,2}$/.test(key)) return key;
-    // Single letter/digit
-    if (/^[a-zA-Z0-9]$/.test(key)) return key.toUpperCase();
-    // Arrow keys
-    if (key.startsWith("Arrow")) return key;
-    // Named keys
-    const mapped: Record<string, string> = {
-      Tab: "Tab", Enter: "Enter", Backspace: "Backspace", Delete: "Delete",
-      Escape: "Escape", Home: "Home", End: "End", PageUp: "PageUp",
-      PageDown: "PageDown", Insert: "Insert",
-    };
-    return mapped[key] ?? null;
-  }
-
   /** Platform-correct modifier display names */
   function modifierNames(): { ctrl: string; alt: string; meta: string } {
     const mac = platform === "macos";
@@ -492,12 +476,20 @@
       .join(" + ");
   }
 
-  function onHotkeyKeydown(e: KeyboardEvent, profileId: string) {
+  function beginHotkeyCapture(profileId: string) {
+    hotkeyCaptureGeneration += 1;
+    recordingProfileId = profileId;
+    hotkeyError = "";
+  }
+
+  async function onHotkeyKeydown(e: KeyboardEvent, profileId: string) {
+    const captureGeneration = hotkeyCaptureGeneration;
     e.preventDefault();
     e.stopPropagation();
 
     // Escape cancels recording
     if (e.key === "Escape") {
+      hotkeyCaptureGeneration += 1;
       recordingProfileId = null;
       hotkeyError = "";
       return;
@@ -508,16 +500,44 @@
 
     const keyName = tauriKeyName(e.key);
     if (!keyName) {
-      hotkeyError = `"${e.key}" is not a supported key. Use A–Z, 0–9, F1–F12, Space, Arrow keys, or Tab/Enter/Delete.`;
+      hotkeyError = `"${e.key}" is not a supported key. Use A–Z, 0–9, F1–F24, Space, Arrow keys, or Tab/Enter/Delete.`;
       return;
     }
 
-    // Must have at least one modifier
+    // Ordinary keys require a modifier. Extended function keys are reserved
+    // for programmable buttons and may be used directly through the native
+    // macOS monitor or the Windows global-shortcut backend.
     const hasModifier = e.ctrlKey || e.altKey || e.metaKey || e.shiftKey;
-    if (!hasModifier) {
-      const m = modifierNames();
-      hotkeyError = `Shortcut must include a modifier (${m.ctrl}, ${m.alt}, ${m.meta}, or Shift)`;
+    if (platform === "macos" && hasModifier && /^F2[1-4]$/.test(keyName)) {
+      hotkeyError = `${keyName} is supported without modifiers on macOS, but its modified forms cannot be registered reliably.`;
       return;
+    }
+    if (!hasModifier && !canUseBareHotkey(keyName, platform)) {
+      const m = modifierNames();
+      const bareRange = supportedBareFunctionKeyRange(platform);
+      hotkeyError = `Shortcut must include a modifier (${m.ctrl}, ${m.alt}, ${m.meta}, or Shift).${bareRange ? ` ${bareRange} may be used alone.` : ""}`;
+      return;
+    }
+
+    if (platform === "macos" && !hasModifier && /^F(?:1[3-9]|2[0-4])$/.test(keyName)) {
+      accessibilityChecking = true;
+      try {
+        accessibilityGranted = await checkAccessibilityPermission();
+        if (!accessibilityGranted) {
+          await requestAccessibilityPermission();
+          accessibilityGranted = await waitForAccessibilityPermission();
+        }
+      } catch (error: any) {
+        hotkeyError = typeof error === "string" ? error : error?.message || "Failed to check Accessibility permission.";
+        return;
+      } finally {
+        accessibilityChecking = false;
+      }
+      if (!accessibilityGranted) {
+        hotkeyError = "F13–F24 requires Accessibility permission on macOS. Permission was not granted.";
+        return;
+      }
+      if (captureGeneration !== hotkeyCaptureGeneration) return;
     }
 
     // Build Tauri-format shortcut string (order: Control, Alt, Super, Shift, Key)
@@ -575,7 +595,7 @@
     };
     settings = { ...settings, hotkey_profiles: [...settings.hotkey_profiles, profile] };
     draftProfileId = profile.id;
-    recordingProfileId = profile.id;
+    beginHotkeyCapture(profile.id);
     void refreshProfileModels(settings.hotkey_profiles);
   }
 
@@ -662,7 +682,7 @@
                 {:else}
                   <button
                     class="hotkey-recorder"
-                    onclick={() => { recordingProfileId = profile.id; hotkeyError = ""; }}
+                    onclick={() => beginHotkeyCapture(profile.id)}
                   >{formatHotkeyDisplay(profile.shortcut)}</button>
                 {/if}
                 {#if settings.hotkey_profiles.length > 1}
@@ -698,10 +718,12 @@
             <div class="hotkey-error">{hotkeyError}</div>
           {:else if !hotkeyStatusOk}
             <div class="hotkey-error">
-              ⚠ Not registered{hotkeyStatusError ? `: ${hotkeyStatusError}` : ""} — this shortcut may already be in use by another app. Try a different combination.
+              ⚠ Not registered{hotkeyStatusError ? `: ${hotkeyStatusError}` : ""}{#if !hotkeyStatusError.includes("Accessibility")} — this shortcut may already be in use by another app. Try a different combination.{/if}
             </div>
           {/if}
-          <div class="hotkey-hint">Each shortcut selects its language. Modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key.</div>
+          <div class="hotkey-hint">
+            Each shortcut selects its language. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission.{/if}
+          </div>
         </div>
 
         <div class="field">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -113,6 +113,11 @@ export async function hotkeyStatus(): Promise<HotkeyStatus> {
   return invoke("hotkey_status");
 }
 
+/** Retry the shortcuts persisted by either the GUI or CLI. */
+export async function retryHotkeyRegistration(): Promise<void> {
+  return invoke("retry_hotkey_registration");
+}
+
 export async function setAutoPaste(enabled: boolean): Promise<void> {
   return invoke("set_auto_paste", { enabled });
 }

--- a/src/lib/hotkey.js
+++ b/src/lib/hotkey.js
@@ -1,0 +1,62 @@
+/**
+ * Map a DOM KeyboardEvent key value to Tauri global-shortcut format.
+ *
+ * @param {string} key
+ * @returns {string | null}
+ */
+export function tauriKeyName(key) {
+  if (key === " ") return "Space";
+  if (["Meta", "Control", "Alt", "Shift"].includes(key)) return null;
+
+  const functionKey = /^F(\d{1,2})$/.exec(key);
+  if (functionKey) {
+    const number = Number.parseInt(functionKey[1], 10);
+    return number >= 1 && number <= 24 ? `F${number}` : null;
+  }
+
+  if (/^[a-zA-Z0-9]$/.test(key)) return key.toUpperCase();
+  if (key.startsWith("Arrow")) return key;
+
+  /** @type {Record<string, string>} */
+  const mapped = {
+    Tab: "Tab",
+    Enter: "Enter",
+    Backspace: "Backspace",
+    Delete: "Delete",
+    Escape: "Escape",
+    Home: "Home",
+    End: "End",
+    PageUp: "PageUp",
+    PageDown: "PageDown",
+    Insert: "Insert",
+  };
+  return mapped[key] ?? null;
+}
+
+/**
+ * Return whether a canonical key may be registered without modifiers.
+ * Sagascript has a native macOS path for F13-F24 and the Windows backend
+ * supports the same range; the locked Linux backend has no mapping beyond F12.
+ *
+ * @param {string} key
+ * @param {string} platform
+ * @returns {boolean}
+ */
+export function canUseBareHotkey(key, platform) {
+  const match = /^F(\d{1,2})$/i.exec(key);
+  if (!match) return false;
+
+  const number = Number.parseInt(match[1], 10);
+  const maximum = platform === "macos" || platform === "windows" ? 24 : 12;
+  return number >= 13 && number <= maximum;
+}
+
+/**
+ * @param {string} platform
+ * @returns {string | null}
+ */
+export function supportedBareFunctionKeyRange(platform) {
+  if (platform === "macos") return "F13–F24";
+  if (platform === "windows") return "F13–F24";
+  return null;
+}

--- a/src/lib/hotkey.js
+++ b/src/lib/hotkey.js
@@ -8,7 +8,7 @@ export function tauriKeyName(key) {
   if (key === " ") return "Space";
   if (["Meta", "Control", "Alt", "Shift"].includes(key)) return null;
 
-  const functionKey = /^F(\d{1,2})$/.exec(key);
+  const functionKey = /^F(\d{1,2})$/i.exec(key.trim());
   if (functionKey) {
     const number = Number.parseInt(functionKey[1], 10);
     return number >= 1 && number <= 24 ? `F${number}` : null;
@@ -43,7 +43,7 @@ export function tauriKeyName(key) {
  * @returns {boolean}
  */
 export function canUseBareHotkey(key, platform) {
-  const match = /^F(\d{1,2})$/i.exec(key);
+  const match = /^F(\d{1,2})$/i.exec(key.trim());
   if (!match) return false;
 
   const number = Number.parseInt(match[1], 10);


### PR DESCRIPTION
## Summary

- support bare F13–F24 hotkeys on macOS through a narrowly filtered AppKit event monitor
- accept bare F13–F24 on Windows through the existing hotkey backend
- preserve modified F13–F24 configurations on Linux while continuing to reject bare variants
- expose the capability consistently in Settings and the CLI
- retry persisted GUI/CLI hotkeys after macOS Accessibility is granted

Refs #171. The issue intentionally remains open until the programmable-keyboard acceptance test and signed test DMG are complete.

## macOS registration and privacy decision

A runtime probe of the locked global-hotkey 0.7.0 Carbon path on macOS 26.6.2 (build 25G83) found that bare F13–F20 reach RegisterEventHotKey but are rejected; bare F21–F24 fail earlier as unknown scancodes. The apparent F13–F20 source mapping therefore does not provide a working permission-free path on the tested stack.

The approved product decision is to use the AppKit monitor for the complete bare F13–F24 range. This requires Accessibility. macOS delivers system KeyDown/KeyUp events to the callback; Sagascript immediately rejects anything that is not one unmodified F13–F24 scalar. Non-matching events are not logged, stored, or sent anywhere, and the monitor lives only for the app process. Settings, README, and installation/configuration docs now disclose this behavior. Users can avoid this access by using a modified shortcut.

Modified F21–F24 remain rejected on macOS because the Carbon backend cannot map them reliably. Modified F13–F24 remain valid on Linux to avoid resetting previously accepted configurations.

## Verification

- cargo check -p sagascript --all-targets
- cargo test --workspace (143 app tests and 358 core tests passed outside the macOS pasteboard sandbox)
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build -p sagascript-cli --no-default-features
- npm run test:frontend (42 passed)
- npx svelte-check --tsconfig ./tsconfig.json (0 errors, 0 warnings)
- cargo tauri build --debug at 2d352b2cc71733c2d244d3d924c8f3368596fd59 (app and DMG produced)
- Settings view visually checked at 500×760

## Remaining acceptance test

Physical F13–F24 validation is still required on Sebastians NuPhy Air75 V3. A signed and notarized DMG must then be published as a clearly marked test build outside the stable channel before issue #171 is closed.