### PR TITLE
fix: ship native, discoverable Windows candidates

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -56,20 +56,36 @@ jobs:
             throw "Expected native ${{ matrix.architecture }} runner, got $runnerArchitecture"
           }
 
+      - name: Configure native ARM64 C and C++ toolchain
+        if: matrix.architecture == 'arm64'
+        shell: pwsh
+        run: |
+          $clang = Get-Command clang-cl -ErrorAction Stop
+          $ninja = Get-Command ninja -ErrorAction Stop
+          & $clang.Source --version
+          & $ninja.Source --version
+          "CMAKE_GENERATOR=Ninja" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CC=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CXX=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_C_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_CXX_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_ASM_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_C_COMPILER_TARGET=aarch64-pc-windows-msvc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_CXX_COMPILER_TARGET=aarch64-pc-windows-msvc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
+      - name: Cache Cargo registry
         uses: actions/cache@v5
         with:
           path: |
             ~\.cargo\registry
             ~\.cargo\git
-            src-tauri\target
-          key: windows-package-${{ matrix.architecture }}-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json') }}
+          key: windows-package-${{ matrix.architecture }}-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json', '.github/workflows/windows-package.yml') }}
           restore-keys: |
             windows-package-${{ matrix.architecture }}-
 

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -83,7 +83,14 @@ jobs:
             --beam 0 `
             --json `
             test-audio/norwegian-short-3s.mp3 > $stdout 2> $stderr
-          if ($LASTEXITCODE -ne 0) { throw "Transcription failed with exit code $LASTEXITCODE" }
+          if ($LASTEXITCODE -ne 0) {
+            $transcriptionExit = $LASTEXITCODE
+            Write-Host "Transcription stdout:"
+            if (Test-Path $stdout) { Get-Content $stdout }
+            Write-Host "Transcription stderr:"
+            if (Test-Path $stderr) { Get-Content $stderr }
+            throw "Transcription failed with exit code $transcriptionExit"
+          }
           python scripts/verify-json-cli-streams.py $stdout $stderr
           $result = Get-Content $stdout -Raw | ConvertFrom-Json
           if ($result.language -ne "no") { throw "Expected Norwegian result, got '$($result.language)'" }

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -17,7 +17,18 @@ permissions:
 
 jobs:
   build-windows-candidate:
-    runs-on: windows-latest
+    name: Build Windows ${{ matrix.architecture }} candidate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: x64
+            runner: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+          - architecture: arm64
+            runner: windows-11-arm
+            rust_target: aarch64-pc-windows-msvc
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
 
     steps:
@@ -28,6 +39,22 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: ${{ matrix.rust_target }}
+
+      - name: Verify native runner architecture
+        shell: pwsh
+        run: |
+          $hostTriple = rustc -vV | Select-String '^host:' | ForEach-Object { ($_ -split ':', 2)[1].Trim() }
+          if ([string]::IsNullOrWhiteSpace($hostTriple)) {
+            throw "Unable to determine the Rust host triple"
+          }
+          if ($hostTriple -ne '${{ matrix.rust_target }}') {
+            throw "Expected native ${{ matrix.rust_target }} runner, got $hostTriple"
+          }
+          $runnerArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+          if ($runnerArchitecture -ne '${{ matrix.architecture }}') {
+            throw "Expected native ${{ matrix.architecture }} runner, got $runnerArchitecture"
+          }
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -42,9 +69,9 @@ jobs:
             ~\.cargo\registry
             ~\.cargo\git
             src-tauri\target
-          key: windows-package-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json') }}
+          key: windows-package-${{ matrix.architecture }}-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json') }}
           restore-keys: |
-            windows-package-
+            windows-package-${{ matrix.architecture }}-
 
       - name: Install npm dependencies
         run: npm ci
@@ -71,8 +98,8 @@ jobs:
       - name: Gate real Windows transcription
         shell: pwsh
         run: |
-          cargo build --release -p sagascript-cli --manifest-path src-tauri/Cargo.toml
-          $binary = "src-tauri\target\release\sagascript.exe"
+          cargo build --release -p sagascript-cli --manifest-path src-tauri/Cargo.toml --target ${{ matrix.rust_target }}
+          $binary = "src-tauri\target\${{ matrix.rust_target }}\release\sagascript.exe"
           $stdout = Join-Path $env:RUNNER_TEMP "transcription-smoke.json"
           $stderr = Join-Path $env:RUNNER_TEMP "transcription-smoke.stderr"
           & $binary download-model nb-whisper-tiny
@@ -99,44 +126,49 @@ jobs:
           Copy-Item $binary (Join-Path $env:RUNNER_TEMP "sagascript-cli.exe")
 
       - name: Build unsigned internal installers
-        run: npx tauri build --ci --bundles nsis,msi --no-sign
+        run: npx tauri build --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }}
 
       - name: Prepare and verify candidate artifacts
         shell: pwsh
         run: |
           $version = node -p "require('./package.json').version"
-          $desktop = "src-tauri\target\release\sagascript.exe"
+          $architecture = "${{ matrix.architecture }}"
+          $targetRoot = "src-tauri\target\${{ matrix.rust_target }}\release"
+          $desktop = Join-Path $targetRoot "sagascript.exe"
           $cli = Join-Path $env:RUNNER_TEMP "sagascript-cli.exe"
-          $nsis = Get-ChildItem "src-tauri\target\release\bundle\nsis" -Filter "*.exe" -File | Select-Object -First 1
-          $msi = Get-ChildItem "src-tauri\target\release\bundle\msi" -Filter "*.msi" -File | Select-Object -First 1
+          if (-not (Test-Path -LiteralPath $desktop -PathType Leaf)) {
+            throw "Tauri did not produce the desktop executable at the native target path: $desktop"
+          }
+          $nsis = Get-ChildItem (Join-Path $targetRoot "bundle\nsis") -Filter "*.exe" -File | Sort-Object Name | Select-Object -First 1
+          $msi = Get-ChildItem (Join-Path $targetRoot "bundle\msi") -Filter "*.msi" -File | Sort-Object Name | Select-Object -First 1
           if (-not $nsis) { throw "Tauri did not produce an NSIS installer" }
           if (-not $msi) { throw "Tauri did not produce an MSI installer" }
 
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          Copy-Item $desktop "artifacts\Sagascript-Windows-x64-Portable.exe"
-          Copy-Item $cli "artifacts\Sagascript-Windows-x64-CLI.exe"
-          Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-x64-Setup.exe"
-          Copy-Item $msi.FullName "artifacts\Sagascript-Windows-x64.msi"
+          Copy-Item $desktop "artifacts\Sagascript-Windows-$architecture-Portable.exe"
+          Copy-Item $cli "artifacts\Sagascript-Windows-$architecture-CLI.exe"
+          Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-$architecture-Setup.exe"
+          Copy-Item $msi.FullName "artifacts\Sagascript-Windows-$architecture.msi"
           Copy-Item "docs\windows-release.md" "artifacts\README-Windows-Candidate.md"
           Copy-Item "scripts\accept-windows-candidate.ps1" "artifacts\accept-windows-candidate.ps1"
           Copy-Item "test-audio\norwegian-short-3s.mp3" "artifacts\norwegian-short-3s.mp3"
 
           ./scripts/verify-windows-release.ps1 `
-            -CliExe "artifacts\Sagascript-Windows-x64-CLI.exe" `
+            -CliExe "artifacts\Sagascript-Windows-$architecture-CLI.exe" `
             -ExpectedVersion $version `
             -Artifacts @(
-              "artifacts\Sagascript-Windows-x64-Portable.exe",
-              "artifacts\Sagascript-Windows-x64-CLI.exe",
-              "artifacts\Sagascript-Windows-x64-Setup.exe",
-              "artifacts\Sagascript-Windows-x64.msi"
+              "artifacts\Sagascript-Windows-$architecture-Portable.exe",
+              "artifacts\Sagascript-Windows-$architecture-CLI.exe",
+              "artifacts\Sagascript-Windows-$architecture-Setup.exe",
+              "artifacts\Sagascript-Windows-$architecture.msi"
             ) `
             -SignaturePolicy Internal `
-            -ChecksumOutput "artifacts\SHA256SUMS-Windows"
+            -ChecksumOutput "artifacts\SHA256SUMS-Windows-$architecture"
 
       - name: Upload internal Windows candidate
         uses: actions/upload-artifact@v4
         with:
-          name: windows-x64-unsigned-candidate
+          name: windows-${{ matrix.architecture }}-unsigned-candidate
           path: artifacts/
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -96,6 +96,7 @@ jobs:
           if ($result.language -ne "no") { throw "Expected Norwegian result, got '$($result.language)'" }
           if ($result.text -notmatch "(?i)storting") { throw "Expected 'storting' in transcription" }
           if (-not $result.segments) { throw "Expected at least one transcription segment" }
+          Copy-Item $binary (Join-Path $env:RUNNER_TEMP "sagascript-cli.exe")
 
       - name: Build unsigned internal installers
         run: npx tauri build --ci --bundles nsis,msi --no-sign
@@ -104,14 +105,16 @@ jobs:
         shell: pwsh
         run: |
           $version = node -p "require('./package.json').version"
-          $native = "src-tauri\target\release\sagascript.exe"
+          $desktop = "src-tauri\target\release\sagascript.exe"
+          $cli = Join-Path $env:RUNNER_TEMP "sagascript-cli.exe"
           $nsis = Get-ChildItem "src-tauri\target\release\bundle\nsis" -Filter "*.exe" -File | Select-Object -First 1
           $msi = Get-ChildItem "src-tauri\target\release\bundle\msi" -Filter "*.msi" -File | Select-Object -First 1
           if (-not $nsis) { throw "Tauri did not produce an NSIS installer" }
           if (-not $msi) { throw "Tauri did not produce an MSI installer" }
 
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          Copy-Item $native "artifacts\Sagascript-Windows-x64.exe"
+          Copy-Item $desktop "artifacts\Sagascript-Windows-x64-Portable.exe"
+          Copy-Item $cli "artifacts\Sagascript-Windows-x64-CLI.exe"
           Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-x64-Setup.exe"
           Copy-Item $msi.FullName "artifacts\Sagascript-Windows-x64.msi"
           Copy-Item "docs\windows-release.md" "artifacts\README-Windows-Candidate.md"
@@ -119,10 +122,11 @@ jobs:
           Copy-Item "test-audio\norwegian-short-3s.mp3" "artifacts\norwegian-short-3s.mp3"
 
           ./scripts/verify-windows-release.ps1 `
-            -AppExe "artifacts\Sagascript-Windows-x64.exe" `
+            -CliExe "artifacts\Sagascript-Windows-x64-CLI.exe" `
             -ExpectedVersion $version `
             -Artifacts @(
-              "artifacts\Sagascript-Windows-x64.exe",
+              "artifacts\Sagascript-Windows-x64-Portable.exe",
+              "artifacts\Sagascript-Windows-x64-CLI.exe",
               "artifacts\Sagascript-Windows-x64-Setup.exe",
               "artifacts\Sagascript-Windows-x64.msi"
             ) `

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,0 +1,131 @@
+name: Windows Package Candidate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/windows-package.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/**"
+      - "src/**"
+      - "src-tauri/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-candidate:
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Cargo registry and target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~\.cargo\registry
+            ~\.cargo\git
+            src-tauri\target
+          key: windows-package-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json') }}
+          restore-keys: |
+            windows-package-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Verify release metadata and licenses
+        run: |
+          npm run release:check
+          npm run licenses:check
+
+      - name: Test frontend release surface
+        run: npm run test:frontend
+
+      - name: Build and check frontend
+        run: |
+          npm run build
+          npm run check
+
+      - name: Test and lint Rust workspace
+        working-directory: src-tauri
+        run: |
+          cargo test --workspace
+          cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Gate real Windows transcription
+        shell: pwsh
+        run: |
+          cargo build --release -p sagascript-cli --manifest-path src-tauri/Cargo.toml
+          $binary = "src-tauri\target\release\sagascript.exe"
+          $stdout = Join-Path $env:RUNNER_TEMP "transcription-smoke.json"
+          $stderr = Join-Path $env:RUNNER_TEMP "transcription-smoke.stderr"
+          & $binary download-model nb-whisper-tiny
+          if ($LASTEXITCODE -ne 0) { throw "Model download failed with exit code $LASTEXITCODE" }
+          & $binary transcribe `
+            --language no `
+            --model nb-whisper-tiny `
+            --beam 0 `
+            --json `
+            test-audio/norwegian-short-3s.mp3 > $stdout 2> $stderr
+          if ($LASTEXITCODE -ne 0) { throw "Transcription failed with exit code $LASTEXITCODE" }
+          python scripts/verify-json-cli-streams.py $stdout $stderr
+          $result = Get-Content $stdout -Raw | ConvertFrom-Json
+          if ($result.language -ne "no") { throw "Expected Norwegian result, got '$($result.language)'" }
+          if ($result.text -notmatch "(?i)storting") { throw "Expected 'storting' in transcription" }
+          if (-not $result.segments) { throw "Expected at least one transcription segment" }
+
+      - name: Build unsigned internal installers
+        run: npx tauri build --ci --bundles nsis,msi --no-sign
+
+      - name: Prepare and verify candidate artifacts
+        shell: pwsh
+        run: |
+          $version = node -p "require('./package.json').version"
+          $native = "src-tauri\target\release\sagascript.exe"
+          $nsis = Get-ChildItem "src-tauri\target\release\bundle\nsis" -Filter "*.exe" -File | Select-Object -First 1
+          $msi = Get-ChildItem "src-tauri\target\release\bundle\msi" -Filter "*.msi" -File | Select-Object -First 1
+          if (-not $nsis) { throw "Tauri did not produce an NSIS installer" }
+          if (-not $msi) { throw "Tauri did not produce an MSI installer" }
+
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          Copy-Item $native "artifacts\Sagascript-Windows-x64.exe"
+          Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-x64-Setup.exe"
+          Copy-Item $msi.FullName "artifacts\Sagascript-Windows-x64.msi"
+          Copy-Item "docs\windows-release.md" "artifacts\README-Windows-Candidate.md"
+          Copy-Item "scripts\accept-windows-candidate.ps1" "artifacts\accept-windows-candidate.ps1"
+          Copy-Item "test-audio\norwegian-short-3s.mp3" "artifacts\norwegian-short-3s.mp3"
+
+          ./scripts/verify-windows-release.ps1 `
+            -AppExe "artifacts\Sagascript-Windows-x64.exe" `
+            -ExpectedVersion $version `
+            -Artifacts @(
+              "artifacts\Sagascript-Windows-x64.exe",
+              "artifacts\Sagascript-Windows-x64-Setup.exe",
+              "artifacts\Sagascript-Windows-x64.msi"
+            ) `
+            -SignaturePolicy Internal `
+            -ChecksumOutput "artifacts\SHA256SUMS-Windows"
+
+      - name: Upload internal Windows candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64-unsigned-candidate
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -125,6 +125,17 @@ jobs:
           if (-not $result.segments) { throw "Expected at least one transcription segment" }
           Copy-Item $binary (Join-Path $env:RUNNER_TEMP "sagascript-cli.exe")
 
+      - name: Remove cached installer bundles
+        shell: pwsh
+        run: |
+          $bundleRoot = "src-tauri\target\${{ matrix.rust_target }}\release\bundle"
+          foreach ($format in @("nsis", "msi")) {
+            $bundleDirectory = Join-Path $bundleRoot $format
+            if (Test-Path -LiteralPath $bundleDirectory) {
+              Remove-Item -LiteralPath $bundleDirectory -Recurse -Force
+            }
+          }
+
       - name: Build unsigned internal installers
         run: npx tauri build --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }}
 
@@ -139,16 +150,18 @@ jobs:
           if (-not (Test-Path -LiteralPath $desktop -PathType Leaf)) {
             throw "Tauri did not produce the desktop executable at the native target path: $desktop"
           }
-          $nsis = Get-ChildItem (Join-Path $targetRoot "bundle\nsis") -Filter "*.exe" -File | Sort-Object Name | Select-Object -First 1
-          $msi = Get-ChildItem (Join-Path $targetRoot "bundle\msi") -Filter "*.msi" -File | Sort-Object Name | Select-Object -First 1
-          if (-not $nsis) { throw "Tauri did not produce an NSIS installer" }
-          if (-not $msi) { throw "Tauri did not produce an MSI installer" }
+          $nsis = @(Get-ChildItem (Join-Path $targetRoot "bundle\nsis") -Filter "*.exe" -File)
+          $msi = @(Get-ChildItem (Join-Path $targetRoot "bundle\msi") -Filter "*.msi" -File)
+          if ($nsis.Count -ne 1) { throw "Expected exactly one current NSIS installer, found $($nsis.Count)" }
+          if ($msi.Count -ne 1) { throw "Expected exactly one current MSI installer, found $($msi.Count)" }
+          if ($nsis[0].Name -notmatch [regex]::Escape($version)) { throw "NSIS installer does not match version ${version}: $($nsis[0].Name)" }
+          if ($msi[0].Name -notmatch [regex]::Escape($version)) { throw "MSI installer does not match version ${version}: $($msi[0].Name)" }
 
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
           Copy-Item $desktop "artifacts\Sagascript-Windows-$architecture-Portable.exe"
           Copy-Item $cli "artifacts\Sagascript-Windows-$architecture-CLI.exe"
-          Copy-Item $nsis.FullName "artifacts\Sagascript-Windows-$architecture-Setup.exe"
-          Copy-Item $msi.FullName "artifacts\Sagascript-Windows-$architecture.msi"
+          Copy-Item $nsis[0].FullName "artifacts\Sagascript-Windows-$architecture-Setup.exe"
+          Copy-Item $msi[0].FullName "artifacts\Sagascript-Windows-$architecture.msi"
           Copy-Item "docs\windows-release.md" "artifacts\README-Windows-Candidate.md"
           Copy-Item "scripts\accept-windows-candidate.ps1" "artifacts\accept-windows-candidate.ps1"
           Copy-Item "test-audio\norwegian-short-3s.mp3" "artifacts\norwegian-short-3s.mp3"

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -67,6 +67,7 @@ jobs:
           "CMAKE_GENERATOR=Ninja" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CC=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CXX=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_CXX_FLAGS=/EHsc /utf-8" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_C_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_CXX_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_ASM_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ for recording audio. Do not install an unsigned binary from an untrusted party.
 - [Installation guide](docs/installation.md) -- detailed install instructions for macOS and Windows
 - [Linux notes](docs/linux-notes.md) -- experimental Linux build, prerequisites, and known limitations
 - [Windows-specific notes](docs/windows-notes.md) -- feature comparison, known limitations, and troubleshooting
+- [Windows release track](docs/windows-release.md) -- unsigned internal candidates, zero-cost Store path, and acceptance gates
 - [Configuration files](docs/configuration.md) -- XDG paths, dotfiles, migration, and personal dictionaries
 - [Third-party notices](THIRD_PARTY_NOTICES.md) -- dependency and downloadable-model licenses
 - [Model sources and integrity manifest](docs/model-sources.md) -- pinned revisions, licenses, sizes, and SHA-256 checksums

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -405,6 +405,7 @@ link; the upstream repository is authoritative for its license terms.
 | tauri-plugin-dialog | 2.6.0 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/plugins-workspace) |
 | tauri-plugin-fs | 2.4.5 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/plugins-workspace) |
 | tauri-plugin-global-shortcut | 2.3.1 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/plugins-workspace) |
+| tauri-plugin-single-instance | 2.4.4 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/plugins-workspace) |
 | tauri-runtime | 2.10.0 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/tauri) |
 | tauri-runtime-wry | 2.10.0 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/tauri) |
 | tauri-utils | 2.8.2 | Apache-2.0 OR MIT | [upstream](https://github.com/tauri-apps/tauri) |
@@ -5490,7 +5491,7 @@ DEALINGS IN THE SOFTWARE.
 
 ### 4bf96504d6e8
 
-Components: Rust arboard@3.6.1, Rust fdeflate@0.3.7, Rust half@2.7.1, Rust image@0.25.9, Rust miniz_oxide@0.8.9, Rust pin-project-lite@0.2.16, Rust portable-atomic@1.13.1, Rust raw-window-handle@0.6.2, Rust sync_wrapper@1.0.2, Rust tauri-build@2.5.5, Rust tauri-codegen@2.5.4, Rust tauri-macros@2.5.4, Rust tauri-plugin-autostart@2.5.1, Rust tauri-plugin-dialog@2.6.0, Rust tauri-plugin-fs@2.4.5, Rust tauri-plugin-global-shortcut@2.3.1, Rust tauri-runtime-wry@2.10.0, Rust tauri-runtime@2.10.0, Rust tauri-utils@2.8.2, Rust tauri@2.10.2, Rust time-core@0.1.8, Rust time-macros@0.2.27, Rust time@0.3.47, npm @tauri-apps/api@2.10.1, npm @tauri-apps/cli@2.10.0
+Components: Rust arboard@3.6.1, Rust fdeflate@0.3.7, Rust half@2.7.1, Rust image@0.25.9, Rust miniz_oxide@0.8.9, Rust pin-project-lite@0.2.16, Rust portable-atomic@1.13.1, Rust raw-window-handle@0.6.2, Rust sync_wrapper@1.0.2, Rust tauri-build@2.5.5, Rust tauri-codegen@2.5.4, Rust tauri-macros@2.5.4, Rust tauri-plugin-autostart@2.5.1, Rust tauri-plugin-dialog@2.6.0, Rust tauri-plugin-fs@2.4.5, Rust tauri-plugin-global-shortcut@2.3.1, Rust tauri-plugin-single-instance@2.4.4, Rust tauri-runtime-wry@2.10.0, Rust tauri-runtime@2.10.0, Rust tauri-utils@2.8.2, Rust tauri@2.10.2, Rust time-core@0.1.8, Rust time-macros@0.2.27, Rust time@0.3.47, npm @tauri-apps/api@2.10.1, npm @tauri-apps/cli@2.10.0
 
 Source filenames: LICENSE, LICENSE-APACHE, LICENSE-APACHE.md, LICENSE-APACHE.txt, LICENSE-Apache, LICENSE_APACHE-2.0
 
@@ -15724,6 +15725,36 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ~~~~
 
+### b7f455413bfe
+
+Components: Rust tauri-plugin-single-instance@2.4.4
+
+Source filenames: LICENSE_MIT
+
+~~~~text
+MIT License
+
+Copyright (c) 2017 - Present The Tauri Programme in the Commons Conservancy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+~~~~
+
 ### b8778b155bfd
 
 Components: npm @jridgewell/resolve-uri@3.1.2
@@ -19228,7 +19259,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 
 ### eb8a6c846304
 
-Components: Rust tauri-plugin-autostart@2.5.1, Rust tauri-plugin-dialog@2.6.0, Rust tauri-plugin-fs@2.4.5, Rust tauri-plugin-global-shortcut@2.3.1, npm @tauri-apps/plugin-autostart@2.5.1, npm @tauri-apps/plugin-dialog@2.6.0
+Components: Rust tauri-plugin-autostart@2.5.1, Rust tauri-plugin-dialog@2.6.0, Rust tauri-plugin-fs@2.4.5, Rust tauri-plugin-global-shortcut@2.3.1, Rust tauri-plugin-single-instance@2.4.4, npm @tauri-apps/plugin-autostart@2.5.1, npm @tauri-apps/plugin-dialog@2.6.0
 
 Source filenames: LICENSE.spdx
 

--- a/docs/windows-notes.md
+++ b/docs/windows-notes.md
@@ -5,6 +5,9 @@ and notarized macOS artifacts only; the project does not publish an unsigned
 Windows installer. CI coverage is useful development evidence, not a promise
 of production support.
 
+The active zero-cost release strategy, candidate workflow, and clean-machine
+acceptance checklist live in [Windows release track](windows-release.md).
+
 ## Differences from macOS
 
 | Feature | macOS | Windows |

--- a/docs/windows-notes.md
+++ b/docs/windows-notes.md
@@ -26,7 +26,7 @@ acceptance checklist live in [Windows release track](windows-release.md).
 
 - **CPU-only transcription.** GPU acceleration (Metal/Core ML) is not available on Windows. Large models (`large`, `large-v3`) will be significantly slower than on macOS with Metal. We recommend using `base` or `small` models on Windows.
 - **No official binary or auto-updater.** Build the current preview from source.
-- **ARM64 not tested.** Snapdragon / Copilot+ PCs (ARM64) have not been tested yet. The app is currently x86_64 only.
+- **Architecture-specific builds.** Use the native ARM64 candidate on Snapdragon / Copilot+ PCs and the x64 candidate on Intel or AMD Windows PCs. CPU transcription is tested natively on both architectures in the candidate workflow.
 
 ## Troubleshooting
 

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -1,0 +1,145 @@
+# Windows release track
+
+Sagascript's Windows build is a release candidate, not a public release. The
+candidate workflow intentionally produces **unsigned** x64 artifacts for
+testing on an owner-controlled Windows PC. Do not publish those artifacts or
+tell users to bypass SmartScreen.
+
+## Zero-cost distribution decision
+
+The intended public path is a Microsoft Store MSIX submission. Microsoft signs
+Store-distributed MSIX packages and provides the trusted installation and
+update path without a separate code-signing subscription. Tauri currently
+produces NSIS and MSI installers for Sagascript; MSIX packaging is a separate
+follow-up after the native Windows behavior passes acceptance.
+
+References:
+
+- [Choose a Windows distribution path](https://learn.microsoft.com/windows/apps/package-and-deploy/choose-distribution-path)
+- [Publish a first Windows app](https://learn.microsoft.com/windows/apps/package-and-deploy/publish-first-app)
+- [SmartScreen reputation for developers](https://learn.microsoft.com/windows/apps/package-and-deploy/smartscreen-reputation)
+
+Direct website/GitHub distribution remains blocked for a normal public release
+while the installers are unsigned. An unsigned build may be used only as a
+clearly labelled internal candidate on a known test machine.
+
+## Candidate workflow
+
+`.github/workflows/windows-package.yml` runs the release metadata, license,
+frontend, Rust, and real CPU-transcription gates on `windows-latest`. It then
+builds unsigned NSIS and MSI installers plus the native executable and uploads
+them as a short-lived GitHub Actions artifact. It never creates or modifies a
+GitHub Release.
+
+`scripts/verify-windows-release.ps1` validates the executable surface,
+signature state, and deterministic checksums. `Internal` signature policy
+allows only a valid signature or a genuinely unsigned artifact. The future
+public pipeline must use `Release`, which requires every executable artifact to
+have a valid Authenticode signature.
+
+After installing an internally accepted candidate on the test PC, run the
+bundled CLI acceptance helper against the exact installed executable (replace
+the placeholder with the path reported by the installer):
+
+```powershell
+.\accept-windows-candidate.ps1 `
+  -AppExe "C:\path-reported-by-installer\sagascript.exe" `
+  -ExpectedVersion "1.1.3"
+```
+
+The helper downloads the recommended Norwegian test engine, transcribes only
+the bundled public fixture, and writes `windows-acceptance.json`. It records
+machine and timing evidence but never records a private microphone sample or
+stores transcript text. The installed path remains an acceptance finding until
+it has been observed on Windows; do not add it to documentation or `PATH`
+promises merely because an installer default was expected.
+
+## Initial support boundary
+
+- Windows 11 on x86-64.
+- CPU transcription using the recommended small language-specific engine.
+- One installed desktop app with system-tray UI and the canonical CLI commands.
+- No ARM64 promise and no GPU-acceleration promise in the first release.
+- Windows 10 may work but is not release-supported until separately accepted.
+
+## Clean-machine acceptance
+
+Record the Windows edition/build, CPU, RAM, microphone, and exact candidate
+artifact checksums. Start from a machine with no prior Sagascript installation,
+settings, model directory, or running process.
+
+### Installation and identity
+
+- SmartScreen identifies the candidate as unsigned; test only after independently
+  matching `SHA256SUMS-Windows` from the workflow artifact.
+- NSIS installation completes without development tools.
+- MSI installation completes without development tools.
+- Only one installer format is selected for the eventual Store/MSIX conversion.
+- Start-menu entry, application icon, publisher placeholder, version, install
+  location, and uninstall entry are coherent.
+- Uninstall removes program files and shortcuts. Record whether user settings
+  and downloaded models are retained.
+
+### First run and daily dictation
+
+- First launch explains local processing and downloads exactly one recommended
+  speech engine for English, Swedish, or Norwegian.
+- Download progress, checksum failure, retry, cancellation, and low-disk/network
+  failure states are recoverable.
+- The S icon is visible in the Windows system tray in idle state.
+- `Control+Shift+Space` starts/stops push-to-talk without opening or focusing the
+  settings window.
+- Recording, loading, transcribing, and error states remain understandable in
+  the tray/indicator.
+- Microphone denial or the Windows desktop-microphone privacy switch produces an
+  actionable recovery message.
+- Auto-paste works in Notepad, Word, and a browser text field. Clipboard fallback
+  preserves the transcript when simulated paste is blocked.
+- A normal, non-elevated Sagascript process must not claim it can paste into an
+  elevated target process.
+- Two language profiles and two shortcuts can be used without restart.
+- Closing settings leaves the tray process running; Quit exits every process.
+- Sagascript never opens its main window merely because the first dictation ran.
+
+### Accuracy, latency, and resilience
+
+- Complete at least ten short utterances in each of English, Swedish, and
+  Norwegian, including two consecutive transcriptions.
+- Record cold and warm key-release-to-paste latency for each language.
+- A 60-second recording finishes without UI lockup or a permanently busy state.
+- Interruptions, no default microphone, sleep/wake, audio-device changes, and a
+  second launch fail safely.
+- CPU usage, memory, fan noise, and battery impact are acceptable with the
+  recommended model; larger models remain Advanced/unsupported if they are not.
+
+### CLI, updates, and upgrade
+
+- The installed `sagascript.exe --version` reports the GUI version and source
+  revision.
+- `--help`, `list-models`, `config`, file transcription, microphone recording,
+  JSON output, and PowerShell completions work from the installed binary.
+- Decide and document whether the installer adds Sagascript to `PATH`; do not
+  imply a bare `sagascript` command works until this is verified.
+- Check for Updates reports checking/current/available/error and opens the exact
+  stable release page without claiming it installed anything.
+- An upgrade candidate preserves settings, profiles, glossary, and downloaded
+  engines and does not create duplicate startup/tray entries.
+
+## Public-release gates
+
+Before removing the candidate warning:
+
+1. All automated Windows candidate checks pass without `continue-on-error`.
+2. Clean-machine acceptance is recorded against the exact commit and hashes.
+3. A Microsoft Store account and product identity are ready at no recurring
+   signing cost.
+4. The accepted installer is converted to MSIX and tested through Store flighting.
+5. Store certification passes and the Store-delivered package is installed on a
+   clean machine.
+6. The website Windows button points to the Store listing only after readback.
+
+Creating the Store product identity is an owner action. Do not store Microsoft
+passwords, session material, recovery codes, or signing credentials in this
+repository. The MSIX manifest's Store-assigned identity values must be copied
+from the exact Partner Center product record when that record exists; do not
+guess them in advance.

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -27,9 +27,12 @@ clearly labelled internal candidate on a known test machine.
 
 `.github/workflows/windows-package.yml` runs the release metadata, license,
 frontend, Rust, and real CPU-transcription gates on `windows-latest`. It then
-builds unsigned NSIS and MSI installers plus the native executable and uploads
-them as a short-lived GitHub Actions artifact. It never creates or modifies a
-GitHub Release.
+builds unsigned NSIS and MSI installers, a portable desktop executable, and a
+separate console CLI executable. It uploads them as one short-lived GitHub
+Actions artifact and never creates or modifies a GitHub Release. Windows GUI
+executables do not reliably expose redirected console output, so the candidate
+keeps the desktop and CLI launch surfaces explicit instead of pretending one
+file behaves identically in both contexts.
 
 `scripts/verify-windows-release.ps1` validates the executable surface,
 signature state, and deterministic checksums. `Internal` signature policy
@@ -38,12 +41,12 @@ public pipeline must use `Release`, which requires every executable artifact to
 have a valid Authenticode signature.
 
 After installing an internally accepted candidate on the test PC, run the
-bundled CLI acceptance helper against the exact installed executable (replace
-the placeholder with the path reported by the installer):
+bundled CLI acceptance helper against the CLI executable from the same workflow
+artifact:
 
 ```powershell
 .\accept-windows-candidate.ps1 `
-  -AppExe "C:\path-reported-by-installer\sagascript.exe" `
+  -CliExe ".\Sagascript-Windows-x64-CLI.exe" `
   -ExpectedVersion "1.1.3"
 ```
 
@@ -58,7 +61,9 @@ promises merely because an installer default was expected.
 
 - Windows 11 on x86-64.
 - CPU transcription using the recommended small language-specific engine.
-- One installed desktop app with system-tray UI and the canonical CLI commands.
+- One installed desktop app with system-tray UI plus a candidate CLI executable
+  exposing the canonical commands. Installer/PATH integration remains a public-
+  release decision.
 - No ARM64 promise and no GPU-acceleration promise in the first release.
 - Windows 10 may work but is not release-supported until separately accepted.
 
@@ -114,11 +119,12 @@ settings, model directory, or running process.
 
 ### CLI, updates, and upgrade
 
-- The installed `sagascript.exe --version` reports the GUI version and source
-  revision.
+- `Sagascript-Windows-x64-CLI.exe --version` reports the candidate version and
+  source revision.
 - `--help`, `list-models`, `config`, file transcription, microphone recording,
-  JSON output, and PowerShell completions work from the installed binary.
-- Decide and document whether the installer adds Sagascript to `PATH`; do not
+  JSON output, and PowerShell completions work from the candidate CLI binary.
+- Decide and document how the CLI is installed and whether it is added to
+  `PATH`; do not
   imply a bare `sagascript` command works until this is verified.
 - Check for Updates reports checking/current/available/error and opens the exact
   stable release page without claiming it installed anything.

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -1,7 +1,7 @@
 # Windows release track
 
 Sagascript's Windows build is a release candidate, not a public release. The
-candidate workflow intentionally produces **unsigned** x64 artifacts for
+candidate workflow intentionally produces **unsigned** x64 and ARM64 artifacts for
 testing on an owner-controlled Windows PC. Do not publish those artifacts or
 tell users to bypass SmartScreen.
 
@@ -26,13 +26,22 @@ clearly labelled internal candidate on a known test machine.
 ## Candidate workflow
 
 `.github/workflows/windows-package.yml` runs the release metadata, license,
-frontend, Rust, and real CPU-transcription gates on `windows-latest`. It then
+frontend, Rust, and real CPU-transcription gates on native `windows-latest`
+(x64) and `windows-11-arm` (ARM64) runners. Each runner then
 builds unsigned NSIS and MSI installers, a portable desktop executable, and a
 separate console CLI executable. It uploads them as one short-lived GitHub
 Actions artifact and never creates or modifies a GitHub Release. Windows GUI
 executables do not reliably expose redirected console output, so the candidate
 keeps the desktop and CLI launch surfaces explicit instead of pretending one
 file behaves identically in both contexts.
+
+The artifact names are architecture-qualified:
+`Sagascript-Windows-<architecture>-Portable.exe`,
+`Sagascript-Windows-<architecture>-CLI.exe`,
+`Sagascript-Windows-<architecture>-Setup.exe`, and
+`Sagascript-Windows-<architecture>.msi`, where `<architecture>` is `x64` or
+`arm64`. The matching `SHA256SUMS-Windows-<architecture>` file covers exactly
+those four files.
 
 `scripts/verify-windows-release.ps1` validates the executable surface,
 signature state, and deterministic checksums. `Internal` signature policy
@@ -46,7 +55,7 @@ artifact:
 
 ```powershell
 .\accept-windows-candidate.ps1 `
-  -CliExe ".\Sagascript-Windows-x64-CLI.exe" `
+  -CliExe ".\Sagascript-Windows-<architecture>-CLI.exe" `
   -ExpectedVersion "1.1.3"
 ```
 
@@ -59,12 +68,12 @@ promises merely because an installer default was expected.
 
 ## Initial support boundary
 
-- Windows 11 on x86-64.
+- Windows 11 on x64 and ARM64.
 - CPU transcription using the recommended small language-specific engine.
 - One installed desktop app with system-tray UI plus a candidate CLI executable
   exposing the canonical commands. Installer/PATH integration remains a public-
   release decision.
-- No ARM64 promise and no GPU-acceleration promise in the first release.
+- No GPU-acceleration promise in the first release.
 - Windows 10 may work but is not release-supported until separately accepted.
 
 ## Clean-machine acceptance
@@ -76,7 +85,8 @@ settings, model directory, or running process.
 ### Installation and identity
 
 - SmartScreen identifies the candidate as unsigned; test only after independently
-  matching `SHA256SUMS-Windows` from the workflow artifact.
+  matching the architecture-specific `SHA256SUMS-Windows-<architecture>` file
+  from the workflow artifact.
 - NSIS installation completes without development tools.
 - MSI installation completes without development tools.
 - Only one installer format is selected for the eventual Store/MSIX conversion.
@@ -119,7 +129,7 @@ settings, model directory, or running process.
 
 ### CLI, updates, and upgrade
 
-- `Sagascript-Windows-x64-CLI.exe --version` reports the candidate version and
+- `Sagascript-Windows-<architecture>-CLI.exe --version` reports the candidate version and
   source revision.
 - `--help`, `list-models`, `config`, file transcription, microphone recording,
   JSON output, and PowerShell completions work from the candidate CLI binary.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "node scripts/build-frontend.mjs",
-    "test:frontend": "node --test scripts/test-*.mjs",
+    "test:frontend": "node scripts/run-frontend-tests.mjs",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "release:check": "node scripts/check-release.mjs",

--- a/scripts/accept-windows-candidate.ps1
+++ b/scripts/accept-windows-candidate.ps1
@@ -1,0 +1,131 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExe,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+
+    [string]$Fixture = (Join-Path $PSScriptRoot "norwegian-short-3s.mp3"),
+
+    [string]$OutputPath = (Join-Path (Get-Location).Path "windows-acceptance.json")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-NonemptyFile {
+    param([string]$Path, [string]$Label)
+
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($item.PSIsContainer -or $item.Length -le 0) {
+        throw "$Label must be a non-empty file: $Path"
+    }
+    return $item.FullName
+}
+
+function Invoke-Sagascript {
+    param([string]$Executable, [string[]]$Arguments)
+
+    $output = & $Executable @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "Sagascript $($Arguments -join ' ') failed with exit code $exitCode`n$($output -join "`n")"
+    }
+    return ($output -join "`n")
+}
+
+if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+    throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
+}
+
+$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$fixturePath = Resolve-NonemptyFile -Path $Fixture -Label "Fixture"
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
+$outputParent = [System.IO.Path]::GetDirectoryName($outputFullPath)
+if (-not [System.IO.Directory]::Exists($outputParent)) {
+    throw "Acceptance output directory does not exist: $outputParent"
+}
+
+$versionOutput = Invoke-Sagascript -Executable $appExePath -Arguments @("--version")
+$versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
+if ($versionOutput -notmatch $versionPattern) {
+    throw "Installed executable did not report expected version $ExpectedVersion`: $versionOutput"
+}
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("--help"))
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("list-models"))
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("config", "path"))
+
+$downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
+[void](Invoke-Sagascript -Executable $appExePath -Arguments @("download-model", "nb-whisper-tiny"))
+$downloadTimer.Stop()
+
+$transcriptTemp = Join-Path ([System.IO.Path]::GetTempPath()) ("sagascript-acceptance-{0}.json" -f [guid]::NewGuid())
+try {
+    $transcriptionTimer = [System.Diagnostics.Stopwatch]::StartNew()
+    & $appExePath transcribe `
+        --language no `
+        --model nb-whisper-tiny `
+        --beam 0 `
+        --json `
+        $fixturePath > $transcriptTemp
+    $transcriptionExit = $LASTEXITCODE
+    $transcriptionTimer.Stop()
+    if ($transcriptionExit -ne 0) {
+        throw "Installed-file transcription failed with exit code $transcriptionExit"
+    }
+
+    $result = Get-Content -LiteralPath $transcriptTemp -Raw | ConvertFrom-Json
+    if ($result.language -ne "no") {
+        throw "Expected Norwegian transcription result, got '$($result.language)'"
+    }
+    if ($result.text -notmatch "(?i)storting") {
+        throw "Expected 'storting' in the public-fixture transcript"
+    }
+    if (-not $result.segments) {
+        throw "Expected at least one transcription segment"
+    }
+
+    $os = Get-CimInstance Win32_OperatingSystem
+    $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+    $computer = Get-CimInstance Win32_ComputerSystem
+    $report = [ordered]@{
+        schema_version = 1
+        accepted_at_utc = [DateTime]::UtcNow.ToString("o")
+        expected_version = $ExpectedVersion
+        reported_version = $versionOutput.Trim()
+        source_fixture_sha256 = (Get-FileHash -LiteralPath $fixturePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        download_seconds = [Math]::Round($downloadTimer.Elapsed.TotalSeconds, 3)
+        transcription_seconds = [Math]::Round($transcriptionTimer.Elapsed.TotalSeconds, 3)
+        detected_language = $result.language
+        segment_count = @($result.segments).Count
+        windows = [ordered]@{
+            caption = $os.Caption
+            version = $os.Version
+            build_number = $os.BuildNumber
+            architecture = $os.OSArchitecture
+        }
+        hardware = [ordered]@{
+            processor = $cpu.Name.Trim()
+            logical_processors = $cpu.NumberOfLogicalProcessors
+            memory_gib = [Math]::Round($computer.TotalPhysicalMemory / 1GB, 2)
+        }
+        automated_cli_acceptance = "pass"
+        manual_gui_acceptance = "required"
+    }
+
+    $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText(
+        $outputFullPath,
+        (($report | ConvertTo-Json -Depth 5) + "`n"),
+        $utf8WithoutBom
+    )
+} finally {
+    Remove-Item -LiteralPath $transcriptTemp -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Automated installed-CLI acceptance passed"
+Write-Host "Evidence: $outputFullPath"
+Write-Host "Continue with the manual tray, microphone, hotkey, paste, focus, and uninstall checklist in README-Windows-Candidate.md"

--- a/scripts/accept-windows-candidate.ps1
+++ b/scripts/accept-windows-candidate.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string]$AppExe,
+    [string]$CliExe,
 
     [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
@@ -41,7 +41,7 @@ if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+
     throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
 }
 
-$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$cliExePath = Resolve-NonemptyFile -Path $CliExe -Label "CliExe"
 $fixturePath = Resolve-NonemptyFile -Path $Fixture -Label "Fixture"
 $outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
 $outputParent = [System.IO.Path]::GetDirectoryName($outputFullPath)
@@ -49,23 +49,23 @@ if (-not [System.IO.Directory]::Exists($outputParent)) {
     throw "Acceptance output directory does not exist: $outputParent"
 }
 
-$versionOutput = Invoke-Sagascript -Executable $appExePath -Arguments @("--version")
+$versionOutput = Invoke-Sagascript -Executable $cliExePath -Arguments @("--version")
 $versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
 if ($versionOutput -notmatch $versionPattern) {
-    throw "Installed executable did not report expected version $ExpectedVersion`: $versionOutput"
+    throw "CLI executable did not report expected version $ExpectedVersion`: $versionOutput"
 }
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("--help"))
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("list-models"))
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("config", "path"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("--help"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("list-models"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("config", "path"))
 
 $downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
-[void](Invoke-Sagascript -Executable $appExePath -Arguments @("download-model", "nb-whisper-tiny"))
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("download-model", "nb-whisper-tiny"))
 $downloadTimer.Stop()
 
 $transcriptTemp = Join-Path ([System.IO.Path]::GetTempPath()) ("sagascript-acceptance-{0}.json" -f [guid]::NewGuid())
 try {
     $transcriptionTimer = [System.Diagnostics.Stopwatch]::StartNew()
-    & $appExePath transcribe `
+    & $cliExePath transcribe `
         --language no `
         --model nb-whisper-tiny `
         --beam 0 `

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -18,6 +18,10 @@ function compareCodeUnits(a, b) {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+function normalizeNewlines(text) {
+  return text.replace(/\r\n?/g, "\n");
+}
+
 function npmInstallationError(pkg, installedVersion, directoryExists) {
   const path = relative(root, pkg.directory);
   if (!directoryExists) {
@@ -76,9 +80,20 @@ if (mode === "--test-npm-installation") {
   process.exit(0);
 }
 
+if (mode === "--test-newline-normalization") {
+  const lf = "first\nsecond\n";
+  for (const candidate of [lf, "first\r\nsecond\r\n", "first\rsecond\r"]) {
+    if (normalizeNewlines(candidate) !== lf) {
+      throw new Error("Generated notice comparison is not newline-stable");
+    }
+  }
+  console.log("newline normalization passed");
+  process.exit(0);
+}
+
 if (!new Set(["--check", "--write"]).has(mode)) {
   console.error(
-    "Usage: node scripts/generate-third-party-notices.mjs --check|--write|--test-sort|--test-npm-installation",
+    "Usage: node scripts/generate-third-party-notices.mjs --check|--write|--test-sort|--test-npm-installation|--test-newline-normalization",
   );
   process.exit(2);
 }
@@ -372,7 +387,7 @@ if (mode === "--write") {
   writeFileSync(outputPath, generated);
   console.log(`Wrote ${relative(root, outputPath)} (${rustPackages.length} Rust, ${npmPackages.length} npm packages)`);
 } else {
-  if (!existsSync(outputPath) || readFileSync(outputPath, "utf8") !== generated) {
+  if (!existsSync(outputPath) || normalizeNewlines(readFileSync(outputPath, "utf8")) !== generated) {
     console.error("THIRD_PARTY_NOTICES.md is stale; run npm run licenses:generate and review the diff");
     process.exit(1);
   }

--- a/scripts/run-frontend-tests.mjs
+++ b/scripts/run-frontend-tests.mjs
@@ -1,0 +1,26 @@
+import { readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDirectory = fileURLToPath(new URL(".", import.meta.url));
+const tests = readdirSync(scriptsDirectory)
+  .filter((name) => /^test-.*\.mjs$/.test(name))
+  .sort()
+  .map((name) => join(scriptsDirectory, name));
+
+if (tests.length === 0) {
+  console.error("No frontend tests found in scripts/");
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, ["--test", ...tests], {
+  stdio: "inherit",
+});
+
+if (result.error) throw result.error;
+if (result.status === null) {
+  console.error(`Frontend tests terminated by signal ${result.signal ?? "unknown"}`);
+  process.exit(1);
+}
+process.exit(result.status);

--- a/scripts/test-release-surface.mjs
+++ b/scripts/test-release-surface.mjs
@@ -92,9 +92,22 @@ test("onboarding starts with language instead of a disposable welcome step", () 
 });
 
 test("cross-platform onboarding copy never identifies every device as a Mac", () => {
-  assert.doesNotMatch(onboardingSource, /this Mac/i);
-  assert.match(onboardingSource, /Speech stays on this device/);
-  assert.match(onboardingSource, /recordings are processed on this device/);
+  const renderedMarkup = onboardingSource
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<!--[\s\S]*?-->/g, "");
+  const visibleCopy = renderedMarkup
+    .replace(/\{[^{}]*\}/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ");
+
+  assert.doesNotMatch(visibleCopy, /\bmac(?:os)?\b/i);
+  assert.match(visibleCopy, /Speech stays on this device/);
+  assert.match(visibleCopy, /recordings are processed on this device/);
+  assert.match(
+    onboardingSource,
+    /if \(platform === "macos"\) \{\s*return \["language", "download", "microphone", "accessibility", "ready"\];\s*\}\s*return \["language", "download", "ready"\];/s,
+  );
 });
 
 test("onboarding automatically prepares one hidden recommended engine", () => {
@@ -133,8 +146,10 @@ test("Dictate reflects backend loading and transcription instead of offering a c
 });
 
 test("onboarding prevents duplicate setup requests and exposes language selection", () => {
-  assert.match(onboardingSource, /if \(languageSaving\) return;/);
-  assert.match(onboardingSource, /disabled=\{languageSaving\}/);
+  assert.match(onboardingSource, /let platform: string \| null = \$state\(null\)/);
+  assert.match(onboardingSource, /if \(languageSaving \|\| platform === null\) return;/);
+  assert.match(onboardingSource, /disabled=\{languageSaving \|\| platform === null\}/);
+  assert.match(onboardingSource, /platform === null \? "Preparing…"/);
   assert.equal((onboardingSource.match(/aria-pressed=\{selectedLanguage ===/g) ?? []).length, 3);
 });
 
@@ -208,6 +223,13 @@ test("second GUI launches are routed to the running instance", () => {
   assert.match(mainSource, /second_instance_requests_settings/);
   assert.match(mainSource, /Second-instance launch requested Settings/);
   assert.doesNotMatch(mainSource, /Another Sagascript GUI instance is already running; exiting/);
+  const singleInstanceInit = mainSource.indexOf("tauri_plugin_single_instance::init");
+  const backendInit = mainSource.indexOf("WhisperBackend::new()");
+  assert.ok(singleInstanceInit >= 0 && backendInit > singleInstanceInit);
+  assert.match(
+    mainSource,
+    /\.setup\(move \|app\| \{[\s\S]*?let whisper: SharedWhisper = Arc::new\(WhisperBackend::new\(\)\);[\s\S]*?app\.manage\(whisper\);/,
+  );
 });
 
 test("profile and update menu states remain explicit after interaction", () => {

--- a/scripts/test-release-surface.mjs
+++ b/scripts/test-release-surface.mjs
@@ -18,15 +18,13 @@ const mainSource = await readFile(
   new URL("../src-tauri/src/main.rs", import.meta.url),
   "utf8",
 );
+const commandsSource = await readFile(
+  new URL("../src-tauri/src/commands.rs", import.meta.url),
+  "utf8",
+);
 const appSource = await readFile(
   new URL("../src/App.svelte", import.meta.url),
   "utf8",
-);
-const defaultCapabilities = JSON.parse(
-  await readFile(
-    new URL("../src-tauri/capabilities/default.json", import.meta.url),
-    "utf8",
-  ),
 );
 const brandMarkSource = await readFile(
   new URL("../assets/brand/sagascript-mark.svg", import.meta.url),
@@ -91,6 +89,12 @@ test("onboarding starts with language instead of a disposable welcome step", () 
   assert.match(onboardingSource, /currentStep:\s*Step\s*=\s*\$state\("language"\)/);
   assert.doesNotMatch(onboardingSource, /type Step = [^\n]*"welcome"/);
   assert.doesNotMatch(onboardingSource, /Welcome to Sagascript/);
+});
+
+test("cross-platform onboarding copy never identifies every device as a Mac", () => {
+  assert.doesNotMatch(onboardingSource, /this Mac/i);
+  assert.match(onboardingSource, /Speech stays on this device/);
+  assert.match(onboardingSource, /recordings are processed on this device/);
 });
 
 test("onboarding automatically prepares one hidden recommended engine", () => {
@@ -162,8 +166,9 @@ test("Accessibility onboarding reopens System Settings without prompting again",
   );
 });
 
-test("menu bar uses compact native state markers", () => {
+test("tray uses compact macOS markers and a real Windows icon", () => {
   assert.match(mainSource, /TrayIconBuilder::with_id\("main"\)[\s\S]*?\.title\("S"\)/);
+  assert.match(mainSource, /#\[cfg\(target_os = "windows"\)\][\s\S]*?default_window_icon\(\)[\s\S]*?tray_builder\.icon\(icon\.clone\(\)\)/);
   assert.match(mainSource, /tray\.set_visible\(true\)/);
   assert.doesNotMatch(mainSource, /include_bytes!\("\.\.\/icons\/tray-icon(?:@2x)?\.png"\)/);
   assert.doesNotMatch(mainSource, /\.icon_as_template\(true\)/);
@@ -187,13 +192,22 @@ test("deliberate macOS reopen requests reveal Settings", () => {
   );
 });
 
-test("finishing onboarding hides its main window", () => {
-  assert.match(appSource, /getCurrentWindow\(\)\.hide\(\)/);
-  assert.match(appSource, /Failed to hide completed onboarding window/);
-  assert.ok(
-    defaultCapabilities.permissions.includes("core:window:allow-hide"),
-    "the onboarding window cannot hide without the explicit Tauri capability",
-  );
+test("finishing onboarding keeps the main Settings window visible", () => {
+  assert.doesNotMatch(appSource, /getCurrentWindow\(\)\.hide\(\)/);
+  assert.doesNotMatch(appSource, /Failed to hide completed onboarding window/);
+  assert.match(appSource, /showOnboarding = false/);
+  const commandStart = commandsSource.indexOf("pub async fn set_onboarding_completed");
+  const commandEnd = commandsSource.indexOf("\n#[tauri::command]", commandStart + 1);
+  assert.ok(commandStart >= 0 && commandEnd > commandStart);
+  const completionCommand = commandsSource.slice(commandStart, commandEnd);
+  assert.doesNotMatch(completionCommand, /\.hide\(\)/);
+});
+
+test("second GUI launches are routed to the running instance", () => {
+  assert.match(mainSource, /tauri_plugin_single_instance::init/);
+  assert.match(mainSource, /second_instance_requests_settings/);
+  assert.match(mainSource, /Second-instance launch requested Settings/);
+  assert.doesNotMatch(mainSource, /Another Sagascript GUI instance is already running; exiting/);
 });
 
 test("profile and update menu states remain explicit after interaction", () => {

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -33,6 +33,13 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /-CliExe "artifacts\\Sagascript-Windows-\$architecture-CLI\.exe"/);
   assert.match(workflow, /ChecksumOutput "artifacts\\SHA256SUMS-Windows-\$architecture"/);
   assert.match(workflow, /targetRoot = "src-tauri\\target\\\$\{\{ matrix\.rust_target \}\}\\release"/);
+  assert.match(workflow, /name: Remove cached installer bundles/);
+  assert.match(workflow, /Remove-Item -LiteralPath \$bundleDirectory -Recurse -Force/);
+  assert.match(workflow, /\$nsis\.Count -ne 1/);
+  assert.match(workflow, /\$msi\.Count -ne 1/);
+  assert.match(workflow, /\$nsis\[0\]\.Name -notmatch \[regex\]::Escape\(\$version\)/);
+  assert.match(workflow, /\$msi\[0\]\.Name -notmatch \[regex\]::Escape\(\$version\)/);
+  assert.doesNotMatch(workflow, /\$version:/);
   assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
 });
 

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -24,6 +24,25 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /windows-\$\{\{ matrix\.architecture \}\}-unsigned-candidate/);
   assert.match(workflow, /RuntimeInformation\]::OSArchitecture/);
   assert.match(workflow, /rustc -vV/);
+  assert.match(workflow, /name: Configure native ARM64 C and C\+\+ toolchain/);
+  assert.match(workflow, /if: matrix\.architecture == 'arm64'/);
+  assert.match(workflow, /CMAKE_GENERATOR=Ninja/);
+  assert.match(workflow, /CMAKE_C_COMPILER=clang-cl/);
+  assert.match(workflow, /CMAKE_CXX_COMPILER=clang-cl/);
+  assert.match(workflow, /CMAKE_C_COMPILER_TARGET=aarch64-pc-windows-msvc/);
+  assert.match(workflow, /CMAKE_CXX_COMPILER_TARGET=aarch64-pc-windows-msvc/);
+  assert.match(
+    workflow,
+    /hashFiles\('src-tauri\/Cargo\.lock', 'package-lock\.json', '\.github\/workflows\/windows-package\.yml'\)/,
+  );
+  const cargoCacheStart = workflow.indexOf("name: Cache Cargo registry");
+  const cargoCacheEnd = workflow.indexOf("name: Install npm dependencies", cargoCacheStart);
+  assert.ok(cargoCacheStart >= 0 && cargoCacheEnd > cargoCacheStart);
+  assert.doesNotMatch(
+    workflow.slice(cargoCacheStart, cargoCacheEnd),
+    /src-tauri\\target/,
+    "native build output must not be restored across C/C++ toolchain changes",
+  );
   assert.match(workflow, /accept-windows-candidate\.ps1/);
   assert.match(workflow, /norwegian-short-3s\.mp3/);
   assert.match(workflow, /Sagascript-Windows-\$architecture-Portable\.exe/);

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -21,6 +21,9 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /windows-x64-unsigned-candidate/);
   assert.match(workflow, /accept-windows-candidate\.ps1/);
   assert.match(workflow, /norwegian-short-3s\.mp3/);
+  assert.match(workflow, /Sagascript-Windows-x64-Portable\.exe/);
+  assert.match(workflow, /Sagascript-Windows-x64-CLI\.exe/);
+  assert.match(workflow, /-CliExe "artifacts\\Sagascript-Windows-x64-CLI\.exe"/);
   assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
 });
 

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -18,12 +18,21 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /permissions:\s*\n\s*contents: read/);
   assert.match(workflow, /tauri build --ci --bundles nsis,msi --no-sign/);
   assert.match(workflow, /SignaturePolicy Internal/);
-  assert.match(workflow, /windows-x64-unsigned-candidate/);
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.runner \}\}/);
+  assert.match(workflow, /architecture: x64[\s\S]*runner: windows-latest[\s\S]*rust_target: x86_64-pc-windows-msvc/);
+  assert.match(workflow, /architecture: arm64[\s\S]*runner: windows-11-arm[\s\S]*rust_target: aarch64-pc-windows-msvc/);
+  assert.match(workflow, /windows-\$\{\{ matrix\.architecture \}\}-unsigned-candidate/);
+  assert.match(workflow, /RuntimeInformation\]::OSArchitecture/);
+  assert.match(workflow, /rustc -vV/);
   assert.match(workflow, /accept-windows-candidate\.ps1/);
   assert.match(workflow, /norwegian-short-3s\.mp3/);
-  assert.match(workflow, /Sagascript-Windows-x64-Portable\.exe/);
-  assert.match(workflow, /Sagascript-Windows-x64-CLI\.exe/);
-  assert.match(workflow, /-CliExe "artifacts\\Sagascript-Windows-x64-CLI\.exe"/);
+  assert.match(workflow, /Sagascript-Windows-\$architecture-Portable\.exe/);
+  assert.match(workflow, /Sagascript-Windows-\$architecture-CLI\.exe/);
+  assert.match(workflow, /Sagascript-Windows-\$architecture-Setup\.exe/);
+  assert.match(workflow, /Sagascript-Windows-\$architecture\.msi/);
+  assert.match(workflow, /-CliExe "artifacts\\Sagascript-Windows-\$architecture-CLI\.exe"/);
+  assert.match(workflow, /ChecksumOutput "artifacts\\SHA256SUMS-Windows-\$architecture"/);
+  assert.match(workflow, /targetRoot = "src-tauri\\target\\\$\{\{ matrix\.rust_target \}\}\\release"/);
   assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
 });
 
@@ -35,12 +44,19 @@ test("Windows candidate makes real transcription a blocking gate", () => {
   assert.match(gate, /download-model nb-whisper-tiny/);
   assert.match(gate, /verify-json-cli-streams\.py/);
   assert.doesNotMatch(gate, /continue-on-error/);
+  assert.match(workflow, /Verify native runner architecture/);
+  assert.match(workflow, /Expected native \$\{\{ matrix\.rust_target \}\} runner/);
 });
 
 test("Windows release guide forbids publishing unsigned candidates", () => {
   assert.match(releaseGuide, /Do not publish those artifacts/);
   assert.match(releaseGuide, /Microsoft Store MSIX/);
   assert.match(releaseGuide, /Release[^\n]*requires every executable artifact/i);
+  assert.match(releaseGuide, /SHA256SUMS-Windows-<architecture>/);
+  assert.match(releaseGuide, /Sagascript-Windows-<architecture>-Portable\.exe/);
+  assert.match(releaseGuide, /Sagascript-Windows-<architecture>-CLI\.exe/);
+  assert.match(releaseGuide, /Sagascript-Windows-<architecture>-Setup\.exe/);
+  assert.match(releaseGuide, /Sagascript-Windows-<architecture>\.msi/);
 });
 
 test("third-party notice comparison accepts Windows checkout line endings", () => {

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../.github/workflows/windows-package.yml", import.meta.url),
+  "utf8",
+);
+const releaseGuide = await readFile(
+  new URL("../docs/windows-release.md", import.meta.url),
+  "utf8",
+);
+
+test("Windows candidate workflow stays non-publishing and explicitly unsigned", () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /permissions:\s*\n\s*contents: read/);
+  assert.match(workflow, /tauri build --ci --bundles nsis,msi --no-sign/);
+  assert.match(workflow, /SignaturePolicy Internal/);
+  assert.match(workflow, /windows-x64-unsigned-candidate/);
+  assert.match(workflow, /accept-windows-candidate\.ps1/);
+  assert.match(workflow, /norwegian-short-3s\.mp3/);
+  assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
+});
+
+test("Windows candidate makes real transcription a blocking gate", () => {
+  const gateStart = workflow.indexOf("name: Gate real Windows transcription");
+  const buildStart = workflow.indexOf("name: Build unsigned internal installers");
+  assert.ok(gateStart >= 0 && buildStart > gateStart);
+  const gate = workflow.slice(gateStart, buildStart);
+  assert.match(gate, /download-model nb-whisper-tiny/);
+  assert.match(gate, /verify-json-cli-streams\.py/);
+  assert.doesNotMatch(gate, /continue-on-error/);
+});
+
+test("Windows release guide forbids publishing unsigned candidates", () => {
+  assert.match(releaseGuide, /Do not publish those artifacts/);
+  assert.match(releaseGuide, /Microsoft Store MSIX/);
+  assert.match(releaseGuide, /Release[^\n]*requires every executable artifact/i);
+});

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const workflow = await readFile(
   new URL("../.github/workflows/windows-package.yml", import.meta.url),
@@ -36,4 +38,16 @@ test("Windows release guide forbids publishing unsigned candidates", () => {
   assert.match(releaseGuide, /Do not publish those artifacts/);
   assert.match(releaseGuide, /Microsoft Store MSIX/);
   assert.match(releaseGuide, /Release[^\n]*requires every executable artifact/i);
+});
+
+test("third-party notice comparison accepts Windows checkout line endings", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      fileURLToPath(new URL("./generate-third-party-notices.mjs", import.meta.url)),
+      "--test-newline-normalization",
+    ],
+    { encoding: "utf8" },
+  );
+  assert.match(output, /newline normalization passed/);
 });

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -27,6 +27,7 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /name: Configure native ARM64 C and C\+\+ toolchain/);
   assert.match(workflow, /if: matrix\.architecture == 'arm64'/);
   assert.match(workflow, /CMAKE_GENERATOR=Ninja/);
+  assert.match(workflow, /CMAKE_CXX_FLAGS=\/EHsc \/utf-8/);
   assert.match(workflow, /CMAKE_C_COMPILER=clang-cl/);
   assert.match(workflow, /CMAKE_CXX_COMPILER=clang-cl/);
   assert.match(workflow, /CMAKE_C_COMPILER_TARGET=aarch64-pc-windows-msvc/);

--- a/scripts/verify-windows-release.ps1
+++ b/scripts/verify-windows-release.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string]$AppExe,
+    [string]$CliExe,
 
     [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
@@ -39,7 +39,7 @@ function Resolve-NonemptyFile {
     return $item.FullName
 }
 
-function Invoke-AppProbe {
+function Invoke-CliProbe {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Executable,
@@ -66,7 +66,7 @@ if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) 
     throw "Get-AuthenticodeSignature is unavailable; run this verifier on Windows"
 }
 
-$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$cliExePath = Resolve-NonemptyFile -Path $CliExe -Label "CliExe"
 $pathSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 $nameSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
 $artifactByName = @{}
@@ -84,16 +84,16 @@ foreach ($artifact in $Artifacts) {
     $artifactByName[$basename] = $resolved
 }
 
-if (-not $pathSet.Contains($appExePath)) {
-    throw "AppExe must also appear in Artifacts: $appExePath"
+if (-not $pathSet.Contains($cliExePath)) {
+    throw "CliExe must also appear in Artifacts: $cliExePath"
 }
 
-$versionOutput = Invoke-AppProbe -Executable $appExePath -Argument "--version"
+$versionOutput = Invoke-CliProbe -Executable $cliExePath -Argument "--version"
 $versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
 if ($versionOutput -notmatch $versionPattern) {
     throw "Version output does not contain exact version '$ExpectedVersion': $versionOutput"
 }
-[void](Invoke-AppProbe -Executable $appExePath -Argument "--help")
+[void](Invoke-CliProbe -Executable $cliExePath -Argument "--help")
 Write-Host "Executable probes passed for Sagascript $ExpectedVersion"
 
 foreach ($basename in $artifactByName.Keys) {

--- a/scripts/verify-windows-release.ps1
+++ b/scripts/verify-windows-release.ps1
@@ -1,0 +1,141 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExe,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$Artifacts,
+
+    [ValidateSet("Internal", "Release")]
+    [string]$SignaturePolicy = "Internal",
+
+    [string]$ChecksumOutput = "SHA256SUMS-Windows"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-NonemptyFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label
+    )
+
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($item.PSIsContainer) {
+        throw "$Label is not a file: $Path"
+    }
+    if ($item.Length -le 0) {
+        throw "$Label is empty: $Path"
+    }
+    return $item.FullName
+}
+
+function Invoke-AppProbe {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Executable,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Argument
+    )
+
+    $output = & $Executable $Argument 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "'$Executable $Argument' exited with code $exitCode"
+    }
+    return ($output -join "`n")
+}
+
+if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
+    throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
+}
+if ($Artifacts.Count -eq 0) {
+    throw "Artifacts must contain at least one file"
+}
+if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) {
+    throw "Get-AuthenticodeSignature is unavailable; run this verifier on Windows"
+}
+
+$appExePath = Resolve-NonemptyFile -Path $AppExe -Label "AppExe"
+$pathSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+$nameSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+$artifactByName = @{}
+
+foreach ($artifact in $Artifacts) {
+    $resolved = Resolve-NonemptyFile -Path $artifact -Label "Artifact"
+    if (-not $pathSet.Add($resolved)) {
+        throw "Duplicate artifact path after resolution: $resolved"
+    }
+
+    $basename = [System.IO.Path]::GetFileName($resolved)
+    if (-not $nameSet.Add($basename)) {
+        throw "Duplicate artifact basename: $basename"
+    }
+    $artifactByName[$basename] = $resolved
+}
+
+if (-not $pathSet.Contains($appExePath)) {
+    throw "AppExe must also appear in Artifacts: $appExePath"
+}
+
+$versionOutput = Invoke-AppProbe -Executable $appExePath -Argument "--version"
+$versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
+if ($versionOutput -notmatch $versionPattern) {
+    throw "Version output does not contain exact version '$ExpectedVersion': $versionOutput"
+}
+[void](Invoke-AppProbe -Executable $appExePath -Argument "--help")
+Write-Host "Executable probes passed for Sagascript $ExpectedVersion"
+
+foreach ($basename in $artifactByName.Keys) {
+    $artifactPath = $artifactByName[$basename]
+    $signature = Get-AuthenticodeSignature -FilePath $artifactPath -ErrorAction Stop
+    $status = $signature.Status.ToString()
+    $valid = $status -eq "Valid"
+    $allowedInternal = $valid -or $status -eq "NotSigned"
+
+    if ($SignaturePolicy -eq "Release" -and -not $valid) {
+        throw "Release artifact '$basename' does not have a valid Authenticode signature (status: $status)"
+    }
+    if ($SignaturePolicy -eq "Internal" -and -not $allowedInternal) {
+        throw "Internal artifact '$basename' has an unsafe signature state: $status"
+    }
+}
+Write-Host "Authenticode checks passed under $SignaturePolicy policy"
+
+$sortedNames = [string[]]$artifactByName.Keys
+[Array]::Sort($sortedNames, [System.StringComparer]::OrdinalIgnoreCase)
+$checksumLines = foreach ($basename in $sortedNames) {
+    $hash = (Get-FileHash -LiteralPath $artifactByName[$basename] -Algorithm SHA256).Hash.ToLowerInvariant()
+    "$hash  $basename"
+}
+
+if ([System.IO.Path]::IsPathRooted($ChecksumOutput)) {
+    $checksumPath = [System.IO.Path]::GetFullPath($ChecksumOutput)
+} else {
+    $checksumPath = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $ChecksumOutput))
+}
+$checksumParent = [System.IO.Path]::GetDirectoryName($checksumPath)
+if (-not [System.IO.Directory]::Exists($checksumParent)) {
+    throw "Checksum output directory does not exist: $checksumParent"
+}
+
+# Windows PowerShell 5.1's UTF8 encoding adds a BOM, so use .NET directly.
+$utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText(
+    $checksumPath,
+    (($checksumLines -join "`n") + "`n"),
+    $utf8WithoutBom
+)
+
+Write-Host "Verified $($Artifacts.Count) Windows artifacts"
+Write-Host "Checksums: $checksumPath"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -146,6 +146,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -612,6 +756,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1101,6 +1254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enigo"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1279,27 @@ dependencies = [
  "x11rb",
  "xkbcommon",
  "xkeysym",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1154,6 +1334,26 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "extended"
@@ -1362,6 +1562,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3189,6 +3402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3236,6 +3459,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3422,6 +3651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3704,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4059,7 +4313,6 @@ dependencies = [
  "core-foundation 0.10.1",
  "dirs 6.0.0",
  "enigo",
- "fs2",
  "notify",
  "objc",
  "objc2-foundation",
@@ -4074,6 +4327,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-single-instance",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4823,6 +5077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5132,6 +5397,22 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -5688,6 +5969,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6693,6 +6985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6929,6 +7230,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7027,4 +7398,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.4",
+ "winnow 1.0.4",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,7 @@ tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-pn
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
-fs2 = "0.4"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -25,6 +25,9 @@ pub const NATIVE_LOG_SUPPRESSION: &str =
 pub const DEFAULT_CLI_LOG_FILTER: &str =
     "warn,whisper_rs::whisper_logging_hook=error,whisper_rs::ggml_logging_hook=error";
 
+#[cfg(target_os = "windows")]
+const WINDOWS_INFERENCE_STACK_BYTES: usize = 16 * 1024 * 1024;
+
 /// Preserve an application's requested log level without accidentally opting
 /// into noisy native Whisper/GGML diagnostics. Native logging is enabled only
 /// when the filter names `whisper_rs` explicitly.
@@ -457,9 +460,10 @@ pub fn run(cli: Cli) {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
 
     let result = match cli.command.unwrap() {
-        Command::Transcribe(args) => transcribe::run(args),
+        Command::Transcribe(args) =>
+            run_inference_command("transcribe", move || transcribe::run(args)),
         #[cfg(feature = "record")]
-        Command::Record(args) => record::run(args),
+        Command::Record(args) => run_inference_command("record", move || record::run(args)),
         Command::ListModels(args) => models::list(args),
         Command::DownloadModel(args) => rt.block_on(models::download(args)),
         Command::DeleteModel(args) => models::delete(args),
@@ -490,6 +494,39 @@ pub fn run(cli: Cli) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }
+}
+
+#[cfg(target_os = "windows")]
+fn run_inference_command(
+    command: &'static str,
+    task: impl FnOnce() -> Result<(), sagascript_core::error::DictationError> + Send + 'static,
+) -> Result<(), sagascript_core::error::DictationError> {
+    // MSVC executables start with a much smaller main-thread stack than the
+    // worker threads used by the desktop app. Whisper inference exhausted it
+    // with STATUS_STACK_OVERFLOW (0xC00000FD) in the real Windows CI gate.
+    std::thread::Builder::new()
+        .name(format!("sagascript-cli-{command}"))
+        .stack_size(WINDOWS_INFERENCE_STACK_BYTES)
+        .spawn(task)
+        .map_err(|error| {
+            sagascript_core::error::DictationError::ApplicationLaunchError(format!(
+                "Failed to start Windows {command} worker: {error}"
+            ))
+        })?
+        .join()
+        .map_err(|_| {
+            sagascript_core::error::DictationError::TranscriptionFailed(format!(
+                "Windows {command} worker terminated unexpectedly"
+            ))
+        })?
+}
+
+#[cfg(not(target_os = "windows"))]
+fn run_inference_command(
+    _command: &'static str,
+    task: impl FnOnce() -> Result<(), sagascript_core::error::DictationError>,
+) -> Result<(), sagascript_core::error::DictationError> {
+    task()
 }
 
 fn formats() {
@@ -561,6 +598,21 @@ fn render_manpage_tree(cmd: &clap::Command, dir: &PathBuf) -> Result<(), io::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_inference_command_has_a_large_named_worker_stack() {
+        run_inference_command("stack-test", || {
+            let stack_probe = [0_u8; 4 * 1024 * 1024];
+            assert_eq!(
+                std::thread::current().name(),
+                Some("sagascript-cli-stack-test")
+            );
+            std::hint::black_box(&stack_probe);
+            Ok(())
+        })
+        .unwrap();
+    }
 
     #[test]
     fn log_filter_suppresses_native_diagnostics_by_default() {

--- a/src-tauri/crates/sagascript-cli/src/open.rs
+++ b/src-tauri/crates/sagascript-cli/src/open.rs
@@ -1,4 +1,6 @@
 use sagascript_core::error::DictationError;
+#[cfg(target_os = "windows")]
+use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "macos")]
 const APP_BUNDLE_PATH: &str = "/Applications/Sagascript.app";
@@ -33,12 +35,57 @@ pub fn run() -> Result<(), DictationError> {
         }
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        let executable = installed_windows_app_path().ok_or_else(|| {
+            DictationError::ApplicationLaunchError(
+                "LOCALAPPDATA is unavailable; cannot locate the installed Sagascript app"
+                    .to_string(),
+            )
+        })?;
+        launch_windows_app(&executable)?;
+        eprintln!("Opening Sagascript...");
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         Err(DictationError::ApplicationLaunchError(
-            "the desktop recovery command is currently available only on macOS".to_string(),
+            "the desktop recovery command is currently available only on macOS and Windows"
+                .to_string(),
         ))
     }
+}
+
+#[cfg(target_os = "windows")]
+fn installed_windows_app_path() -> Option<PathBuf> {
+    std::env::var_os("LOCALAPPDATA").map(|base| windows_app_path(Path::new(&base)))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_app_path(local_app_data: &Path) -> PathBuf {
+    local_app_data.join("Sagascript").join("sagascript.exe")
+}
+
+#[cfg(target_os = "windows")]
+fn launch_windows_app(executable: &Path) -> Result<(), DictationError> {
+    if !executable.is_file() {
+        return Err(DictationError::ApplicationLaunchError(format!(
+            "Sagascript desktop app was not found at {}; install the desktop app first",
+            executable.display()
+        )));
+    }
+
+    std::process::Command::new(executable)
+        .arg(GUI_OPEN_ARG)
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| {
+            DictationError::ApplicationLaunchError(format!(
+                "failed to launch {}: {error}",
+                executable.display()
+            ))
+        })
 }
 
 #[cfg(target_os = "macos")]
@@ -64,6 +111,17 @@ mod tests {
                 OsStr::new("--args"),
                 OsStr::new(super::GUI_OPEN_ARG),
             ]
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_launcher_targets_the_per_user_install() {
+        use std::path::Path;
+
+        assert_eq!(
+            super::windows_app_path(Path::new(r"C:\Users\test\AppData\Local")),
+            Path::new(r"C:\Users\test\AppData\Local\Sagascript\sagascript.exe")
         );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tauri::{Manager, State};
+use tauri::State;
 use tracing::{error, info, warn};
 
 /// Maximum time to wait for whisper inference before aborting (seconds)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -260,7 +260,6 @@ fn set_language_for_controller(
 
 #[tauri::command]
 pub async fn set_onboarding_completed(
-    app: tauri::AppHandle,
     controller: State<'_, SharedController>,
 ) -> Result<(), String> {
     let persisted = sagascript_core::settings::store::update(|settings| {
@@ -270,15 +269,6 @@ pub async fn set_onboarding_completed(
     ctrl.settings_mut().has_completed_onboarding = persisted.has_completed_onboarding;
     drop(ctrl);
 
-    // The frontend also hides itself after this command resolves, but doing it
-    // here closes the first-dictation race: once completion is persisted, no
-    // background hotkey work can briefly revive a still-visible onboarding
-    // window before the next JavaScript turn runs.
-    if let Some(window) = app.get_webview_window("settings") {
-        if let Err(error) = window.hide() {
-            warn!("Failed to hide completed onboarding window: {error}");
-        }
-    }
     info!("Onboarding marked as completed");
     Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,9 +25,6 @@ mod updates;
 
 use tracing_subscriber::EnvFilter;
 
-use fs2::FileExt;
-use std::fs::{File, OpenOptions};
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -46,7 +43,6 @@ use tauri::{
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tracing::{error, info, warn};
 
-#[cfg(any(target_os = "macos", test))]
 use app_controller::AppState;
 use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
@@ -383,74 +379,6 @@ fn load_settings_with_permission_gate() -> sagascript_core::settings::Settings {
     settings
 }
 
-#[derive(Debug, PartialEq, Eq)]
-enum GuiInstanceLockError {
-    AlreadyRunning,
-    Unavailable(String),
-}
-
-/// Process-lifetime OS lock for the bare GUI launch path. The lock file may
-/// remain on disk, but the kernel-owned lock is released automatically on
-/// clean exit or crash, so stale files cannot strand a later launch.
-#[derive(Debug)]
-struct GuiInstanceGuard {
-    _file: File,
-}
-
-fn acquire_gui_instance_guard() -> Result<GuiInstanceGuard, GuiInstanceLockError> {
-    let app_data_dir = sagascript_core::settings::store::app_data_dir();
-    std::fs::create_dir_all(&app_data_dir).map_err(|error| {
-        GuiInstanceLockError::Unavailable(format!(
-            "failed to create app data directory {}: {error}",
-            app_data_dir.display()
-        ))
-    })?;
-    acquire_gui_instance_guard_at(&app_data_dir.join("gui-instance.lock"))
-}
-
-fn is_gui_instance_lock_contention(error: &std::io::Error) -> bool {
-    if error.kind() == std::io::ErrorKind::WouldBlock {
-        return true;
-    }
-
-    // LockFileEx reports contention as ERROR_LOCK_VIOLATION. Rust does not
-    // currently normalize that code to WouldBlock on Windows.
-    #[cfg(windows)]
-    if error.raw_os_error() == Some(33) {
-        return true;
-    }
-
-    false
-}
-
-fn acquire_gui_instance_guard_at(path: &Path) -> Result<GuiInstanceGuard, GuiInstanceLockError> {
-    let mut options = OpenOptions::new();
-    options.create(true).read(true).write(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-
-    let file = options.open(path).map_err(|error| {
-        GuiInstanceLockError::Unavailable(format!(
-            "failed to open GUI instance lock {}: {error}",
-            path.display()
-        ))
-    })?;
-
-    match file.try_lock_exclusive() {
-        Ok(()) => Ok(GuiInstanceGuard { _file: file }),
-        Err(error) if is_gui_instance_lock_contention(&error) => {
-            Err(GuiInstanceLockError::AlreadyRunning)
-        }
-        Err(error) => Err(GuiInstanceLockError::Unavailable(format!(
-            "failed to lock GUI instance file {}: {error}",
-            path.display()
-        ))),
-    }
-}
-
 fn main() {
     let gui_launch_mode = gui_launch_mode(std::env::args_os());
 
@@ -485,20 +413,6 @@ fn main() {
 
     info!("Sagascript starting...");
 
-    // CLI subcommands returned above, so this lock covers GUI processes only.
-    // Acquire it before TCC checks, state construction, or desktop services.
-    let _gui_instance_guard = match acquire_gui_instance_guard() {
-        Ok(guard) => guard,
-        Err(GuiInstanceLockError::AlreadyRunning) => {
-            info!("Another Sagascript GUI instance is already running; exiting");
-            return;
-        }
-        Err(GuiInstanceLockError::Unavailable(error)) => {
-            error!("Cannot establish single-instance GUI ownership: {error}");
-            return;
-        }
-    };
-
     let settings = load_settings_with_permission_gate();
     info!("Loaded settings: language={:?}, model={:?}, hotkey={}", settings.language, settings.whisper_model, settings.hotkey);
     let initial_hotkey = settings.hotkey.clone();
@@ -512,6 +426,31 @@ fn main() {
     let hotkey_health = hotkey::HotkeyHealth::new(&initial_hotkey);
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            if !second_instance_requests_settings(&args) {
+                info!("Background second-instance launch ignored");
+                return;
+            }
+
+            // The callback is delivered by the single-instance transport,
+            // which is not guaranteed to be the Tauri main thread (notably on
+            // macOS). Queue all state/UI work onto the main thread. This also
+            // makes the Windows WM_COPYDATA callback return promptly instead
+            // of keeping the secondary process blocked on a window operation.
+            let app = app.clone();
+            dispatch_to_main(&app, move |app| {
+                let should_reveal = app
+                    .try_state::<SharedController>()
+                    .map(|ctrl| should_reveal_for_reopen(ctrl.lock().unwrap().state()))
+                    .unwrap_or(true);
+                if should_reveal {
+                    info!("Second-instance launch requested Settings");
+                    open_settings_window(app, None);
+                } else {
+                    info!("Ignoring second-instance launch while dictation is active");
+                }
+            });
+        }))
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
                 .with_handler(move |app, shortcut, event| {
@@ -744,13 +683,19 @@ fn main() {
             #[cfg(target_os = "macos")]
             seed_macos_tray_preferred_position();
 
-            let tray = TrayIconBuilder::with_id("main")
+            let tray_builder = TrayIconBuilder::with_id("main")
                 .menu(&menu)
                 .tooltip("Sagascript")
                 // macOS 26 can register an image-backed status item but paint
                 // it blank. Compact native text stays visible: S while idle,
                 // then a state marker while recording or transcribing.
-                .title("S")
+                .title("S");
+            #[cfg(target_os = "windows")]
+            let tray_builder = match app.default_window_icon() {
+                Some(icon) => tray_builder.icon(icon.clone()),
+                None => return Err("Windows tray icon is missing from the app bundle".into()),
+            };
+            let tray = tray_builder
                 .on_menu_event(move |app, event| {
                     match event.id().as_ref() {
                     "quit" => {
@@ -1230,6 +1175,18 @@ fn gui_launch_mode(args: impl IntoIterator<Item = std::ffi::OsString>) -> GuiLau
     }
 }
 
+fn second_instance_requests_settings(args: &[String]) -> bool {
+    // `tauri-plugin-single-instance` forwards the complete argv on Windows,
+    // including argv[0], but transports differ across platforms and versions.
+    // Treat the private background marker as a capability to stay hidden and
+    // let every other relaunch (including a bare Start-menu launch) reveal
+    // Settings. Looking for the marker anywhere is robust to either argv
+    // shape and to a future plugin adding metadata arguments.
+    !args
+        .iter()
+        .any(|argument| argument == sagascript_cli::open::GUI_BACKGROUND_ARG)
+}
+
 fn initial_window_request(
     has_completed_onboarding: bool,
     launch_mode: GuiLaunchMode,
@@ -1243,7 +1200,6 @@ fn initial_window_request(
     }
 }
 
-#[cfg(any(target_os = "macos", test))]
 fn should_reveal_for_reopen(state: AppState) -> bool {
     !state.is_busy()
 }
@@ -1376,9 +1332,9 @@ fn handle_hotkey_release(
     stop_recording_and_transcribe(app, ctrl);
 }
 
-/// Run a UI closure on the macOS main thread. NSStatusItem / NSWindow (tray,
-/// overlay) APIs must not be touched from a worker thread; best-effort — logs
-/// if the dispatch itself fails.
+/// Run a UI closure on Tauri's main thread. Native tray/window APIs must not be
+/// touched from a transport or worker thread; best-effort — logs if dispatch
+/// itself fails.
 fn dispatch_to_main<F>(app: &tauri::AppHandle, f: F)
 where
     F: FnOnce(&tauri::AppHandle) + Send + 'static,
@@ -1788,23 +1744,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn gui_instance_lock_rejects_a_concurrent_owner_and_recovers_after_drop() {
-        let dir = std::env::temp_dir().join(format!(
-            "sagascript-instance-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("gui-instance.lock");
-
-        let first = acquire_gui_instance_guard_at(&path).unwrap();
-        assert_eq!(
-            acquire_gui_instance_guard_at(&path).unwrap_err(),
-            GuiInstanceLockError::AlreadyRunning
-        );
-
-        drop(first);
-        acquire_gui_instance_guard_at(&path).unwrap();
-        std::fs::remove_dir_all(dir).unwrap();
+    fn second_instance_reveals_settings_except_for_background_startup() {
+        assert!(second_instance_requests_settings(&[
+            "sagascript".to_string()
+        ]));
+        assert!(second_instance_requests_settings(&[
+            "sagascript".to_string(),
+            sagascript_cli::open::GUI_OPEN_ARG.to_string()
+        ]));
+        assert!(second_instance_requests_settings(&[
+            sagascript_cli::open::GUI_OPEN_ARG.to_string()
+        ]));
+        assert!(!second_instance_requests_settings(&[
+            "sagascript".to_string(),
+            sagascript_cli::open::GUI_BACKGROUND_ARG.to_string()
+        ]));
+        assert!(!second_instance_requests_settings(&[
+            sagascript_cli::open::GUI_BACKGROUND_ARG.to_string(),
+            "future-metadata".to_string()
+        ]));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -413,18 +413,6 @@ fn main() {
 
     info!("Sagascript starting...");
 
-    let settings = load_settings_with_permission_gate();
-    info!("Loaded settings: language={:?}, model={:?}, hotkey={}", settings.language, settings.whisper_model, settings.hotkey);
-    let initial_hotkey = settings.hotkey.clone();
-    let controller = Mutex::new(AppController::new(settings));
-    let whisper: SharedWhisper = Arc::new(WhisperBackend::new());
-    // Process-wide hotkey registration health (see hotkey::health for why this
-    // is deliberately independent of the AppController mutex). Assumed healthy
-    // until the first real registration attempt in `.setup()` below proves
-    // otherwise — there's no observable window in between since that attempt
-    // runs synchronously before the event loop starts.
-    let hotkey_health = hotkey::HotkeyHealth::new(&initial_hotkey);
-
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             if !second_instance_requests_settings(&args) {
@@ -519,17 +507,34 @@ fn main() {
             Some(vec![sagascript_cli::open::GUI_BACKGROUND_ARG]),
         ))
         .plugin(tauri_plugin_dialog::init())
-        .manage(controller)
-        .manage(whisper)
-        .manage(hotkey_health)
-        .manage(Mutex::new(None::<MenuItem<tauri::Wry>>) as SharedStatusItem)
-        .manage(Mutex::new(None::<ProfileMenuState>) as SharedProfileMenuState)
-        .manage(Mutex::new(UpdateMenuState {
-            items: None,
-            checking: false,
-            available_version: None,
-        }) as SharedUpdateMenuState)
         .setup(move |app| {
+            // `tauri-plugin-single-instance` is initialized before Tauri calls
+            // setup. Keep backend construction here so a secondary process is
+            // rejected before it loads settings, opens audio resources, or
+            // creates a Whisper backend.
+            let settings = load_settings_with_permission_gate();
+            info!("Loaded settings: language={:?}, model={:?}, hotkey={}", settings.language, settings.whisper_model, settings.hotkey);
+            let initial_hotkey = settings.hotkey.clone();
+            let controller: SharedController = Mutex::new(AppController::new(settings));
+            let whisper: SharedWhisper = Arc::new(WhisperBackend::new());
+            app.manage(controller);
+            app.manage(whisper);
+            // Process-wide hotkey registration health (see hotkey::health for
+            // why this is deliberately independent of the AppController
+            // mutex). Assumed healthy until the synchronous registration
+            // attempt below proves otherwise.
+            app.manage(hotkey::HotkeyHealth::new(&initial_hotkey));
+            let status_item: SharedStatusItem = Mutex::new(None);
+            let profile_menu: SharedProfileMenuState = Mutex::new(None);
+            let update_menu: SharedUpdateMenuState = Mutex::new(UpdateMenuState {
+                items: None,
+                checking: false,
+                available_version: None,
+            });
+            app.manage(status_item);
+            app.manage(profile_menu);
+            app.manage(update_menu);
+
             // Hide from dock on macOS (tray-only app)
             #[cfg(target_os = "macos")]
             platform::macos::set_activation_policy_accessory();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,7 +4,6 @@
   import Onboarding from "./lib/Onboarding.svelte";
   import Overlay from "./lib/Overlay.svelte";
   import { getSettings } from "./lib/api";
-  import { getCurrentWindow } from "@tauri-apps/api/window";
 
   // null = loading, true = show onboarding, false = show settings
   let showOnboarding: boolean | null = null;
@@ -41,11 +40,6 @@
     const url = new URL(window.location.href);
     url.searchParams.delete("onboarding");
     window.history.replaceState({}, "", url.toString());
-    try {
-      await getCurrentWindow().hide();
-    } catch (error) {
-      console.error("Failed to hide completed onboarding window", error);
-    }
   }
 </script>
 

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -413,7 +413,7 @@
         </div>
         <h1>Set up Sagascript</h1>
         <p class="description">
-          Choose your first dictation language. Speech stays on this Mac, and
+          Choose your first dictation language. Speech stays on this device, and
           you can add more language profiles later.
         </p>
         <div class="language-options">
@@ -476,7 +476,7 @@
         <h1>Setting up speech engine</h1>
         <p class="description">
           Preparing the local speech engine ({engineSize[selectedLanguage]}).
-          Your recordings are processed on this Mac.
+          Your recordings are processed on this device.
         </p>
 
         {#if downloadError}

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -28,7 +28,7 @@
   type OnboardingLanguage = "en" | "sv" | "no";
 
   let currentStep: Step = $state("language");
-  let platform = $state("macos");
+  let platform: string | null = $state(null);
 
   // Language selection — seeded from existing settings in onMount
   let selectedLanguage: OnboardingLanguage = $state("en");
@@ -98,7 +98,7 @@
   // -- Language --
 
   async function selectLanguageAndContinue() {
-    if (languageSaving) return;
+    if (languageSaving || platform === null) return;
     languageError = null;
     languageSaving = true;
     try {
@@ -343,7 +343,14 @@
     );
     if (componentDestroyed) return;
 
-    platform = await getPlatform();
+    try {
+      platform = await getPlatform();
+    } catch (error) {
+      // Never fall back to the macOS-only permission flow when platform
+      // detection fails. "unknown" follows the portable onboarding path.
+      console.error("Failed to detect platform", error);
+      platform = "unknown";
+    }
     try {
       micStatus = await microphoneStatus();
     } catch {
@@ -452,8 +459,12 @@
           </div>
         {/if}
         <div class="actions">
-          <button class="primary" onclick={selectLanguageAndContinue} disabled={languageSaving}>
-            {languageSaving ? "Saving…" : "Continue"}
+          <button
+            class="primary"
+            onclick={selectLanguageAndContinue}
+            disabled={languageSaving || platform === null}
+          >
+            {platform === null ? "Preparing…" : languageSaving ? "Saving…" : "Continue"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- replace hard-coded Mac onboarding copy with platform-neutral device wording
- keep Settings visible after onboarding in both the frontend and backend
- provide a real Windows tray icon and route repeated launches to the existing process through Tauri single-instance IPC
- support `sagascript open` for the per-user Windows installation
- build and test separate native Windows x64 and ARM64 desktop, CLI, NSIS, and MSI candidates
- run real local Whisper transcription as a blocking gate on both native architectures

## Validation

- delegated implementation review across runtime, frontend, and Windows packaging
- 43 frontend/static regression tests passed
- `svelte-check`: 0 errors, 0 warnings
- Vite production build passed
- release metadata check passed
- third-party notices regenerated and verified from the locked dependency graph
- PowerShell parser checks passed for Windows candidate scripts
- local native ARM64 Cargo dependency resolution succeeded; compilation reached the expected local-environment boundary (MSVC linker is not installed), so GitHub's native Windows jobs are the blocking compile/package gates

## Release safety

The Windows artifacts remain unsigned, short-lived internal candidates. This workflow does not publish a GitHub Release.

Supersedes #166.

Closes #173.
Closes #174.
Closes #175.
