### PR TITLE
ci: fix TEST DMG checksum step on macOS runner

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -132,7 +132,7 @@ jobs:
           mkdir -p artifacts
           cp "$dmg" "artifacts/Sagascript-TEST-${label}-${sha}.dmg"
           tar -czf "artifacts/Sagascript-TEST-${label}-${sha}.app.tar.gz" -C "$(dirname "$app")" "$(basename "$app")"
-          (cd artifacts && sha256sum Sagascript-TEST-* > SHA256SUMS)
+          (cd artifacts && shasum -a 256 Sagascript-TEST-* > SHA256SUMS)
           ls -lh artifacts/
 
       - name: Upload macOS test artifacts (no GitHub Release is created)


### PR DESCRIPTION
Follow-up to #177: the test-build lane runs on macos-14, which has no `sha256sum`. Use `shasum -a 256` (release.yml is unaffected — its checksum step runs on ubuntu-latest). First dispatched run proved the rest of the lane: signed, hardened, notarized, stapled, spctl-accepted.