### PR TITLE
fix: silent dictation handling and visible build identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ Rust, Svelte 5, and local Whisper inference.
   discover the current inventory with `sagascript --help` rather than duplicating it here.
 - **Privacy first:** local transcription is the default; remote/cloud behavior is opt-in.
 - Optimize latency and perceived speed; keep the UI to the menu bar, settings, and indicator.
+- Every build must identify itself with its release version and source revision/build
+  identity in the tray menu, prominently in Settings, and in CLI `--version` output.
+  Use generated build metadata rather than manually maintained display strings.
 - Make changes only on a task branch in a separate worktree; never edit the primary checkout.
 - Never read, print, modify, or commit `.env`, `.env.*`, or `secrets/**` without explicit
   user authorization. Never hardcode secrets.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,20 @@ not automatically transcribed or pasted. These measurements help diagnose
 startup latency; they do not establish that Bluetooth caused a delay or that
 the first spoken word was captured.
 
+Before live dictation decoding (GUI and CLI `record`), a local near-silence guard
+examines 20 ms frames of 16 kHz audio. If every frame's RMS level is below 0.0015,
+the capture returns empty text without running Whisper. A frame above this
+conservative floor keeps the entire recording, including its beginning; no
+minimum word duration is imposed. This is separate from optional Silero VAD and
+does not download a model or send audio anywhere. Explicit `[BLANK_AUDIO]`
+artifacts are also removed from display text; ordinary words such as “tack” and
+“thank you” are never blacklisted. File/diagnostic APIs and model warmup are
+unchanged. Louder microphone noise can still reach Whisper, so acceptance testing
+should include silent taps and short spoken words on each microphone in use.
+
+The tray menu and the top of Settings show the release version, build revision,
+and build date. The CLI exposes the same identity with `sagascript --version`.
+
 ## Overrides and migration
 
 `SAGASCRIPT_SETTINGS_PATH=/absolute/path/to/settings.json` selects one exact

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -14,6 +14,33 @@ fn metadata_value(key: &str, fallback: impl FnOnce() -> String) -> String {
     std::env::var(key).ok().unwrap_or_else(fallback)
 }
 
+fn local_git_hash() -> String {
+    let hash =
+        command_output(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let dirty = command_output(&["status", "--porcelain=v1", "--untracked-files=all"])
+        .is_some_and(|status| !status.is_empty());
+    if dirty {
+        format!("{hash}-dirty")
+    } else {
+        hash
+    }
+}
+
+fn emit_source_rerun_triggers() {
+    // Watch source trees that affect the binary's identity without watching
+    // the package root, which would include target/ and cause rebuild loops.
+    for path in [
+        "src",
+        "crates",
+        "../src",
+        "../package-lock.json",
+        "Cargo.lock",
+        "Cargo.toml",
+    ] {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
 fn emit_git_rerun_triggers() {
     println!("cargo:rerun-if-env-changed=SAGASCRIPT_GIT_HASH");
     println!("cargo:rerun-if-env-changed=SAGASCRIPT_BUILD_DATE");
@@ -21,6 +48,7 @@ fn emit_git_rerun_triggers() {
 
     if let Some(git_dir) = command_output(&["rev-parse", "--absolute-git-dir"]) {
         println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        println!("cargo:rerun-if-changed={git_dir}/index");
         if let Some(reference) = command_output(&["symbolic-ref", "-q", "HEAD"]) {
             if let Some(reference_path) =
                 command_output(&["rev-parse", "--git-path", reference.as_str()])
@@ -36,10 +64,9 @@ fn emit_git_rerun_triggers() {
 
 fn main() {
     emit_git_rerun_triggers();
+    emit_source_rerun_triggers();
 
-    let git_hash = metadata_value("SAGASCRIPT_GIT_HASH", || {
-        command_output(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
-    });
+    let git_hash = metadata_value("SAGASCRIPT_GIT_HASH", local_git_hash);
     let build_date = metadata_value("SAGASCRIPT_BUILD_DATE", || {
         chrono::Utc::now().format("%Y-%m-%d").to_string()
     });

--- a/src-tauri/crates/sagascript-cli/build.rs
+++ b/src-tauri/crates/sagascript-cli/build.rs
@@ -14,9 +14,36 @@ fn metadata_value(key: &str, fallback: impl FnOnce() -> String) -> String {
     std::env::var(key).ok().unwrap_or_else(fallback)
 }
 
+fn local_git_hash() -> String {
+    let hash =
+        command_output(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let dirty = command_output(&["status", "--porcelain=v1", "--untracked-files=all"])
+        .is_some_and(|status| !status.is_empty());
+    if dirty {
+        format!("{hash}-dirty")
+    } else {
+        hash
+    }
+}
+
+fn emit_source_rerun_triggers() {
+    // Watch CLI and core source without watching the package root, which can
+    // include target/ and cause the build script to rebuild itself forever.
+    for path in [
+        "src",
+        "../sagascript-core/src",
+        "../sagascript-core/Cargo.toml",
+        "../../Cargo.lock",
+        "Cargo.toml",
+    ] {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
 fn emit_git_rerun_triggers() {
     if let Some(git_dir) = command_output(&["rev-parse", "--absolute-git-dir"]) {
         println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        println!("cargo:rerun-if-changed={git_dir}/index");
         if let Some(reference) = command_output(&["symbolic-ref", "-q", "HEAD"]) {
             if let Some(reference_path) =
                 command_output(&["rev-parse", "--git-path", reference.as_str()])
@@ -34,10 +61,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SAGASCRIPT_GIT_HASH");
     println!("cargo:rerun-if-env-changed=SAGASCRIPT_BUILD_DATE");
     emit_git_rerun_triggers();
+    emit_source_rerun_triggers();
 
-    let git_hash = metadata_value("SAGASCRIPT_GIT_HASH", || {
-        command_output(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
-    });
+    let git_hash = metadata_value("SAGASCRIPT_GIT_HASH", local_git_hash);
     let build_date = metadata_value("SAGASCRIPT_BUILD_DATE", || {
         // Keep local builds reproducible enough to identify without adding a
         // chrono build dependency to the CLI crate. Release CI always supplies

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -9,7 +10,7 @@ use sagascript_core::audio::AudioCaptureService;
 use sagascript_core::audio::resample::TARGET_SAMPLE_RATE;
 use sagascript_core::error::DictationError;
 use sagascript_core::transcription::model;
-use sagascript_core::transcription::{Glossary, WhisperBackend};
+use sagascript_core::transcription::{Glossary, TranscribeOptions, WhisperBackend};
 
 use super::transcribe::{
     copy_to_clipboard, model_id_string, parse_language, resolve_effective_model, resolve_profile,
@@ -162,6 +163,10 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     let glossary = Glossary::parse(effective_prompt.as_deref().unwrap_or_default());
     let decoder_prompt = glossary.decoder_prompt();
     let prompt = decoder_prompt.as_deref();
+    let opts = TranscribeOptions {
+        prompt: prompt.map(str::to_string),
+        ..TranscribeOptions::default()
+    };
     let text = if duration > 10.0 {
         let pb = ProgressBar::new(100);
         pb.set_style(
@@ -169,10 +174,10 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
                 .unwrap(),
         );
         let pb_cb = pb.clone();
-        let text = backend.transcribe_sync_with_progress_and_prompt(
+        let text = backend.transcribe_live_sync_with_options(
             &audio,
             language,
-            prompt,
+            &opts,
             move |pct| {
                 crate::set_transcription_progress(&pb_cb, pct);
             },
@@ -181,10 +186,11 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         text
     } else {
         eprintln!("Transcribing...");
-        backend.transcribe_sync_with_progress_and_prompt(&audio, language, prompt, |_| {})?
+        backend.transcribe_live_sync_with_options(&audio, language, &opts, |_| {})?
     };
 
     let (text, vocabulary_corrections) = glossary.correct_text(&text);
+    let has_text = !text.trim().is_empty();
 
     // Output
     if args.json {
@@ -197,10 +203,13 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         });
         println!("{}", serde_json::to_string_pretty(&json).unwrap());
     } else {
-        println!("{text}");
+        let mut stdout = io::stdout().lock();
+        write_plain_record_output(&mut stdout, &text).map_err(|error| {
+            DictationError::TranscriptionFailed(format!("Failed to write output: {error}"))
+        })?;
     }
 
-    if args.clipboard {
+    if args.clipboard && has_text {
         copy_to_clipboard(&text)?;
         eprintln!("Copied to clipboard.");
     }
@@ -208,8 +217,38 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     Ok(())
 }
 
+fn write_plain_record_output(writer: &mut impl Write, text: &str) -> io::Result<bool> {
+    if text.trim().is_empty() {
+        return Ok(false);
+    }
+
+    writeln!(writer, "{text}")?;
+    Ok(true)
+}
+
 fn ctrlc_handler(running: Arc<AtomicBool>) {
     let _ = ctrlc::set_handler(move || {
         running.store(false, Ordering::Relaxed);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_plain_record_output;
+
+    #[test]
+    fn empty_plain_record_output_emits_nothing() {
+        for text in ["", " \n\t"] {
+            let mut output = Vec::new();
+            assert!(!write_plain_record_output(&mut output, text).unwrap());
+            assert!(output.is_empty());
+        }
+    }
+
+    #[test]
+    fn nonempty_plain_record_output_keeps_text_and_newline() {
+        let mut output = Vec::new();
+        assert!(write_plain_record_output(&mut output, "hello").unwrap());
+        assert_eq!(output, b"hello\n");
+    }
 }

--- a/src-tauri/crates/sagascript-core/src/audio/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/audio/mod.rs
@@ -4,7 +4,10 @@
 pub mod capture;
 pub mod decoder;
 pub mod resample;
+pub mod speech;
 pub mod wav;
+
+pub use speech::has_audio_signal;
 
 #[cfg(feature = "record")]
 pub use capture::AudioCaptureService;

--- a/src-tauri/crates/sagascript-core/src/audio/speech.rs
+++ b/src-tauri/crates/sagascript-core/src/audio/speech.rs
@@ -1,0 +1,195 @@
+//! Small, model-free signal-presence checks for decoded 16 kHz mono audio.
+
+const FRAME_SAMPLES: usize = 320; // 20 ms at 16 kHz
+const MIN_FRAME_RMS: f64 = 0.0015;
+
+/// Return whether any 20 ms frame has enough signal energy to transcribe.
+///
+/// Input is expected to be mono PCM at 16 kHz, matching the core decoder and
+/// capture paths. The input is never modified. A final partial frame is
+/// normalized by its actual length rather than by a zero-padded frame size.
+pub fn has_audio_signal(audio: &[f32]) -> Result<bool, &'static str> {
+    if audio.is_empty() {
+        return Ok(false);
+    }
+    if audio.iter().any(|sample| !sample.is_finite()) {
+        return Err("audio contains non-finite samples");
+    }
+
+    for frame in audio.chunks(FRAME_SAMPLES) {
+        let sum_squared = frame
+            .iter()
+            .map(|&sample| {
+                let sample = f64::from(sample);
+                sample * sample
+            })
+            .sum::<f64>();
+        let rms = (sum_squared / frame.len() as f64).sqrt();
+        if rms >= MIN_FRAME_RMS {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_audio_signal;
+    use crate::audio::decoder::decode_audio_file;
+    use std::path::PathBuf;
+
+    const ZERO_LENGTHS: &[usize] = &[1, 159, 160, 319, 320, 321, 4_000, 8_000, 16_000];
+    const NOISE_LENGTHS: &[usize] = &[4_000, 8_000]; // 0.25 s and 0.5 s
+
+    #[test]
+    fn silence_is_not_speech_for_supported_frame_boundaries() {
+        for &length in ZERO_LENGTHS {
+            let audio = vec![0.0; length];
+            assert_eq!(has_audio_signal(&audio), Ok(false), "length={length}");
+        }
+    }
+
+    #[test]
+    fn empty_audio_is_not_speech() {
+        assert_eq!(has_audio_signal(&[]), Ok(false));
+    }
+
+    #[test]
+    fn non_finite_samples_are_rejected_even_at_the_tail() {
+        for invalid in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            for length in [1, 159, 320, 321, 4_000] {
+                let mut audio = vec![0.0; length];
+                audio[length - 1] = invalid;
+                assert_eq!(
+                    has_audio_signal(&audio),
+                    Err("audio contains non-finite samples"),
+                    "invalid={invalid:?}, length={length}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn detector_does_not_modify_input() {
+        let audio = (0..321)
+            .map(|index| (index as f32 / 321.0 * 2.0) - 1.0)
+            .collect::<Vec<_>>();
+        let original = audio.clone();
+
+        let _ = has_audio_signal(&audio);
+
+        assert_eq!(audio, original);
+    }
+
+    #[test]
+    fn deterministic_noise_below_floor_is_rejected() {
+        for &length in NOISE_LENGTHS {
+            for &target_rms in &[0.0001, 0.001] {
+                let audio = seeded_uniform_noise(length, target_rms);
+                assert_eq!(
+                    has_audio_signal(&audio),
+                    Ok(false),
+                    "length={length}, rms={target_rms}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn deterministic_noise_at_or_above_floor_is_signal() {
+        for &length in NOISE_LENGTHS {
+            for &target_rms in &[0.003, 0.01] {
+                let audio = seeded_uniform_noise(length, target_rms);
+                assert_eq!(
+                    has_audio_signal(&audio),
+                    Ok(true),
+                    "length={length}, rms={target_rms}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn partial_frame_rms_uses_actual_sample_count() {
+        assert_eq!(has_audio_signal(&[0.002]), Ok(true));
+    }
+
+    #[test]
+    fn norwegian_fixture_is_detected_at_original_and_attenuated_volume() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../test-audio/norwegian-short-3s.mp3");
+        let audio = decode_audio_file(&path).expect("tracked Norwegian fixture should decode");
+        assert!(!audio.is_empty());
+        assert!(has_audio_signal(&audio).expect("original fixture should be valid"));
+
+        let attenuated = audio.iter().map(|sample| sample * 0.1).collect::<Vec<_>>();
+        assert!(has_audio_signal(&attenuated).expect("attenuated fixture should be valid"));
+    }
+
+    #[test]
+    fn max_energy_short_speech_crops_pass_at_both_volumes() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../test-audio/norwegian-short-3s.mp3");
+        let audio = decode_audio_file(&path).expect("tracked Norwegian fixture should decode");
+
+        for duration_ms in [100, 200, 300] {
+            let samples = duration_ms * 16;
+            let original_crop = padded_max_energy_crop(&audio, samples);
+            let attenuated_crop = original_crop
+                .iter()
+                .map(|sample| sample * 0.1)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                has_audio_signal(&original_crop),
+                Ok(true),
+                "{duration_ms} ms original crop rejected"
+            );
+            assert_eq!(
+                has_audio_signal(&attenuated_crop),
+                Ok(true),
+                "{duration_ms} ms attenuated crop rejected"
+            );
+        }
+    }
+
+    fn seeded_uniform_noise(length: usize, target_rms: f32) -> Vec<f32> {
+        let mut state = 0x4d595df4d0f33173_u64;
+        let mut noise = Vec::with_capacity(length);
+        for _ in 0..length {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let unit = (state >> 11) as f32 / ((1_u64 << 53) as f32);
+            noise.push(unit * 2.0 - 1.0);
+        }
+        let rms =
+            (noise.iter().map(|sample| sample * sample).sum::<f32>() / noise.len() as f32).sqrt();
+        let scale = target_rms / rms;
+        noise.into_iter().map(|sample| sample * scale).collect()
+    }
+
+    fn padded_max_energy_crop(audio: &[f32], samples: usize) -> Vec<f32> {
+        assert!(samples <= audio.len());
+
+        let mut energy = audio[..samples]
+            .iter()
+            .map(|sample| sample * sample)
+            .sum::<f32>();
+        let mut best_energy = energy;
+        let mut best_start = 0;
+        for start in 1..=audio.len() - samples {
+            energy += audio[start + samples - 1] * audio[start + samples - 1]
+                - audio[start - 1] * audio[start - 1];
+            if energy > best_energy {
+                best_energy = energy;
+                best_start = start;
+            }
+        }
+
+        let mut padded = vec![0.0; 3_200]; // 200 ms of leading context
+        padded.extend_from_slice(&audio[best_start..best_start + samples]);
+        padded.resize(padded.len() + 3_200, 0.0); // 200 ms of trailing context
+        padded
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/transcription/postprocess.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/postprocess.rs
@@ -13,10 +13,12 @@ struct Token<'a> {
 /// Bare labels are only treated as annotations when Whisper repeats them at
 /// least three times in a row; this preserves genuine phrases such as
 /// "jag gillar musik" and even a spoken double repetition.
+/// Exact `[BLANK_AUDIO]` artifacts are removed from the display text.
 pub fn normalize_nonspeech_markers(text: &str, language: Language) -> String {
-    let tokens = token_spans(text);
+    let text = remove_blank_audio_markers(text);
+    let tokens = token_spans(&text);
     if tokens.is_empty() {
-        return text.to_string();
+        return text;
     }
 
     let marker = music_marker(language);
@@ -49,10 +51,58 @@ pub fn normalize_nonspeech_markers(text: &str, language: Language) -> String {
     }
 
     if cursor == 0 {
-        return text.to_string();
+        return text;
     }
     rendered.push_str(&text[cursor..]);
     rendered
+}
+
+const BLANK_AUDIO_MARKER: &str = "[BLANK_AUDIO]";
+
+fn remove_blank_audio_markers(text: &str) -> String {
+    if !text.contains(BLANK_AUDIO_MARKER) {
+        return text.to_string();
+    }
+
+    let mut rendered = String::with_capacity(text.len());
+    for (index, part) in text.split(BLANK_AUDIO_MARKER).enumerate() {
+        if index == 0 {
+            rendered.push_str(part);
+            continue;
+        }
+        // Only normalize the boundary left by a removed marker. Paragraphs
+        // and intentional spacing elsewhere must remain untouched.
+        let left_trimmed_len = rendered.trim_end().len();
+        let right_trimmed = part.trim_start();
+        let boundary = format!(
+            "{}{}",
+            &rendered[left_trimmed_len..],
+            &part[..part.len() - right_trimmed.len()]
+        );
+        rendered.truncate(left_trimmed_len);
+        let part = right_trimmed;
+        if !rendered.is_empty() && !part.is_empty() {
+            if boundary.contains('\n') {
+                rendered.push_str(if boundary.matches('\n').count() > 1 {
+                    "\n\n"
+                } else {
+                    "\n"
+                });
+            } else if !part.starts_with(['.', ',', '!', '?', ';', ':']) {
+                rendered.push(' ');
+            }
+        }
+        rendered.push_str(part);
+    }
+
+    if rendered
+        .chars()
+        .all(|character| !character.is_alphanumeric())
+    {
+        String::new()
+    } else {
+        rendered
+    }
 }
 
 fn token_spans(text: &str) -> Vec<Token<'_>> {
@@ -180,6 +230,85 @@ mod tests {
         assert_eq!(
             normalize_nonspeech_markers(transcript, Language::Swedish),
             transcript
+        );
+    }
+
+    #[test]
+    fn removes_repeated_blank_audio_markers_from_display() {
+        for language in [Language::Swedish, Language::English] {
+            assert_eq!(
+                normalize_nonspeech_markers("[BLANK_AUDIO] [BLANK_AUDIO] [BLANK_AUDIO]", language,),
+                ""
+            );
+        }
+    }
+
+    #[test]
+    fn removes_blank_audio_between_real_words() {
+        assert_eq!(
+            normalize_nonspeech_markers("One.\n\n[BLANK_AUDIO]\n\nTwo.", Language::English),
+            "One.\n\nTwo."
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("First.\n\nHello [BLANK_AUDIO] world", Language::English),
+            "First.\n\nHello world"
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Hello [BLANK_AUDIO] world", Language::English),
+            "Hello world"
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Hello[BLANK_AUDIO]world", Language::English),
+            "Hello world"
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Hello  [BLANK_AUDIO]   world", Language::English),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn removes_adjacent_and_attached_blank_audio_artifacts() {
+        assert_eq!(
+            normalize_nonspeech_markers("[BLANK_AUDIO][BLANK_AUDIO]", Language::Swedish),
+            ""
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("[BLANK_AUDIO].", Language::Swedish),
+            ""
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Hello [BLANK_AUDIO].", Language::English),
+            "Hello."
+        );
+    }
+
+    #[test]
+    fn preserves_raw_segment_text_and_genuine_thanks() {
+        let raw_segment = crate::transcription::TranscriptSegment {
+            start: 0.0,
+            end: 1.0,
+            text: "Hello [BLANK_AUDIO] world".to_string(),
+            avg_logprob: None,
+            no_speech_prob: 0.0,
+        };
+        let raw_json = serde_json::to_value(&raw_segment).unwrap();
+        assert_eq!(
+            normalize_nonspeech_markers(&raw_segment.text, Language::English),
+            "Hello world"
+        );
+        assert_eq!(serde_json::to_value(&raw_segment).unwrap(), raw_json);
+        assert_eq!(
+            normalize_nonspeech_markers("Tack! Tack! Tack.", Language::Swedish),
+            "Tack! Tack! Tack."
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("[BLANK_AUDIO] Tack! Tack! Tack.", Language::Swedish),
+            "Tack! Tack! Tack."
+        );
+        assert_eq!(
+            normalize_nonspeech_markers("Thank you", Language::English),
+            "Thank you"
         );
     }
 }

--- a/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
+++ b/src-tauri/crates/sagascript-core/src/transcription/whisper_backend.rs
@@ -1117,6 +1117,27 @@ impl WhisperBackend {
         self.transcribe_sync_with_options(audio, language, &opts, on_progress)
     }
 
+    /// Live microphone transcription with a conservative near-silence guard.
+    /// File/diagnostic APIs and intentional silent model warmup remain ungated.
+    pub fn transcribe_live_sync_with_options(
+        &self,
+        audio: &[f32],
+        language: Language,
+        opts: &TranscribeOptions,
+        on_progress: impl FnMut(i32) + Send + 'static,
+    ) -> Result<String, DictationError> {
+        if audio.is_empty() {
+            return Err(DictationError::NoAudioCaptured);
+        }
+        let has_signal = crate::audio::speech::has_audio_signal(audio)
+            .map_err(|reason| DictationError::TranscriptionFailed(reason.to_string()))?;
+        if !has_signal {
+            info!("Skipping near-silent dictation: {} samples", audio.len());
+            return Ok(String::new());
+        }
+        self.transcribe_sync_with_options(audio, language, opts, on_progress)
+    }
+
     /// Core transcription entry point. Honors the opt-in [`TranscribeOptions`]
     /// (prompt, beam search, temperature fallback, VAD). Blocking — call from
     /// spawn_blocking.
@@ -2433,6 +2454,39 @@ mod progress_callback_tests {
 #[cfg(test)]
 mod segment_confidence_tests {
     use super::*;
+
+    #[test]
+    fn silent_audio_skips_decoder_without_a_loaded_model() {
+        let backend = WhisperBackend::new();
+        for language in [Language::Swedish, Language::English] {
+            for samples in [4052, 6400, 8000] {
+                let audio = vec![0.0; samples];
+                assert!(backend
+                    .transcribe_live_sync_with_options(
+                        &audio,
+                        language,
+                        &TranscribeOptions::default(),
+                        |_| {},
+                    )
+                    .unwrap()
+                    .is_empty());
+                assert!(matches!(
+                    backend.transcribe_sync_with_options_segments(
+                        &audio, language, &TranscribeOptions::default(), |_| {},
+                    ),
+                    Err(DictationError::ModelNotLoaded)
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn warmup_still_requires_a_model_and_does_not_skip_silent_inference() {
+        assert!(matches!(
+            WhisperBackend::new().warmup(Language::English),
+            Err(DictationError::ModelNotLoaded)
+        ));
+    }
 
     #[test]
     fn assembled_transcript_discards_no_speech_marked_hallucination() {

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -419,7 +419,11 @@ impl AppController {
     ) -> Result<String, String> {
         match result {
             Ok(text) => {
-                self.on_transcription_success(&text);
+                if text.trim().is_empty() {
+                    self.on_no_speech_detected();
+                } else {
+                    self.on_transcription_success(&text);
+                }
                 Ok(text)
             }
             Err(error) => {
@@ -625,6 +629,32 @@ mod tests {
 
         assert_eq!(result, Ok("Hello again".to_string()));
         assert_eq!(ctrl.last_transcription(), Some("Hello again"));
+        assert_eq!(ctrl.state(), AppState::Idle);
+    }
+
+    #[test]
+    fn finish_transcription_empty_result_preserves_last_transcription() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Transcribing;
+        ctrl.last_transcription = Some("Previous useful result".to_string());
+
+        let result = ctrl.finish_transcription(Ok(String::new()));
+
+        assert_eq!(result, Ok(String::new()));
+        assert_eq!(ctrl.last_transcription(), Some("Previous useful result"));
+        assert_eq!(ctrl.state(), AppState::Idle);
+    }
+
+    #[test]
+    fn finish_transcription_whitespace_result_preserves_last_transcription() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Transcribing;
+        ctrl.last_transcription = Some("Previous useful result".to_string());
+
+        let result = ctrl.finish_transcription(Ok(" \n\t".to_string()));
+
+        assert_eq!(result, Ok(" \n\t".to_string()));
+        assert_eq!(ctrl.last_transcription(), Some("Previous useful result"));
         assert_eq!(ctrl.state(), AppState::Idle);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -684,7 +684,7 @@ async fn stop_and_transcribe_impl(
         // exit after abort and log whether the lock was released.
         let whisper_ref = whisper.inner().clone();
         let mut fut = tokio::task::spawn_blocking(move || {
-            whisper_ref.transcribe_sync_with_options(&audio, language, &opts, |_| {})
+            whisper_ref.transcribe_live_sync_with_options(&audio, language, &opts, |_| {})
         });
 
         let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,6 +61,14 @@ use sagascript_core::transcription::{
 /// Minimum recording duration before we allow stop (300ms)
 const MIN_RECORDING_MS: u64 = 300;
 const SAFE_FALLBACK_HOTKEY: &str = "Control+Shift+Space";
+const BUILD_IDENTITY: &str = concat!(
+    "Version ",
+    env!("CARGO_PKG_VERSION"),
+    " · Build ",
+    env!("GIT_HASH"),
+    " · ",
+    env!("BUILD_DATE"),
+);
 #[cfg(target_os = "macos")]
 const TRAY_AUTOSAVE_NAME: &str = "ai.gille.sagascript.main";
 #[cfg(target_os = "macos")]
@@ -664,6 +672,8 @@ fn main() {
                 true,
                 None::<&str>,
             )?;
+            let build_info_item =
+                MenuItem::with_id(app, "build_info", BUILD_IDENTITY, false, None::<&str>)?;
 
             // Store status item so we can update it after transcription
             {
@@ -693,6 +703,7 @@ fn main() {
                     &profiles_menu,
                     &update_status,
                     &check_for_updates_item,
+                    &build_info_item,
                     &settings_item,
                     &transcribe_file_item,
                     &quit,
@@ -1513,7 +1524,7 @@ fn stop_recording_and_transcribe(
             let whisper_ref = whisper.inner().clone();
             let whisper_started_at = Instant::now();
             let mut fut = tokio::task::spawn_blocking(move || {
-                whisper_ref.transcribe_sync_with_options(&audio, language, &opts, |_| {})
+                whisper_ref.transcribe_live_sync_with_options(&audio, language, &opts, |_| {})
             });
 
             let timeout = Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS);
@@ -2324,6 +2335,13 @@ mod tests {
             stable_release_url(&semver::Version::new(1, 2, 0)),
             "https://github.com/Magnus-Gille/sagascript/releases/tag/v1.2.0"
         );
+    }
+
+    #[test]
+    fn build_identity_identifies_the_exact_app_build() {
+        assert!(BUILD_IDENTITY.contains(env!("CARGO_PKG_VERSION")));
+        assert!(BUILD_IDENTITY.contains(env!("GIT_HASH")));
+        assert!(BUILD_IDENTITY.contains(env!("BUILD_DATE")));
     }
 
     #[cfg(target_os = "macos")]

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -207,13 +207,19 @@
     (async () => {
       initError = "";
       try {
+        buildInfo = await getBuildInfo();
+      } catch (error) {
+        // Build identity is diagnostic only. Keep it independent from the
+        // settings bootstrap so it remains visible when another query fails.
+        console.warn("Failed to load build information", error);
+      }
+      try {
         settings = await getSettings();
         await refreshProfileModels(settings.hotkey_profiles);
         platform = await getPlatform();
         if (platform === "macos") {
           accessibilityGranted = await checkAccessibilityPermission();
         }
-        buildInfo = await getBuildInfo();
         models = await getModelInfo();
         supportedFormats = await getSupportedFormats();
         const status = await hotkeyStatus();
@@ -676,6 +682,17 @@
     </button>
   </div>
 
+  <header class="window-header">
+    <h1 class="window-title">Sagascript</h1>
+    <div class="build-info" aria-label="Build information">
+      {#if buildInfo}
+        Version {buildInfo.version} · Build {buildInfo.git_hash} · {buildInfo.build_date}
+      {:else}
+        Version information unavailable
+      {/if}
+    </div>
+  </header>
+
   {#if settings}
     <div class="content">
       {#if initError}
@@ -1023,14 +1040,6 @@
     </div>
   {/if}
 
-  <div class="build-footer" aria-label="Build information">
-    {#if buildInfo}
-      Version {buildInfo.version} · Build {buildInfo.git_hash} · {buildInfo.build_date}
-    {:else}
-      Version information unavailable
-    {/if}
-  </div>
-
   {#if downloading}
     <div class="download-status-bar">
       <div class="download-status-info">
@@ -1056,6 +1065,29 @@
     padding: 12px 20px 0;
     gap: 4px;
     border-bottom: 1px solid var(--border);
+  }
+
+  .window-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    padding: 16px 20px 12px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .window-title {
+    font-size: 18px;
+    line-height: 1.2;
+    color: var(--text);
+  }
+
+  .build-info {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
   }
 
   .tab {
@@ -1456,15 +1488,6 @@
     background: var(--accent);
     border-radius: 3px;
     transition: width 0.2s;
-  }
-
-  .build-footer {
-    padding: 8px 20px 10px;
-    border-top: 1px solid var(--border);
-    color: var(--text-muted);
-    font-size: 11px;
-    font-variant-numeric: tabular-nums;
-    flex-shrink: 0;
   }
 
   .initial-prompt-input {


### PR DESCRIPTION
## Summary

- Guard near-silent live dictation before decoding, shared by GUI and CLI record.
- Remove explicit `[BLANK_AUDIO]` display artifacts; retain genuine short speech and raw file/diagnostic behavior.
- Preserve the clipboard and last useful transcript on empty results.
- Show version/revision/date prominently in Settings and the tray; label modified local builds.

## Verification

- 662 Rust tests, workspace check and Clippy, lean CLI build passed.
- Frontend build/check, 49 frontend tests and 20 release-surface tests passed.
- Silence/noise and 100–300 ms speech regression tests at original and attenuated volume.
- Final immutable review by Claude Fable 5.1: APPROVE, no blocking findings.

## Acceptance limits

The conservative energy floor can still admit louder microphone noise. The reported Swedish silent-tap symptom needs physical headset/Mac microphone retesting. Native build-identity visual verification will be performed with the signed test build. No stable release is requested.
