### PR TITLE
fix: suppress no-speech output and measure dictation latency

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,33 @@ rejected there; F21–F24 failed earlier as unknown scancodes. The source mappin
 for F13–F20 therefore did not provide a working permission-free registration
 path. This probe was run on 2026-09-04 before adopting the AppKit monitor.
 
+## Dictation latency diagnostics
+
+The macOS app writes local JSONL events to
+`~/Library/Logs/Sagascript/sagascript.log`. Match events by `dictationSession`
+when comparing a Bluetooth headset microphone with the Mac microphone.
+The new performance events contain timings, sample counts, sample rate, and
+decoder settings, but no audio, transcript text, or device names.
+
+- `capture_stopped` reports `captureRequestToStreamPlayReturnMs` and
+  `captureRequestToFirstAudioCallbackMs`. These start at the capture request,
+  not the shortcut event; they separate stream setup from first-buffer delivery.
+- `dictation_phase_timings` separates model readiness, Whisper duration, and
+  paste completion. `keyUpToCaptureStoppedMs` includes any minimum-recording
+  top-up delay (up to 300 ms); it is not a pure device-stop measurement. In
+  toggle mode, the origin is the second shortcut press instead of key-up.
+- Missing stages are `null`. Paste completion is measured only when its
+  main-thread callback reports a result. The app waits at most two seconds
+  for that result before returning to idle; a callback already dispatched may
+  still run later. `pasteOutcome` distinguishes success, failure, and timeout.
+
+Quiet cancellation and no-speech-marked Whisper output do not replace the last
+useful dictation or paste text. Capture failures are errors, not silence. If
+the input stream fails partway through a recording, the partial recording is
+not automatically transcribed or pasted. These measurements help diagnose
+startup latency; they do not establish that Bluetooth caused a delay or that
+the first spoken word was captured.
+
 ## Overrides and migration
 
 `SAGASCRIPT_SETTINGS_PATH=/absolute/path/to/settings.json` selects one exact

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -159,6 +159,32 @@ fn assemble_diarized_plain_text(segments: &[DiarizedSegment]) -> String {
 }
 
 #[cfg(feature = "diarization")]
+fn prepare_diarized_plain_segments(
+    segments: &[DiarizedSegment],
+    language: Language,
+    glossary: &Glossary,
+) -> Vec<DiarizedSegment> {
+    let filtered = segments
+        .iter()
+        .filter(|segment| !contains_no_speech_marker(&segment.text))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut consolidated = sagascript_core::diarization::merge::consolidate(&filtered);
+    for segment in &mut consolidated {
+        segment.text = normalize_nonspeech_markers(&segment.text, language);
+    }
+    let fragments = consolidated
+        .iter()
+        .map(|segment| segment.text.as_str())
+        .collect::<Vec<_>>();
+    let (corrected_fragments, _) = glossary.correct_fragments(&fragments);
+    for (segment, text) in consolidated.iter_mut().zip(corrected_fragments) {
+        segment.text = text;
+    }
+    consolidated
+}
+
+#[cfg(feature = "diarization")]
 #[derive(Debug, Default, serde::Serialize)]
 struct DiarizationPerformance {
     acceleration_backend: &'static str,
@@ -722,6 +748,7 @@ fn transcribe_file(
             .collect();
 
         let diarized = merge_with_transcript(&speaker_segments, &transcript);
+        let plain_segments = prepare_diarized_plain_segments(&diarized, language, glossary);
         let mut consolidated = consolidate(&diarized);
         for segment in &mut consolidated {
             segment.text = normalize_nonspeech_markers(&segment.text, language);
@@ -763,7 +790,7 @@ fn transcribe_file(
                 .filter(|speaker| seen.insert(speaker.clone()))
                 .collect()
         };
-        let plain = assemble_diarized_plain_text(&consolidated);
+        let plain = assemble_diarized_plain_text(&plain_segments);
         performance.merge_diagnostics_seconds = merge_diagnostics_started.elapsed().as_secs_f64();
         let json_assembly_started = Instant::now();
         let mut json = serde_json::json!({
@@ -1830,6 +1857,48 @@ mod tests {
             "[SPEAKER_0] First.\n[SPEAKER_1] Second."
         );
         assert!(contains_no_speech_marker(&segments[1].text));
+    }
+
+    #[cfg(feature = "diarization")]
+    #[test]
+    fn diarized_plain_filter_precedes_consolidation_without_mutating_diagnostics() {
+        let segments = vec![
+            DiarizedSegment {
+                start: 0.0,
+                end: 1.0,
+                speaker: "SPEAKER_0".to_string(),
+                text: "First hello Music Music Music".to_string(),
+            },
+            DiarizedSegment {
+                start: 1.0,
+                end: 1.3,
+                speaker: "SPEAKER_0".to_string(),
+                text: "<|nospeech|>-Hej Tack! Tack! Tack!".to_string(),
+            },
+            DiarizedSegment {
+                start: 1.3,
+                end: 2.0,
+                speaker: "SPEAKER_0".to_string(),
+                text: "Second.".to_string(),
+            },
+        ];
+        let consolidated = sagascript_core::diarization::merge::consolidate(&segments);
+        let diagnostic_text = consolidated[0].text.clone();
+
+        let glossary = Glossary::parse("Greeting = hello");
+        let plain_segments =
+            prepare_diarized_plain_segments(&segments, Language::English, &glossary);
+
+        assert_eq!(consolidated.len(), 1);
+        assert_eq!(consolidated[0].text, diagnostic_text);
+        assert_eq!(
+            diagnostic_text,
+            "First hello Music Music Music <|nospeech|>-Hej Tack! Tack! Tack! Second."
+        );
+        assert_eq!(
+            assemble_diarized_plain_text(&plain_segments),
+            "[SPEAKER_0] First Greeting [MUSIC] Second."
+        );
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -8,6 +8,8 @@ use clap::Args;
 use indicatif::{ProgressBar, ProgressStyle};
 
 use sagascript_core::audio::decoder::{decode_audio_file, SUPPORTED_EXTENSIONS};
+#[cfg(feature = "diarization")]
+use sagascript_core::diarization::DiarizedSegment;
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{HotkeyProfile, Language, Settings, WhisperModel};
 use sagascript_core::transcription::diagnostics::{
@@ -18,6 +20,9 @@ use sagascript_core::transcription::diagnostics::{
 #[cfg(feature = "diarization")]
 use sagascript_core::transcription::diagnostics::{analyze_coverage_profile, CoverageProfile};
 use sagascript_core::transcription::model;
+use sagascript_core::transcription::whisper_backend::assemble_transcript;
+#[cfg(feature = "diarization")]
+use sagascript_core::transcription::whisper_backend::contains_no_speech_marker;
 use sagascript_core::transcription::{
     normalize_nonspeech_markers, recommended_parallel_chunks, ContextProfile, Glossary,
     TranscribeOptions, TranscriptSegment, WhisperBackend,
@@ -141,6 +146,16 @@ pub struct TranscribeArgs {
 struct FileTranscription {
     json: serde_json::Value,
     plain: String,
+}
+
+#[cfg(feature = "diarization")]
+fn assemble_diarized_plain_text(segments: &[DiarizedSegment]) -> String {
+    segments
+        .iter()
+        .filter(|segment| !contains_no_speech_marker(&segment.text))
+        .map(|segment| format!("[{}] {}", segment.speaker, segment.text.trim()))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[cfg(feature = "diarization")]
@@ -748,11 +763,7 @@ fn transcribe_file(
                 .filter(|speaker| seen.insert(speaker.clone()))
                 .collect()
         };
-        let plain = consolidated
-            .iter()
-            .map(|segment| format!("[{}] {}", segment.speaker, segment.text.trim()))
-            .collect::<Vec<_>>()
-            .join("\n");
+        let plain = assemble_diarized_plain_text(&consolidated);
         performance.merge_diagnostics_seconds = merge_diagnostics_started.elapsed().as_secs_f64();
         let json_assembly_started = Instant::now();
         let mut json = serde_json::json!({
@@ -860,14 +871,7 @@ fn transcribe_file(
     // Keep timestamped segment text source-faithful, while the rendered
     // top-level text excludes quarantined loops and uses the same display
     // normalization as live dictation.
-    let raw_text = segments
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| !repetition.quarantines_segment(*index))
-        .map(|(_, segment)| segment.text.as_str())
-        .collect::<String>()
-        .trim()
-        .to_string();
+    let raw_text = assemble_transcript(&trusted_segments).trim().to_string();
     let text = normalize_nonspeech_markers(&raw_text, language);
     let coverage = analyze_coverage(&audio, &trusted_segments);
     let mut warnings = combined_warnings(&coverage, language, detected_language.as_ref());
@@ -1780,6 +1784,52 @@ mod tests {
             avg_logprob,
             no_speech_prob,
         }
+    }
+
+    #[test]
+    fn cli_plain_assembly_matches_core_no_speech_filter() {
+        let segments = vec![
+            segment(" First.", Some(-0.1), 0.01),
+            segment("<|nospeech|>-Hej Tack! Tack! Tack!", Some(-0.1), 0.9),
+            segment(" Second.", Some(-0.1), 0.01),
+        ];
+
+        assert_eq!(assemble_transcript(&segments), " First. Second.");
+        assert_eq!(
+            segments[1].text, "<|nospeech|>-Hej Tack! Tack! Tack!",
+            "display assembly must not mutate diagnostic segment text"
+        );
+    }
+
+    #[cfg(feature = "diarization")]
+    #[test]
+    fn diarized_plain_assembly_discards_no_speech_segments() {
+        let segments = vec![
+            DiarizedSegment {
+                start: 0.0,
+                end: 1.0,
+                speaker: "SPEAKER_0".to_string(),
+                text: "First.".to_string(),
+            },
+            DiarizedSegment {
+                start: 1.0,
+                end: 1.3,
+                speaker: "SPEAKER_1".to_string(),
+                text: "<|nospeech|>-Hej Tack! Tack! Tack!".to_string(),
+            },
+            DiarizedSegment {
+                start: 1.3,
+                end: 2.0,
+                speaker: "SPEAKER_1".to_string(),
+                text: "Second.".to_string(),
+            },
+        ];
+
+        assert_eq!(
+            assemble_diarized_plain_text(&segments),
+            "[SPEAKER_0] First.\n[SPEAKER_1] Second."
+        );
+        assert!(contains_no_speech_marker(&segments[1].text));
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/audio/capture.rs
+++ b/src-tauri/crates/sagascript-core/src/audio/capture.rs
@@ -1,6 +1,7 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Instant;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::SampleFormat;
@@ -13,6 +14,20 @@ use super::resample::{resample_to_16khz, TARGET_SAMPLE_RATE};
 /// recording (the buffer holds raw mono at the device rate), then resampled to
 /// 16 kHz on stop.
 const MAX_BUFFER_SECONDS: usize = 60 * 15;
+const STREAM_NOT_READY: u64 = u64::MAX;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AudioCaptureMetrics {
+    /// Time from the capture request until `stream.play()` returns. A slow
+    /// Bluetooth profile switch is visible here without recording a device
+    /// name or any audio content.
+    pub stream_play_return_ms: Option<u64>,
+    /// Time from the capture request until the first input callback runs.
+    /// This can be later than `stream_play_return_ms` when the audio backend
+    /// takes time to deliver the first buffer.
+    pub first_callback_ms: Option<u64>,
+    pub device_sample_rate_hz: Option<u32>,
+}
 
 /// Audio capture service using cpal
 /// The cpal::Stream is !Send, so we spawn a dedicated thread to own it.
@@ -24,6 +39,13 @@ pub struct AudioCaptureService {
     /// Device sample rate published by the capture thread once the input opens
     /// (0 until known). Read by `stop_capture` to resample the whole buffer.
     device_sample_rate: Arc<AtomicU32>,
+    /// Time published by the capture thread after `stream.play()` returns.
+    stream_play_return_ms: Arc<AtomicU64>,
+    /// Time published by the first input callback.
+    first_callback_ms: Arc<AtomicU64>,
+    /// First initialization or stream-processing error from the capture
+    /// thread for the current capture, if any.
+    worker_error: Arc<Mutex<Option<DictationError>>>,
     capture_thread: Option<thread::JoinHandle<()>>,
     /// Retained audio from last capture for retry
     last_captured: Option<Vec<f32>>,
@@ -45,6 +67,9 @@ impl AudioCaptureService {
             buffer: Arc::new(Mutex::new(Vec::new())),
             stop_signal: Arc::new(Mutex::new(false)),
             device_sample_rate: Arc::new(AtomicU32::new(0)),
+            stream_play_return_ms: Arc::new(AtomicU64::new(STREAM_NOT_READY)),
+            first_callback_ms: Arc::new(AtomicU64::new(STREAM_NOT_READY)),
+            worker_error: Arc::new(Mutex::new(None)),
             capture_thread: None,
             last_captured: None,
         }
@@ -65,11 +90,27 @@ impl AudioCaptureService {
         let buffer = Arc::clone(&self.buffer);
         let stop_signal = Arc::clone(&self.stop_signal);
         let device_sample_rate = Arc::clone(&self.device_sample_rate);
+        let stream_play_return_ms = Arc::clone(&self.stream_play_return_ms);
+        let first_callback_ms = Arc::clone(&self.first_callback_ms);
+        clear_worker_error(&self.worker_error);
+        let worker_error = Arc::clone(&self.worker_error);
         device_sample_rate.store(0, Ordering::SeqCst);
+        stream_play_return_ms.store(STREAM_NOT_READY, Ordering::SeqCst);
+        first_callback_ms.store(STREAM_NOT_READY, Ordering::SeqCst);
+        let capture_requested_at = Instant::now();
 
         // Spawn a thread that owns the cpal::Stream
         let handle = thread::spawn(move || {
-            if let Err(e) = run_capture(buffer, stop_signal, device_sample_rate) {
+            if let Err(e) = run_capture(
+                buffer,
+                stop_signal,
+                device_sample_rate,
+                stream_play_return_ms,
+                first_callback_ms,
+                worker_error.clone(),
+                capture_requested_at,
+            ) {
+                record_first_worker_error(&worker_error, e.clone());
                 error!("Audio capture thread error: {e}");
             }
         });
@@ -78,6 +119,16 @@ impl AudioCaptureService {
 
         // Give the capture thread a moment to initialize
         thread::sleep(std::time::Duration::from_millis(50));
+
+        // Initialization failures are often known by now. Return them to the
+        // caller while retaining the error for stop_capture as well.
+        let startup_error = { self.worker_error.lock().unwrap().clone() };
+        if let Some(error) = startup_error {
+            if let Some(handle) = self.capture_thread.take() {
+                let _ = handle.join();
+            }
+            return Err(error);
+        }
 
         info!("Audio capture started");
         Ok(())
@@ -99,6 +150,11 @@ impl AudioCaptureService {
         // Wait for the capture thread to finish
         if let Some(handle) = self.capture_thread.take() {
             let _ = handle.join();
+        }
+
+        if let Some(error) = self.worker_error.lock().unwrap().take() {
+            error!("Audio capture failed: {error}");
+            return Err(error);
         }
 
         let raw = {
@@ -146,6 +202,18 @@ impl AudioCaptureService {
     pub fn clear_last_captured(&mut self) {
         self.last_captured = None;
     }
+
+    pub fn metrics(&self) -> AudioCaptureMetrics {
+        let stream_play_return_ms = self.stream_play_return_ms.load(Ordering::SeqCst);
+        let first_callback_ms = self.first_callback_ms.load(Ordering::SeqCst);
+        let device_sample_rate_hz = self.device_sample_rate.load(Ordering::SeqCst);
+        AudioCaptureMetrics {
+            stream_play_return_ms: (stream_play_return_ms != STREAM_NOT_READY)
+                .then_some(stream_play_return_ms),
+            first_callback_ms: (first_callback_ms != STREAM_NOT_READY).then_some(first_callback_ms),
+            device_sample_rate_hz: (device_sample_rate_hz != 0).then_some(device_sample_rate_hz),
+        }
+    }
 }
 
 /// Run audio capture on a dedicated thread (owns the !Send cpal::Stream)
@@ -153,6 +221,10 @@ fn run_capture(
     buffer: Arc<Mutex<Vec<f32>>>,
     stop_signal: Arc<Mutex<bool>>,
     device_sample_rate_out: Arc<AtomicU32>,
+    stream_play_return_ms_out: Arc<AtomicU64>,
+    first_callback_ms_out: Arc<AtomicU64>,
+    worker_error: Arc<Mutex<Option<DictationError>>>,
+    capture_requested_at: Instant,
 ) -> Result<(), DictationError> {
     let host = cpal::default_host();
     let device = host
@@ -176,11 +248,21 @@ fn run_capture(
         config.sample_format()
     );
 
-    let err_fn = |err: cpal::StreamError| {
+    let worker_error_for_callback = Arc::clone(&worker_error);
+    let stop_signal_for_callback = Arc::clone(&stop_signal);
+    let err_fn = move |err: cpal::StreamError| {
+        record_first_worker_error(
+            &worker_error_for_callback,
+            DictationError::AudioCaptureError(format!("Audio stream error: {err}")),
+        );
         error!("Audio stream error: {err}");
+        if let Ok(mut stop) = stop_signal_for_callback.lock() {
+            *stop = true;
+        }
     };
 
     let buf_clone = Arc::clone(&buffer);
+    let first_callback_ms_clone = Arc::clone(&first_callback_ms_out);
 
     let stream = match config.sample_format() {
         SampleFormat::F32 => {
@@ -189,6 +271,10 @@ fn run_capture(
                 .build_input_stream(
                     &config,
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                        publish_first_callback_ms(
+                            &first_callback_ms_clone,
+                            elapsed_ms(capture_requested_at),
+                        );
                         process_samples(data, device_channels, device_sample_rate, &buf_clone);
                     },
                     err_fn,
@@ -200,10 +286,15 @@ fn run_capture(
         }
         SampleFormat::I16 => {
             let config = config.into();
+            let first_callback_ms_clone = Arc::clone(&first_callback_ms_out);
             device
                 .build_input_stream(
                     &config,
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                        publish_first_callback_ms(
+                            &first_callback_ms_clone,
+                            elapsed_ms(capture_requested_at),
+                        );
                         process_samples_i16(
                             data,
                             device_channels,
@@ -228,6 +319,9 @@ fn run_capture(
     stream
         .play()
         .map_err(|e| DictationError::AudioCaptureError(format!("Failed to start stream: {e}")))?;
+    let stream_play_return_ms = elapsed_ms(capture_requested_at);
+    stream_play_return_ms_out.store(stream_play_return_ms, Ordering::SeqCst);
+    info!("Audio input stream play returned after {stream_play_return_ms}ms");
 
     // Spin until stop signal (the stream callback fills the buffer)
     loop {
@@ -240,6 +334,36 @@ fn run_capture(
 
     // Stream is dropped here, stopping capture
     Ok(())
+}
+
+fn clear_worker_error(error: &Arc<Mutex<Option<DictationError>>>) {
+    *error.lock().unwrap() = None;
+}
+
+fn record_first_worker_error(
+    error_slot: &Arc<Mutex<Option<DictationError>>>,
+    error: DictationError,
+) {
+    let mut first_error = error_slot.lock().unwrap();
+    if first_error.is_none() {
+        *first_error = Some(error);
+    }
+}
+
+fn elapsed_ms(since: Instant) -> u64 {
+    since
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+fn publish_first_callback_ms(output: &AtomicU64, elapsed_ms: u64) {
+    let _ = output.compare_exchange(
+        STREAM_NOT_READY,
+        elapsed_ms,
+        Ordering::SeqCst,
+        Ordering::SeqCst,
+    );
 }
 
 fn process_samples(
@@ -382,5 +506,101 @@ mod tests {
             .stop_capture()
             .expect("silence should be Ok(empty), not Err");
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn capture_metrics_are_unknown_before_a_stream_opens() {
+        let svc = AudioCaptureService::new();
+        assert_eq!(
+            svc.metrics(),
+            AudioCaptureMetrics {
+                stream_play_return_ms: None,
+                first_callback_ms: None,
+                device_sample_rate_hz: None,
+            }
+        );
+    }
+
+    #[test]
+    fn capture_metrics_preserve_zero_latency_and_known_sample_rate() {
+        let svc = AudioCaptureService::new();
+        svc.stream_play_return_ms.store(0, Ordering::SeqCst);
+        svc.first_callback_ms.store(0, Ordering::SeqCst);
+        svc.device_sample_rate.store(48_000, Ordering::SeqCst);
+
+        assert_eq!(
+            svc.metrics(),
+            AudioCaptureMetrics {
+                stream_play_return_ms: Some(0),
+                first_callback_ms: Some(0),
+                device_sample_rate_hz: Some(48_000),
+            }
+        );
+    }
+
+    #[test]
+    fn capture_metrics_keep_zero_sample_rate_unknown() {
+        let svc = AudioCaptureService::new();
+        svc.stream_play_return_ms.store(0, Ordering::SeqCst);
+        svc.first_callback_ms.store(3, Ordering::SeqCst);
+
+        assert_eq!(
+            svc.metrics(),
+            AudioCaptureMetrics {
+                stream_play_return_ms: Some(0),
+                first_callback_ms: Some(3),
+                device_sample_rate_hz: None,
+            }
+        );
+    }
+
+    #[test]
+    fn first_callback_metric_records_only_the_first_callback() {
+        let output = AtomicU64::new(STREAM_NOT_READY);
+        publish_first_callback_ms(&output, 0);
+        publish_first_callback_ms(&output, 12);
+
+        assert_eq!(output.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn first_worker_error_is_retained_and_taken_once() {
+        let error_slot = Arc::new(Mutex::new(None));
+        record_first_worker_error(
+            &error_slot,
+            DictationError::MicrophonePermissionDenied,
+        );
+        record_first_worker_error(
+            &error_slot,
+            DictationError::AudioCaptureError("later error".into()),
+        );
+
+        assert!(matches!(
+            error_slot.lock().unwrap().take(),
+            Some(DictationError::MicrophonePermissionDenied)
+        ));
+        assert!(error_slot.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn stop_capture_returns_worker_error_and_consumes_it() {
+        let mut svc = AudioCaptureService::new();
+        *svc.worker_error.lock().unwrap() = Some(DictationError::AudioCaptureError(
+            "stream stopped".into(),
+        ));
+
+        let err = svc.stop_capture().expect_err("worker error should not become silence");
+        assert_eq!(err.to_string(), "Audio capture error: stream stopped");
+        assert!(svc.stop_capture().expect("error should be consumed").is_empty());
+    }
+
+    #[test]
+    fn clearing_worker_error_removes_stale_capture_failure() {
+        let svc = AudioCaptureService::new();
+        *svc.worker_error.lock().unwrap() = Some(DictationError::MicrophonePermissionDenied);
+
+        clear_worker_error(&svc.worker_error);
+
+        assert!(svc.worker_error.lock().unwrap().is_none());
     }
 }

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -249,15 +249,32 @@ fn mean_logprob(plogs: &[f32]) -> Option<f32> {
     Some(plogs.iter().sum::<f32>() / plogs.len() as f32)
 }
 
+/// Return whether a raw Whisper segment contains its exact no-speech marker.
+///
+/// The marker is only interpreted while assembling user-facing text. Raw
+/// timestamped segments remain unchanged for diagnostics.
+pub fn contains_no_speech_marker(text: &str) -> bool {
+    text.contains("<|nospeech|>")
+}
+
 /// Assemble the plain transcript from Whisper's raw segments.
 ///
 /// Whisper normally includes a leading space on each new segment. When it does
 /// not, preserve the expected sentence boundary in the user-facing transcript
 /// without changing the raw, timestamped segment text.
-fn assemble_transcript(segments: &[TranscriptSegment]) -> String {
+pub fn assemble_transcript(segments: &[TranscriptSegment]) -> String {
     let mut transcript = String::new();
 
     for segment in segments {
+        // Whisper can prefix a silence hallucination with its internal
+        // no-speech token. Dropping only the marker would still expose the
+        // fabricated words that follow it, so discard the whole segment from
+        // the plain user-facing transcript. Raw timestamped segments remain
+        // unchanged for diagnostics.
+        if contains_no_speech_marker(&segment.text) {
+            continue;
+        }
+
         let previous_ends_with_whitespace = transcript
             .chars()
             .next_back()
@@ -2416,6 +2433,48 @@ mod progress_callback_tests {
 #[cfg(test)]
 mod segment_confidence_tests {
     use super::*;
+
+    #[test]
+    fn assembled_transcript_discards_no_speech_marked_hallucination() {
+        let segments = [TranscriptSegment {
+            start: 0.0,
+            end: 0.3,
+            text: "<|nospeech|>-Hej Tack! Tack! Tack!".to_string(),
+            avg_logprob: Some(-0.1),
+            no_speech_prob: 0.9,
+        }];
+
+        assert_eq!(assemble_transcript(&segments), "");
+    }
+
+    #[test]
+    fn assembled_transcript_discards_no_speech_segment_between_sentences() {
+        let segments = [
+            TranscriptSegment {
+                start: 0.0,
+                end: 1.0,
+                text: "First.".to_string(),
+                avg_logprob: Some(-0.1),
+                no_speech_prob: 0.01,
+            },
+            TranscriptSegment {
+                start: 1.0,
+                end: 1.3,
+                text: "<|nospeech|>-Hej Tack! Tack! Tack!".to_string(),
+                avg_logprob: Some(-0.1),
+                no_speech_prob: 0.9,
+            },
+            TranscriptSegment {
+                start: 1.3,
+                end: 2.0,
+                text: "Second.".to_string(),
+                avg_logprob: Some(-0.1),
+                no_speech_prob: 0.01,
+            },
+        ];
+
+        assert_eq!(assemble_transcript(&segments), "First. Second.");
+    }
 
     #[test]
     fn assembled_transcript_separates_sentence_ending_segments() {

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -292,10 +292,29 @@ impl AppController {
             .recording_start
             .map(|s| s.elapsed().as_millis())
             .unwrap_or(0);
+        let metrics = self.audio.metrics();
+        let recording_duration_ms = u64::try_from(duration).unwrap_or(u64::MAX);
+        let audio_duration_ms = u64::try_from(
+            (samples.len() as u128).saturating_mul(1_000) / 16_000,
+        )
+        .unwrap_or(u64::MAX);
 
         info!(
             "Recording stopped: {} samples ({duration}ms)",
             samples.len()
+        );
+        self.logging.log(
+            "info",
+            "Performance",
+            log_events::audio::CAPTURE_STOPPED,
+            serde_json::json!({
+                "recordingDurationMs": recording_duration_ms,
+                "audioDurationMs": audio_duration_ms,
+                "audioSamples": samples.len(),
+                "captureRequestToStreamPlayReturnMs": metrics.stream_play_return_ms,
+                "captureRequestToFirstAudioCallbackMs": metrics.first_callback_ms,
+                "deviceSampleRateHz": metrics.device_sample_rate_hz,
+            }),
         );
 
         self.state = AppState::Transcribing;
@@ -331,6 +350,31 @@ impl AppController {
         self.active_hotkey_profile = None;
         self.training_recording = false;
         self.logging.end_dictation_session();
+    }
+
+    /// Complete a quiet push-to-talk cancellation without replacing the last
+    /// useful transcript, surfacing an error, or leaving retry audio behind.
+    pub fn on_no_speech_detected(&mut self) {
+        self.audio.clear_last_captured();
+        self.state = AppState::Idle;
+        self.active_hotkey_profile = None;
+        self.training_recording = false;
+        self.logging.log(
+            "info",
+            "Transcription",
+            log_events::transcription::NO_SPEECH,
+            serde_json::json!({}),
+        );
+        self.logging.end_dictation_session();
+    }
+
+    pub fn log_dictation_performance(&self, data: serde_json::Value) {
+        self.logging.log(
+            "info",
+            "Performance",
+            log_events::transcription::PHASE_TIMINGS,
+            data,
+        );
     }
 
     /// Called after transcription fails
@@ -560,6 +604,20 @@ mod tests {
         assert_eq!(result, Ok("Hello again".to_string()));
         assert_eq!(ctrl.last_transcription(), Some("Hello again"));
         assert_eq!(ctrl.state(), AppState::Idle);
+    }
+
+    #[test]
+    fn no_speech_returns_idle_without_replacing_last_transcription() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Transcribing;
+        ctrl.last_transcription = Some("Previous useful result".to_string());
+        ctrl.last_error = Some("stale error".to_string());
+
+        ctrl.on_no_speech_detected();
+
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert_eq!(ctrl.last_transcription(), Some("Previous useful result"));
+        assert_eq!(ctrl.last_error(), Some("stale error"));
     }
 
     // -- Recording elapsed --

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -235,6 +235,23 @@ impl AppController {
         &mut self,
         profile: HotkeyProfile,
     ) -> Result<bool, DictationError> {
+        self.start_recording_for_profile_with_capture(profile, |audio| audio.start_capture())
+    }
+
+    /// Start recording using the supplied capture operation.
+    ///
+    /// The injected capture operation keeps the startup transition testable
+    /// without requiring a microphone. It also makes sure a failure after the
+    /// dictation session is opened goes through the same controller-owned
+    /// cleanup path as other workflow errors.
+    fn start_recording_for_profile_with_capture<F>(
+        &mut self,
+        profile: HotkeyProfile,
+        start_capture: F,
+    ) -> Result<bool, DictationError>
+    where
+        F: FnOnce(&mut AudioCaptureService) -> Result<(), DictationError>,
+    {
         if self.state != AppState::Idle {
             warn!("Cannot start recording: state is {:?}", self.state);
             return Ok(false);
@@ -248,7 +265,12 @@ impl AppController {
             serde_json::json!({ "dictationSessionId": session_id }),
         );
 
-        self.audio.start_capture()?;
+        if let Err(error) = start_capture(&mut self.audio) {
+            let message = error.to_string();
+            self.on_transcription_error(&message);
+            return Err(error);
+        }
+
         info!(
             profile_id = %profile.id,
             profile_name = %profile.name,
@@ -780,6 +802,45 @@ mod tests {
         let started = ctrl.start_recording().unwrap();
         assert!(!started);
         assert_eq!(ctrl.state(), AppState::Transcribing); // unchanged
+    }
+
+    #[test]
+    fn recording_start_failure_closes_session_and_restores_idle_without_capture() {
+        let mut ctrl = default_controller();
+        let profile = ctrl
+            .settings()
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .next()
+            .expect("default settings provide a hotkey profile");
+        let expected_error = DictationError::MicrophonePermissionDenied;
+        let expected_message = expected_error.to_string();
+
+        let result = ctrl.start_recording_for_profile_with_capture(profile, |_| {
+            Err(expected_error.clone())
+        });
+
+        assert!(matches!(result, Err(DictationError::MicrophonePermissionDenied)));
+        assert_eq!(ctrl.last_error(), Some(expected_message.as_str()));
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert!(ctrl.active_hotkey_profile().is_none());
+        assert!(!ctrl.training_recording);
+
+        // The failed start must leave the controller reusable for a later
+        // attempt; this still injects the capture result and never opens a mic.
+        assert!(matches!(
+            ctrl.start_recording_for_profile_with_capture(
+                ctrl.settings()
+                    .resolved_hotkey_profiles()
+                    .into_iter()
+                    .next()
+                    .unwrap(),
+                |_| Ok(()),
+            ),
+            Ok(true)
+        ));
+        assert_eq!(ctrl.state(), AppState::Recording);
+        ctrl.cancel_recording();
     }
 
     // -- stop_recording_guarded --

--- a/src-tauri/src/logging/log_events.rs
+++ b/src-tauri/src/logging/log_events.rs
@@ -37,6 +37,8 @@ pub mod transcription {
     pub const FAILED: &str = "transcription_failed";
     pub const MODEL_LOADING: &str = "model_loading";
     pub const MODEL_LOADED: &str = "model_loaded";
+    pub const NO_SPEECH: &str = "no_speech_detected";
+    pub const PHASE_TIMINGS: &str = "dictation_phase_timings";
 }
 
 #[allow(dead_code)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,7 +26,7 @@ mod updates;
 use tracing_subscriber::EnvFilter;
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Maximum time to wait for whisper inference before aborting (seconds)
 const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
@@ -34,6 +34,11 @@ const TRANSCRIPTION_TIMEOUT_SECS: u64 = 60;
 /// Grace after a timeout-triggered abort for the blocking inference to unwind and
 /// release the warm-state lock before we log it as still stuck.
 const ABORT_GRACE_SECS: u64 = 5;
+
+/// Maximum time to wait for the main-thread paste callback to report its result.
+/// The paste operation itself remains on the main thread, but transcription state
+/// must not stay wedged if the callback is never run or never reports completion.
+const PASTE_COMPLETION_TIMEOUT_MS: u64 = 2_000;
 
 use tauri::{
     menu::{Menu, MenuItem, Submenu},
@@ -1359,12 +1364,22 @@ where
     }
 }
 
+fn elapsed_ms(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn elapsed_ms_if_success<T, E>(result: &Result<T, E>, start: Instant) -> Option<u64> {
+    result.as_ref().ok().map(|_| elapsed_ms(start))
+}
+
 /// Stop recording, enforce minimum duration, and spawn transcription.
 /// Shared by both push-to-talk (on key-up) and toggle (on second key-down).
 fn stop_recording_and_transcribe(
     app: &tauri::AppHandle,
     ctrl: &tauri::State<'_, SharedController>,
 ) {
+    let key_up_at = Instant::now();
+
     // Compute how long we still need to hold to satisfy the minimum recording
     // duration — but do NOT block the global-shortcut (UI) thread waiting for it
     // (finding 2): a std::thread::sleep here freezes UI redraw and stalls
@@ -1416,6 +1431,7 @@ fn stop_recording_and_transcribe(
             }
             StopRecordingOutcome::Stopped(audio) => audio,
         };
+        let key_up_to_capture_stopped_ms = elapsed_ms(key_up_at);
 
         // Hide overlay + show the transcribing state — re-dispatched to the main
         // thread now that this runs on a worker.
@@ -1428,7 +1444,17 @@ fn stop_recording_and_transcribe(
         if audio.is_empty() {
             {
                 let ctrl: tauri::State<'_, SharedController> = app_handle.state();
-                ctrl.lock().unwrap().on_transcription_error("No audio captured");
+                let mut c = ctrl.lock().unwrap();
+                c.log_dictation_performance(serde_json::json!({
+                    "outcome": "no_speech",
+                    "keyUpToCaptureStoppedMs": key_up_to_capture_stopped_ms,
+                    "keyUpToModelReadyMs": null,
+                    "modelLoadMs": null,
+                    "whisperMs": null,
+                    "keyUpToPasteCompletedMs": null,
+                    "totalMs": elapsed_ms(key_up_at),
+                }));
+                c.on_no_speech_detected();
             }
             dispatch_to_main(&app_handle, |app| update_tray_status(app, "idle"));
             let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
@@ -1455,16 +1481,27 @@ fn stop_recording_and_transcribe(
             )
         };
 
-        info!("Transcribing with model: {}", effective_model.display_name());
+        let model_name = effective_model.display_name().to_string();
+        let language_name = language.display_name().to_string();
+        let beam_size = opts.beam_size;
+        let temperature_fallback = opts.temperature_fallback;
+        let vad_enabled = opts.vad_model_path.is_some();
+        let model_was_warm = !whisper.needs_reload(effective_model);
+        info!("Transcribing with model: {model_name}");
 
         // Show model loading status in tray
-        if whisper.needs_reload(effective_model) {
+        if !model_was_warm {
             let _ = app_handle.emit(events::event::STATE_CHANGED, "loading_model");
             dispatch_to_main(&app_handle, |app| update_tray_status(app, "loading_model"));
         }
 
         // Ensure model is loaded
-        let result = if let Err(e) = whisper.ensure_model(effective_model) {
+        let model_load_started_at = Instant::now();
+        let model_result = whisper.ensure_model(effective_model);
+        let model_load_ms = elapsed_ms(model_load_started_at);
+        let key_up_to_model_ready_ms = model_result.is_ok().then(|| elapsed_ms(key_up_at));
+        let mut whisper_ms = None;
+        let result = if let Err(e) = model_result {
             Err(e)
         } else {
             // Run blocking transcription on a separate thread with a timeout. On
@@ -1473,12 +1510,13 @@ fn stop_recording_and_transcribe(
             // between compute steps, so the blocking task returns and releases the
             // warm state instead of running to completion and wedging the pipeline.
             let whisper_ref = whisper.inner().clone();
+            let whisper_started_at = Instant::now();
             let mut fut = tokio::task::spawn_blocking(move || {
                 whisper_ref.transcribe_sync_with_options(&audio, language, &opts, |_| {})
             });
 
             let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);
-            match tokio::time::timeout(timeout, &mut fut).await {
+            let result = match tokio::time::timeout(timeout, &mut fut).await {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => Err(sagascript_core::error::DictationError::TranscriptionFailed(
                     format!("Task join error: {e}"),
@@ -1501,13 +1539,43 @@ fn stop_recording_and_transcribe(
                         format!("Transcription timed out after {TRANSCRIPTION_TIMEOUT_SECS}s (inference aborted)"),
                     ))
                 }
-            }
+            };
+            whisper_ms = Some(elapsed_ms(whisper_started_at));
+            result
         };
+
+        let key_up_to_whisper_complete_ms = elapsed_ms_if_success(&result, key_up_at);
 
         match result {
             Ok(text) => {
                 let text = commands::apply_glossary(text, &glossary);
                 info!("Transcription complete: {} chars", text.len());
+
+                if text.trim().is_empty() {
+                    let mut c = ctrl.lock().unwrap();
+                    c.log_dictation_performance(serde_json::json!({
+                        "outcome": "no_speech",
+                        "model": model_name,
+                        "language": language_name,
+                        "modelWasWarm": model_was_warm,
+                        "beamSize": beam_size,
+                        "temperatureFallback": temperature_fallback,
+                        "vadEnabled": vad_enabled,
+                        "keyUpToCaptureStoppedMs": key_up_to_capture_stopped_ms,
+                        "modelLoadMs": model_load_ms,
+                        "keyUpToModelReadyMs": key_up_to_model_ready_ms,
+                        "whisperMs": whisper_ms,
+                        "keyUpToWhisperCompleteMs": key_up_to_whisper_complete_ms,
+                        "keyUpToPasteCompletedMs": null,
+                        "totalMs": elapsed_ms(key_up_at),
+                    }));
+                    c.on_no_speech_detected();
+                    drop(c);
+                    let _ = app_handle.emit(events::event::STATE_CHANGED, "idle");
+                    dispatch_to_main(&app_handle, |app| update_tray_status(app, "idle"));
+                    info!("No speech detected; returning to idle without paste");
+                    return;
+                }
 
                 // Check if auto-paste is enabled (lock briefly)
                 let should_paste = {
@@ -1515,23 +1583,71 @@ fn stop_recording_and_transcribe(
                     c.settings().auto_paste
                 };
 
+                let mut paste_outcome = "disabled";
+                let mut key_up_to_paste_completed_ms = None;
                 if should_paste {
                     // Auto-paste MUST run on the main thread — enigo's macOS TIS APIs
                     // crash (SIGABRT) if called from a tokio worker thread.
                     let text_for_paste = text.clone();
+                    let (paste_tx, paste_rx) = tokio::sync::oneshot::channel();
                     if let Err(e) = app_handle.run_on_main_thread(move || {
                         info!("Running auto-paste on main thread...");
                         let paste_svc = crate::paste::PasteService::new();
-                        match paste_svc.paste(&text_for_paste) {
+                        let paste_result = paste_svc
+                            .paste(&text_for_paste)
+                            .map_err(|error| error.to_string());
+                        match &paste_result {
                             Ok(()) => info!("Auto-paste completed successfully"),
                             Err(e) => error!("Auto-paste failed: {e}"),
                         }
+                        let _ = paste_tx.send(paste_result);
                     }) {
                         error!("Failed to dispatch paste to main thread: {e}");
+                        paste_outcome = "dispatch_failed";
+                    } else {
+                        match tokio::time::timeout(
+                            Duration::from_millis(PASTE_COMPLETION_TIMEOUT_MS),
+                            paste_rx,
+                        )
+                        .await
+                        {
+                            Ok(Ok(Ok(()))) => {
+                                paste_outcome = "succeeded";
+                                key_up_to_paste_completed_ms = Some(elapsed_ms(key_up_at));
+                            }
+                            Ok(Ok(Err(_))) => {
+                                paste_outcome = "failed";
+                                key_up_to_paste_completed_ms = Some(elapsed_ms(key_up_at));
+                            }
+                            Ok(Err(_)) => paste_outcome = "completion_dropped",
+                            Err(_) => {
+                                paste_outcome = "timed_out";
+                                warn!(
+                                    "Auto-paste completion timed out after {PASTE_COMPLETION_TIMEOUT_MS}ms"
+                                );
+                            }
+                        }
                     }
                 }
 
                 let mut c = ctrl.lock().unwrap();
+                c.log_dictation_performance(serde_json::json!({
+                    "outcome": "success",
+                    "model": model_name,
+                    "language": language_name,
+                    "modelWasWarm": model_was_warm,
+                    "beamSize": beam_size,
+                    "temperatureFallback": temperature_fallback,
+                    "vadEnabled": vad_enabled,
+                    "keyUpToCaptureStoppedMs": key_up_to_capture_stopped_ms,
+                    "modelLoadMs": model_load_ms,
+                    "keyUpToModelReadyMs": key_up_to_model_ready_ms,
+                    "whisperMs": whisper_ms,
+                    "keyUpToWhisperCompleteMs": key_up_to_whisper_complete_ms,
+                    "pasteOutcome": paste_outcome,
+                    "keyUpToPasteCompletedMs": key_up_to_paste_completed_ms,
+                    "totalMs": elapsed_ms(key_up_at),
+                }));
                 c.on_transcription_success(&text);
                 drop(c);
 
@@ -1547,6 +1663,22 @@ fn stop_recording_and_transcribe(
             Err(e) => {
                 error!("Transcription failed: {e}");
                 let mut c = ctrl.lock().unwrap();
+                c.log_dictation_performance(serde_json::json!({
+                    "outcome": "error",
+                    "model": model_name,
+                    "language": language_name,
+                    "modelWasWarm": model_was_warm,
+                    "beamSize": beam_size,
+                    "temperatureFallback": temperature_fallback,
+                    "vadEnabled": vad_enabled,
+                    "keyUpToCaptureStoppedMs": key_up_to_capture_stopped_ms,
+                    "modelLoadMs": model_load_ms,
+                    "keyUpToModelReadyMs": key_up_to_model_ready_ms,
+                    "whisperMs": whisper_ms,
+                    "keyUpToWhisperCompleteMs": key_up_to_whisper_complete_ms,
+                    "keyUpToPasteCompletedMs": null,
+                    "totalMs": elapsed_ms(key_up_at),
+                }));
                 c.on_transcription_error(&e.to_string());
                 drop(c);
                 let _ = app_handle.emit(events::event::ERROR, e.to_string());
@@ -1757,6 +1889,13 @@ fn start_settings_watcher(app: tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn elapsed_ms_if_success_only_marks_successful_operations_complete() {
+        let start = Instant::now();
+        assert!(elapsed_ms_if_success::<(), ()>(&Ok(()), start).is_some());
+        assert!(elapsed_ms_if_success::<(), ()>(&Err(()), start).is_none());
+    }
 
     #[test]
     fn second_instance_reveals_settings_except_for_background_startup() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -404,6 +404,7 @@ fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::Ba
                         Ok(result) => result,
                         Err(error) => {
                             error!("Hotkey down error: {error}");
+                            let _ = app.emit(events::event::ERROR, error.to_string());
                             HotkeyDownResult::NoOp
                         }
                     },


### PR DESCRIPTION
## What

Quick push-to-talk cancellation could paste Whisper output such as `<|nospeech|>-Hej Tack! Tack! Tack!`. Suppress entire no-speech-marked segments in user-facing GUI, CLI, and diarized plain text, preserving raw timestamped diagnostic segments. Empty dictations return to idle without pasting or replacing the last useful result.

Capture initialization and stream failures now propagate as errors. Content-free timings distinguish capture startup and first callback, model loading, inference, and main-thread paste completion; paste completion waiting is bounded.

## Why

Follow-up to #171 and groundwork for #163. The reported delay before the first word may involve Bluetooth microphone startup. This PR adds measurements to locate it; it does not claim to fix Bluetooth startup latency. Both issues remain open for hardware acceptance.

## Testing

- [x] Rust workspace check and tests pass (642 tests including review regressions).
- [x] Frontend build, Svelte check, and all 49 frontend tests pass.
- [x] Strict workspace Clippy and lean CLI build pass.
- [x] Regression tests cover no-speech text assembly, capture error retention/reset, startup-error recovery, same-speaker consolidation with glossary/normalization parity, and timing semantics.
- [ ] Physical signed-build test: compare Bluetooth headset mic with Mac mic, quick cancellation, and first-word capture.

Claude Fable 5.1 (`claude-fable-5-1`) re-reviewed final head `10d9e29f903552d5999527b904bbec824ec4162d` and returned APPROVE with no material findings. [Review record](https://github.com/Magnus-Gille/sagascript/pull/186#issuecomment-5552436607). Merge is gated on green GitHub CI for that head. A new signed/notarized test artifact will be built from the merged revision, outside the stable release channel.

Fable's first review identified two medium findings, both addressed in `10d9e29`: hotkey startup errors now reach the UI and close the logging session, and no-speech filtering now precedes speaker consolidation. See `docs/configuration.md` for timing interpretation, bounded paste completion, and the intentional behavior when a stream fails during a recording.
