### PR TITLE
ci: cancel superseded PR runs, rust-cache, model/fixture caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,15 @@ on:
   pull_request:
     branches: [main]
 
-# Cancel superseded PR runs (#178): pushing a fix cancels the stale run instead
-# of burning runner-minutes compiling it from scratch. PR runs only — `main`
-# pushes use event `push`, so they are never cancelled.
+# Cancel superseded PR runs (#178): pushes to a PR share one group, so a fix
+# cancels the stale run instead of burning runner-minutes compiling it twice.
+# Pushes (e.g. to `main`) get a unique group per run, so a newer push can
+# neither cancel an in-progress run nor replace a pending one — with the
+# default single-slot queue, same-group pending runs would otherwise be
+# dropped. Never touches release.yml (tag builds must never cancel).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check-macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded PR runs (#178): pushing a fix cancels the stale run instead
+# of burning runner-minutes compiling it from scratch. PR runs only — `main`
+# pushes use event `push`, so they are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-macos:
     runs-on: macos-14
@@ -25,16 +32,27 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
+      # Per-crate fingerprints shared across branches (#178): the previous
+      # `actions/cache` over `src-tauri/target` keyed on `Cargo.lock` forced a
+      # cold multi-GB rebuild (plus minutes of save/restore) on any lockfile
+      # change. rust-cache prunes before upload and stays warm across branches.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: sagascript-ci
+
+      # Tier-2 smokes re-download `nb-whisper-tiny` every run (#178). The key
+      # tracks model-definition sources; restore-keys plus idempotent
+      # `download-model` (skips artifacts already at the expected size) cover
+      # all other cases.
+      - name: Cache downloaded models
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: macos-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          path: ~/Library/Application Support/Sagascript/Models
+          key: macos-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
           restore-keys: |
-            macos-cargo-
+            macos-models-
 
       - name: Install npm dependencies
         run: npm ci
@@ -206,16 +224,13 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
-        uses: actions/cache@v5
+      # Same rust-cache scheme as the macOS job (#178); the shared key spans
+      # branches while rust-cache keeps OS/target entries separate.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: linux-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            linux-cargo-
+          workspaces: src-tauri
+          shared-key: sagascript-ci
 
       - name: Install npm dependencies
         run: npm ci
@@ -296,16 +311,23 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
+      # Same rust-cache scheme as the macOS job (#178); the shared key spans
+      # branches while rust-cache keeps OS/target entries separate.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: sagascript-ci
+
+      # Tier-2 smokes re-download `nb-whisper-tiny` every run (#178). Same
+      # scheme as macOS; `%APPDATA%` is `~\AppData\Roaming` on the runner.
+      - name: Cache downloaded models
         uses: actions/cache@v5
         with:
-          path: |
-            ~\.cargo\registry
-            ~\.cargo\git
-            src-tauri\target
-          key: windows-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          path: ~\AppData\Roaming\Sagascript\Models
+          key: windows-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
           restore-keys: |
-            windows-cargo-
+            windows-models-
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,35 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
+      # Same rust-cache scheme as CI (#178): per-crate fingerprints shared
+      # across branches instead of a `Cargo.lock`-keyed multi-GB target dump.
+      # `build-macos` below uses the same shared key so the release Tauri
+      # build reuses dependencies this gate job just compiled.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: sagascript-release
+
+      # The inference gates re-download `nb-whisper-tiny`, `tiny` and the
+      # diarization models every run (#178). Same key as CI, so a PR-warmed
+      # model cache carries over to the release run.
+      - name: Cache downloaded models
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: release-gate-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json') }}
+          path: ~/Library/Application Support/Sagascript/Models
+          key: macos-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
           restore-keys: |
-            release-gate-
+            macos-models-
+
+      # The diarization fixture is re-downloaded from Hugging Face every run
+      # (#178). RUNNER_TEMP is per-run, so the cache lives in a stable path
+      # and is copied into place; actions/cache persists it post-job.
+      - name: Cache diarization fixture
+        uses: actions/cache@v5
+        with:
+          path: ~/sagascript-fixture-cache
+          key: diarization-fixture-dj_2022_feu-6b63943
 
       - name: Install npm dependencies
         run: npm ci
@@ -99,9 +118,16 @@ jobs:
           result="$RUNNER_TEMP/diarization-smoke.json"
           "$binary" download-model tiny
           "$binary" download-model diarization
-          curl --fail --location --retry 3 \
-            'https://huggingface.co/datasets/medkit/simsamu/resolve/6b639431f658d636c30dbf342074d723bf303e0f/dj_2022_feu/dj_2022_feu.m4a' \
-            --output "$fixture"
+          fixture_cache="$HOME/sagascript-fixture-cache/dj_2022_feu.m4a"
+          mkdir -p "$HOME/sagascript-fixture-cache"
+          if [[ -f "$fixture_cache" ]]; then
+            cp "$fixture_cache" "$fixture"
+          else
+            curl --fail --location --retry 3 \
+              'https://huggingface.co/datasets/medkit/simsamu/resolve/6b639431f658d636c30dbf342074d723bf303e0f/dj_2022_feu/dj_2022_feu.m4a' \
+              --output "$fixture"
+            cp "$fixture" "$fixture_cache"
+          fi
           "$binary" transcribe \
             --language auto \
             --model tiny \
@@ -130,16 +156,13 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
-        uses: actions/cache@v5
+      # Shares the quality-gate shared key above (#178) so this build reuses
+      # dependencies the gate just compiled instead of rebuilding from cold.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: macos-arm64-release-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            macos-arm64-release-cargo-
+          workspaces: src-tauri
+          shared-key: sagascript-release
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   quality-gate:
@@ -31,20 +31,25 @@ jobs:
       # `build-macos` below uses the same shared key so the release Tauri
       # build reuses dependencies this gate job just compiled.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2, pinned (#180 review: release handles signing credentials)
         with:
           workspaces: src-tauri
           shared-key: sagascript-release
 
       # The inference gates re-download `nb-whisper-tiny`, `tiny` and the
-      # diarization models every run (#178). Same key as CI, so a PR-warmed
-      # model cache carries over to the release run.
+      # diarization models every run (#178). Dedicated release primary key:
+      # sharing CI's exact key would exact-hit on the smaller CI model set and
+      # then skip saving the release additions, so they would never persist.
+      # The CI key stays as fallback (same hash → PR-warmed `nb-whisper-tiny`
+      # carries over). Note: caches are tag-scoped, so each new tag downloads
+      # the release-only models once; same-tag reruns are warm.
       - name: Cache downloaded models
         uses: actions/cache@v5
         with:
           path: ~/Library/Application Support/Sagascript/Models
-          key: macos-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
+          key: macos-models-release-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
           restore-keys: |
+            macos-models-release-
             macos-models-
 
       # The diarization fixture is re-downloaded from Hugging Face every run
@@ -92,13 +97,18 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # Same explicit triple as `build-macos` below (#178): the shared
+      # rust-cache key covers one target dir, so building the gate binary
+      # here lets the release Tauri build reuse these compiled dependencies
+      # instead of compiling them cold. macos-14 runners are aarch64, so no
+      # extra rustup target is needed.
       - name: Build release CLI for inference smoke tests
         working-directory: src-tauri
-        run: cargo build --release -p sagascript-cli
+        run: cargo build --release --target aarch64-apple-darwin -p sagascript-cli
 
       - name: Gate real transcription
         run: |
-          binary=src-tauri/target/release/sagascript
+          binary=src-tauri/target/aarch64-apple-darwin/release/sagascript
           stdout="$RUNNER_TEMP/transcription-smoke.json"
           stderr="$RUNNER_TEMP/transcription-smoke.stderr"
           "$binary" download-model nb-whisper-tiny
@@ -113,7 +123,7 @@ jobs:
 
       - name: Gate real two-speaker diarization
         run: |
-          binary=src-tauri/target/release/sagascript
+          binary=src-tauri/target/aarch64-apple-darwin/release/sagascript
           fixture="$RUNNER_TEMP/dj_2022_feu.m4a"
           result="$RUNNER_TEMP/diarization-smoke.json"
           "$binary" download-model tiny
@@ -159,7 +169,7 @@ jobs:
       # Shares the quality-gate shared key above (#178) so this build reuses
       # dependencies the gate just compiled instead of rebuilding from cold.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2, pinned (#180 review: release handles signing credentials)
         with:
           workspaces: src-tauri
           shared-key: sagascript-release
@@ -276,6 +286,9 @@ jobs:
   publish-release:
     needs: build-macos
     runs-on: ubuntu-latest
+    # Sole writer: publishes the draft release. All other jobs run read-only.
+    permissions:
+      contents: write
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
Refs #178. Safe subset only — no coverage, policy, or branch-protection changes.

## What changed

**`ci.yml`**
- `concurrency` with `cancel-in-progress` on PR runs only (`github.event_name == 'pull_request'`), so pushing a fix cancels the stale run instead of burning runner-minutes compiling it twice. `main` pushes never cancel.
- All three cargo caches (`actions/cache` over `src-tauri/target`, keyed on `Cargo.lock`) replaced with `Swatinem/rust-cache@v2` (`workspaces: src-tauri`, `shared-key: sagascript-ci`): per-crate fingerprints, shared across branches, pruned before upload.
- Downloaded-model cache for macOS and Windows Tier-2 jobs (`nb-whisper-tiny` was re-downloaded every run), keyed on model-definition sources with `restore-keys` fallback. Linux job downloads no models — untouched.

**`release.yml`** (no concurrency: tag builds must never cancel)
- `quality-gate` and `build-macos` caches replaced with rust-cache under one unified `shared-key: sagascript-release`, so the Tauri build reuses what the gate just compiled (previously different keys forced a recompile).
- Model cache with the same key as CI, so PR-warmed models carry into releases.
- `dj_2022_feu.m4a` fixture cached in `~/sagascript-fixture-cache` and copied into `RUNNER_TEMP`; Hugging Face curl only runs on cache miss.

## Validation
- Both files YAML-parse; `hashFiles` targets verified to exist in-tree.
- No Rust/frontend code touched. Real proof is this PR's own CI run (expect first run to repopulate caches, subsequent runs faster).

## Deliberately deferred (stay on #178)
- apt caching/container pin, sccache eval — measure after this lands.
- Path filters, Tier-2-to-nightly, Windows `tauri build` downgrade (open Windows PRs rely on that coverage), fast-feedback required job + branch protection, nextest, dev-profile debuginfo (active perf work), paid runners, sbom audit.