### PR TITLE
fix: avoid Windows model verification stack overflow

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -121,6 +121,8 @@ jobs:
           $stderr = Join-Path $env:RUNNER_TEMP "transcription-smoke.stderr"
           & $binary download-model nb-whisper-tiny
           if ($LASTEXITCODE -ne 0) { throw "Model download failed with exit code $LASTEXITCODE" }
+          & $binary download-model nb-whisper-tiny
+          if ($LASTEXITCODE -ne 0) { throw "Existing model verification failed with exit code $LASTEXITCODE" }
           & $binary transcribe `
             --language no `
             --model nb-whisper-tiny `

--- a/scripts/accept-windows-candidate.ps1
+++ b/scripts/accept-windows-candidate.ps1
@@ -61,6 +61,9 @@ if ($versionOutput -notmatch $versionPattern) {
 $downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
 [void](Invoke-Sagascript -Executable $cliExePath -Arguments @("download-model", "nb-whisper-tiny"))
 $downloadTimer.Stop()
+$verificationTimer = [System.Diagnostics.Stopwatch]::StartNew()
+[void](Invoke-Sagascript -Executable $cliExePath -Arguments @("download-model", "nb-whisper-tiny"))
+$verificationTimer.Stop()
 
 $transcriptTemp = Join-Path ([System.IO.Path]::GetTempPath()) ("sagascript-acceptance-{0}.json" -f [guid]::NewGuid())
 try {
@@ -98,6 +101,7 @@ try {
         reported_version = $versionOutput.Trim()
         source_fixture_sha256 = (Get-FileHash -LiteralPath $fixturePath -Algorithm SHA256).Hash.ToLowerInvariant()
         download_seconds = [Math]::Round($downloadTimer.Elapsed.TotalSeconds, 3)
+        verification_seconds = [Math]::Round($verificationTimer.Elapsed.TotalSeconds, 3)
         transcription_seconds = [Math]::Round($transcriptionTimer.Elapsed.TotalSeconds, 3)
         detected_language = $result.language
         segment_count = @($result.segments).Count

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -12,6 +12,10 @@ const releaseGuide = await readFile(
   new URL("../docs/windows-release.md", import.meta.url),
   "utf8",
 );
+const acceptanceScript = await readFile(
+  new URL("./accept-windows-candidate.ps1", import.meta.url),
+  "utf8",
+);
 
 test("Windows candidate workflow stays non-publishing and explicitly unsigned", () => {
   assert.match(workflow, /workflow_dispatch:/);
@@ -68,11 +72,47 @@ test("Windows candidate makes real transcription a blocking gate", () => {
   const buildStart = workflow.indexOf("name: Build unsigned internal installers");
   assert.ok(gateStart >= 0 && buildStart > gateStart);
   const gate = workflow.slice(gateStart, buildStart);
-  assert.match(gate, /download-model nb-whisper-tiny/);
+  const downloadCalls = gate.match(/& \$binary download-model nb-whisper-tiny/g) ?? [];
+  assert.equal(
+    downloadCalls.length,
+    2,
+    "native gate must download once and re-verify the existing model",
+  );
+  const firstDownload = gate.indexOf("& $binary download-model nb-whisper-tiny");
+  const secondDownload = gate.indexOf(
+    "& $binary download-model nb-whisper-tiny",
+    firstDownload + 1,
+  );
+  const transcription = gate.indexOf("& $binary transcribe");
+  assert.ok(firstDownload >= 0 && secondDownload > firstDownload);
+  assert.ok(transcription > secondDownload);
+  assert.match(gate, /Existing model verification failed/);
   assert.match(gate, /verify-json-cli-streams\.py/);
   assert.doesNotMatch(gate, /continue-on-error/);
   assert.match(workflow, /Verify native runner architecture/);
   assert.match(workflow, /Expected native \$\{\{ matrix\.rust_target \}\} runner/);
+});
+
+test("Windows acceptance re-verifies an already-downloaded model", () => {
+  const downloadCalls = acceptanceScript.match(
+    /Invoke-Sagascript -Executable \$cliExePath -Arguments @\("download-model", "nb-whisper-tiny"\)/g,
+  ) ?? [];
+  assert.equal(
+    downloadCalls.length,
+    2,
+    "packaged acceptance must exercise existing-model verification",
+  );
+  const firstDownload = acceptanceScript.indexOf(
+    'Invoke-Sagascript -Executable $cliExePath -Arguments @("download-model", "nb-whisper-tiny")',
+  );
+  const secondDownload = acceptanceScript.indexOf(
+    'Invoke-Sagascript -Executable $cliExePath -Arguments @("download-model", "nb-whisper-tiny")',
+    firstDownload + 1,
+  );
+  const transcription = acceptanceScript.indexOf("$cliExePath transcribe");
+  assert.ok(firstDownload >= 0 && secondDownload > firstDownload);
+  assert.ok(transcription > secondDownload);
+  assert.match(acceptanceScript, /verification_seconds/);
 });
 
 test("Windows release guide forbids publishing unsigned candidates", () => {

--- a/src-tauri/crates/sagascript-core/src/download.rs
+++ b/src-tauri/crates/sagascript-core/src/download.rs
@@ -364,7 +364,11 @@ fn verify_file_detailed(
 
     let mut reader = BufReader::new(file);
     let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 1024 * 1024];
+    // Keep the multi-megabyte artifact hash buffer off the thread stack. The
+    // CLI verifier runs on the process's main/Tokio thread on Windows, whose
+    // stack is small enough for this allocation to trigger STATUS_STACK_OVERFLOW
+    // (especially on ARM64).
+    let mut buffer = vec![0_u8; 1024 * 1024];
     loop {
         let read = reader.read(&mut buffer).map_err(|e| {
             VerificationFailure::Other(DictationError::ModelDownloadFailed(format!(
@@ -656,6 +660,35 @@ mod tests {
         assert!(verify_file(&path, expected).is_ok());
         std::fs::write(&path, b"tampered model").unwrap();
         assert!(verify_file(&path, expected).is_err());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn verify_file_works_on_a_small_stack() {
+        let dir = temp_test_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"verified model").unwrap();
+        let expected = DownloadIntegrity {
+            sha256: "6c736b3dfa943bf4e7c61df78d1dfcad9a3d8b56369f0559670497b19127e74d",
+            size: 14,
+        };
+
+        // This is intentionally below the verifier's former 1 MiB stack
+        // buffer. A regression therefore fails on Windows with a stack
+        // overflow instead of depending on the host process stack size.
+        let result = std::thread::Builder::new()
+            .name("sagascript-small-stack-verification".to_string())
+            .stack_size(256 * 1024)
+            .spawn({
+                let path = path.clone();
+                move || verify_file(&path, expected)
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+
+        assert!(result.is_ok());
         let _ = std::fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## Summary
- move the 1 MiB model hash buffer from the Windows main-thread stack to the heap
- exercise existing-model verification from a constrained-stack regression test
- run download-model twice in the native Windows gate and packaged acceptance helper

## Evidence
The ARM64 candidate from #176 passed clean-runner CI but reproduced STATUS_STACK_OVERFLOW (0xC00000FD) locally when verifying an already-downloaded NB-Whisper Tiny model. The clean runner only exercised the first-download path.

## Validation
- node --test scripts/test-windows-package-workflow.mjs scripts/test-release-surface.mjs (25/25)
- git diff --check
- native x64 and ARM64 workflow gates must pass before merge