### PR TITLE
fix: put Sagascript build header above navigation tabs

### DIFF
--- a/scripts/test-settings-layout.mjs
+++ b/scripts/test-settings-layout.mjs
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const content = readFileSync(new URL("../src/lib/Settings.svelte", import.meta.url), "utf8");
+
+test("Settings presents build identity above the ordered navigation tabs", () => {
+  const settingsWindow = '<div class="settings-window">';
+  const header = '<header class="window-header">';
+  const tabs = '<div class="tabs">';
+  assert.equal(content.split(header).length - 1, 1, "Exactly one build header");
+  assert.equal(content.split(tabs).length - 1, 1, "Exactly one tab bar");
+  const windowStart = content.indexOf(settingsWindow);
+  assert(windowStart >= 0, "Settings window exists");
+  const headerStart = content.indexOf(header, windowStart);
+  const tabsStart = content.indexOf(tabs, windowStart);
+  assert(headerStart >= 0 && tabsStart >= 0, "Header and tabs follow the window opening");
+  const headerEnd = content.indexOf("</header>", headerStart);
+  assert(headerEnd > headerStart && headerEnd < tabsStart, "Header must precede tabs");
+  const headerContent = content.slice(headerStart, headerEnd);
+  for (const field of ["version", "git_hash", "build_date"]) {
+    assert(headerContent.includes(`{buildInfo.${field}}`), `Header contains ${field}`);
+  }
+  const tabsEnd = content.indexOf("</div>", tabsStart);
+  assert(tabsEnd > tabsStart, "Tab bar closes");
+  const tabsContent = content.slice(tabsStart, tabsEnd);
+  const indices = ["Dictate", "Transcribe", "Settings"].map((label) => tabsContent.indexOf(label));
+  assert(indices.every((index) => index >= 0), "All tab labels remain");
+  assert(indices[0] < indices[1] && indices[1] < indices[2], "Tab order remains unchanged");
+});

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -670,6 +670,17 @@
 </script>
 
 <div class="settings-window">
+  <header class="window-header">
+    <h1 class="window-title">Sagascript</h1>
+    <div class="build-info" aria-label="Build information">
+      {#if buildInfo}
+        Version {buildInfo.version} · Build {buildInfo.git_hash} · {buildInfo.build_date}
+      {:else}
+        Version information unavailable
+      {/if}
+    </div>
+  </header>
+
   <div class="tabs">
     <button class="tab" class:active={activeTab === "dictate"} onclick={() => (activeTab = "dictate")}>
       Dictate
@@ -681,17 +692,6 @@
       Settings
     </button>
   </div>
-
-  <header class="window-header">
-    <h1 class="window-title">Sagascript</h1>
-    <div class="build-info" aria-label="Build information">
-      {#if buildInfo}
-        Version {buildInfo.version} · Build {buildInfo.git_hash} · {buildInfo.build_date}
-      {:else}
-        Version information unavailable
-      {/if}
-    </div>
-  </header>
 
   {#if settings}
     <div class="content">


### PR DESCRIPTION
## Summary

Move the existing Sagascript title/version/build header above the Dictate, Transcribe, and Settings tabs, as requested after testing PR192. No CSS, audio, or behavior changes.

## Verification

- Regression test failed on the old order and passes on the new order.
- Frontend check: zero errors/warnings; build passed; 50 frontend tests passed.
- Independent Fable5.1 review of immutable90300ac5a654b2011a82b9b935422e3c1b629124: APPROVE, no blockers.
- Native visual verification planned on the signed test installation.
