### PR TITLE
ci: cache native dependencies and measure R0 pipeline latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # cold multi-GB rebuild (plus minutes of save/restore) on any lockfile
       # change. rust-cache prunes before upload and stays warm across branches.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
           workspaces: src-tauri
           shared-key: sagascript-ci
@@ -230,7 +230,7 @@ jobs:
       # Same rust-cache scheme as the macOS job (#178); the shared key spans
       # branches while rust-cache keeps OS/target entries separate.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
           workspaces: src-tauri
           shared-key: sagascript-ci
@@ -317,7 +317,7 @@ jobs:
       # Same rust-cache scheme as the macOS job (#178); the shared key spans
       # branches while rust-cache keeps OS/target entries separate.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
           workspaces: src-tauri
           shared-key: sagascript-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # cold multi-GB rebuild (plus minutes of save/restore) on any lockfile
       # change. rust-cache prunes before upload and stays warm across branches.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
           shared-key: sagascript-ci
@@ -230,7 +230,7 @@ jobs:
       # Same rust-cache scheme as the macOS job (#178); the shared key spans
       # branches while rust-cache keeps OS/target entries separate.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
           shared-key: sagascript-ci
@@ -317,7 +317,7 @@ jobs:
       # Same rust-cache scheme as the macOS job (#178); the shared key spans
       # branches while rust-cache keeps OS/target entries separate.
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
           shared-key: sagascript-ci

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -38,16 +38,11 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Cache Cargo registry and target
-        uses: actions/cache@v5
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: macos-arm64-test-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            macos-arm64-test-cargo-
+          workspaces: src-tauri
+          shared-key: sagascript-test-macos-arm64
 
       - name: Install npm dependencies
         run: npm ci
@@ -90,9 +85,11 @@ jobs:
           api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
           printf '%s' "$APPLE_API_PRIVATE_KEY_BASE64" | base64 --decode > "$api_key_path"
           chmod 600 "$api_key_path"
-          echo "APPLE_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
-          echo "SAGASCRIPT_GIT_HASH=$(printf '%s' "$GITHUB_SHA" | cut -c1-7)" >> "$GITHUB_ENV"
-          echo "SAGASCRIPT_BUILD_DATE=$(date -u +%F)" >> "$GITHUB_ENV"
+          {
+            echo "APPLE_API_KEY_PATH=$api_key_path"
+            echo "SAGASCRIPT_GIT_HASH=$(printf '%s' "$GITHUB_SHA" | cut -c1-7)"
+            echo "SAGASCRIPT_BUILD_DATE=$(date -u +%F)"
+          } >> "$GITHUB_ENV"
 
       - name: Build, sign, notarize, and staple Apple Silicon app
         env:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -39,7 +39,7 @@ jobs:
           cache: npm
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
           shared-key: sagascript-test-macos-arm64

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-windows-candidate:
     name: Build Windows ${{ matrix.architecture }} candidate
@@ -74,21 +78,32 @@ jobs:
           "CMAKE_C_COMPILER_TARGET=aarch64-pc-windows-msvc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_CXX_COMPILER_TARGET=aarch64-pc-windows-msvc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Identify Windows runner image
+        id: windows-image
+        shell: pwsh
+        run: |
+          $imageOs = $env:ImageOS
+          $imageVersion = $env:ImageVersion
+          if ([string]::IsNullOrWhiteSpace($imageOs)) {
+            throw "ImageOS is unavailable; refusing to share native build cache"
+          }
+          if ([string]::IsNullOrWhiteSpace($imageVersion)) {
+            throw "ImageVersion is unavailable; refusing to share native build cache"
+          }
+          "image_os=$imageOs" >> $env:GITHUB_OUTPUT
+          "image_version=$imageVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          workspaces: src-tauri
+          shared-key: windows-package-${{ matrix.architecture }}-${{ steps.windows-image.outputs.image_os }}-${{ steps.windows-image.outputs.image_version }}-${{ hashFiles('.github/workflows/windows-package.yml') }}
+
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
-
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~\.cargo\registry
-            ~\.cargo\git
-          key: windows-package-${{ matrix.architecture }}-${{ hashFiles('src-tauri/Cargo.lock', 'package-lock.json', '.github/workflows/windows-package.yml') }}
-          restore-keys: |
-            windows-package-${{ matrix.architecture }}-
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -94,7 +94,7 @@ jobs:
           "image_version=$imageVersion" >> $env:GITHUB_OUTPUT
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
           shared-key: windows-package-${{ matrix.architecture }}-${{ steps.windows-image.outputs.image_os }}-${{ steps.windows-image.outputs.image_version }}-${{ hashFiles('.github/workflows/windows-package.yml') }}

--- a/docs/ci-performance-r0.md
+++ b/docs/ci-performance-r0.md
@@ -1,0 +1,130 @@
+# CI performance R0 baseline (#178)
+
+Measured 2026-09-05 from the read-only GitHub Actions job JSON for the
+successful runs below. Job elapsed time is `completedAt - startedAt` using the
+whole-second timestamps returned by GitHub. CI wall time is the earliest job
+`startedAt` to the latest job `completedAt`; it includes post-job cleanup that
+is represented in `completedAt`, and excludes queue time before the first job
+starts. No workflow was dispatched and no cache was cleared.
+
+## Current PR #197 observation
+
+The current CI and Windows candidate runs are on the exact revision
+`90300ac5a654b2011a82b9b935422e3c1b629124`.
+
+| Lane | Run/job | Elapsed | Critical path evidence |
+| --- | --- | ---: | --- |
+| PR CI wall | [33982933041](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933041) | 8m 12s | Linux 1m 26s, macOS 4m 18s, Windows 8m 12s |
+| PR CI — Windows | [job 101351279721](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933041/job/101351279721) | 8m 12s | native release 4m 16s; model-backed smokes 27s total |
+| PR CI — macOS | [job 101351279937](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933041/job/101351279937) | 4m 18s | native release 2m 00s; model-backed smokes 15s total |
+| PR CI — Linux | [job 101351280041](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933041/job/101351280041) | 1m 26s | compile/test/lint checks only |
+| Windows package — x64 | [job 101351279993](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933148/job/101351279993) | 20m 20s | Rust workspace 6m 30s; real-transcription gate 4m 08s; unsigned installers 8m 03s |
+| Windows package — arm64 | [job 101351280210](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933148/job/101351280210) | 17m 00s* | Rust workspace 5m 27s; real-transcription gate 2m 42s; unsigned installers 6m 39s |
+| Signed macOS test | [job 101354351246](https://github.com/Magnus-Gille/sagascript/actions/runs/33984088875/job/101354351246) | 4m 36s | sign/notarize/staple app 3m 19s |
+
+Run links: [Windows package 33982933148](https://github.com/Magnus-Gille/sagascript/actions/runs/33982933148),
+[signed test 33984088875](https://github.com/Magnus-Gille/sagascript/actions/runs/33984088875).
+
+The signed-test run is a separate exact revision,
+`62dadba7c3ba780867d8fede441990bb35abc407`, and is included as the available
+signing-lane baseline rather than as a same-SHA PR comparison.
+
+\* The supplied run summary called this 16m 59s. The API timestamps are
+`18:05:00Z` to `18:22:00Z`, i.e. 1,020 seconds (17m 00s); the one-second
+difference is retained here rather than silently inventing sub-second timing.
+
+The current Windows x64 package critical path is therefore installer creation
+(483s), followed by the Rust workspace gate (390s) and real-transcription gate
+(248s). The named steps total 1,121s; setup, frontend, and inter-step overhead
+account for the remaining 99s of the 1,220s job span.
+
+The timing reporter returns `wallSeconds=492` and `runnerSeconds=836` for the
+current CI run. The earlier 8m 15s figure used the top-level run start and
+therefore included three seconds before the first job; it is not the table's
+job-span metric.
+
+## Prior comparison observations
+
+These are directional comparisons, not a controlled A/B test: the runs have
+different head SHAs and may have different runner/cache state.
+
+| Lane | Exact revision | Run/job | Elapsed |
+| --- | --- | --- | ---: |
+| PR CI wall | `28e87c20fb2feeb39e1ce77f2ef7a6982b06d887` | [33980787222](https://github.com/Magnus-Gille/sagascript/actions/runs/33980787222) | 8m 22s |
+| Prior Windows package — x64 | `28e87c20fb2feeb39e1ce77f2ef7a6982b06d887` | [job 101345501742](https://github.com/Magnus-Gille/sagascript/actions/runs/33980787220/job/101345501742) | 22m 05s |
+| Prior Windows package — arm64 | `28e87c20fb2feeb39e1ce77f2ef7a6982b06d887` | [job 101345501654](https://github.com/Magnus-Gille/sagascript/actions/runs/33980787220/job/101345501654) | 18m 03s |
+| Prior signed macOS test | `2ce5e923dfd09fa01ae1fd66005fb22900e06b9a` | [job 101348797780](https://github.com/Magnus-Gille/sagascript/actions/runs/33982013412/job/101348797780) | 4m 44s |
+
+Supporting run links: [Windows package 33980787220](https://github.com/Magnus-Gille/sagascript/actions/runs/33980787220),
+[signed test 33982013412](https://github.com/Magnus-Gille/sagascript/actions/runs/33982013412).
+
+Against those observations, current x64 is 105s (7.9%) faster than prior x64,
+current arm64 is 63s (5.8%) faster than prior arm64, and the signed test is 8s
+(2.8%) faster overall. These changes are not attributable to caching without
+same-SHA, same-runner, cache-hit evidence. On the same reporter metric, CI wall
+time is 10s (2.0%) faster, with runner-seconds falling from 1,035 to 836
+(19.2%); these are also directional because the revisions differ.
+
+## Observed cache configuration and limits
+
+The job JSON exposes cache step names and durations, but not the cache-hit
+outputs. The following is the workflow configuration that produced each
+baseline run; it is distinct from the uncommitted workflow changes in the
+working tree:
+
+- The baseline CI run used floating `Swatinem/rust-cache@v2`, plus the macOS
+  model cache. Its actual hit/miss state is not represented in this JSON, so
+  the run is not a fully cold or fully warm measurement.
+- The baseline Windows package run used `actions/cache` for the Cargo registry
+  only. The native `target` directory was not cached by that workflow, so the
+  native target was uncached by design; registry hit/miss state remains
+  unknown. It must not be described as a fully cold run because a registry
+  cache could still have been restored.
+- The baseline signed macOS test used raw `actions/cache` over `src-tauri/target`
+  keyed by `Cargo.lock`. A target hit or miss is not represented in this JSON,
+  so its 4m 36s result is not a cold signing baseline.
+- No true fully-cold datapoint is available in the specified runs. The current
+  timings are “observed run; actual cache hit/miss unknown,” with the Windows
+  native-target scope known from the workflow configuration.
+
+The proposed workflow changes must record a first-miss run before a warm rerun
+on the same revision, preserving all required checks and recording the actual
+cache hit/miss result. Future timing reports can be reproduced with:
+
+```sh
+gh run view <RUN_ID> --repo Magnus-Gille/sagascript --json databaseId,headSha,jobs | node scripts/ci-run-timings.mjs
+```
+
+Stable-toolchain comparisons assume the runner labels and workflow toolchain
+inputs used here: `macos-14`, `windows-latest`, `windows-11-arm`,
+`dtolnay/rust-toolchain@stable`, and Node.js 20. The Rust-cache action revision
+must be recorded for each future run; the proposed pinned revision is not a
+property of these baseline measurements. Runner image/toolchain drift must be
+noted with the measurement.
+
+## R0 acceptance targets
+
+- Keep all current required CI, Windows x64/arm64 candidate, transcription
+  gate, and signed-test checks green.
+- Warm Windows x64 final package: target **≤12m 00s**. The fallback target of
+  at least 30% reduction from 20m 20s is **≤14m 14s** (`1,220 × 0.70 = 854s`).
+- Warm signed macOS test: target **≤6m 00s**, with no material regression from
+  the observed 4m 36s baseline.
+- Record the first cache miss before the warm rerun; report both cache states,
+  exact SHA, runner image, and run/job links.
+
+## Cache isolation decision
+
+The Windows native cache includes architecture, `ImageOS`, `ImageVersion`, and
+the workflow content hash in `shared-key`, not merely in a lockfile suffix.
+Missing image identity fails the job before restoration. This preserves the
+reason the old workflow disabled target caching: C/C++ toolchain changes must
+not reuse incompatible native outputs. The pinned action also hashes the Rust
+toolchain and C/C++ environment. Its only fallback retains the shared namespace
+and environment hash; see the reviewed [key construction](https://github.com/Swatinem/rust-cache/blob/6323deb102c322ba6fcbdcafc7e3dddab59af2b6/src/config.ts)
+and [restore implementation](https://github.com/Swatinem/rust-cache/blob/6323deb102c322ba6fcbdcafc7e3dddab59af2b6/src/restore.ts).
+
+No gate is removed. PR package runs share a PR-number concurrency group; manual
+runs use their unique run ID and do not cancel unrelated builds. The macOS test
+cache remains separate from Windows and the stable release lane, and only
+dependency artifacts are retained by the action's default policy.

--- a/docs/ci-performance-r0.md
+++ b/docs/ci-performance-r0.md
@@ -5,9 +5,14 @@ successful runs below. Job elapsed time is `completedAt - startedAt` using the
 whole-second timestamps returned by GitHub. CI wall time is the earliest job
 `startedAt` to the latest job `completedAt`; it includes post-job cleanup that
 is represented in `completedAt`, and excludes queue time before the first job
-starts. No workflow was dispatched and no cache was cleared.
+starts. The archival baseline collection itself dispatched no workflow and
+cleared no cache. Later R0 measurement runs are explicitly separated below;
+their cache saves and restores are part of those measurements.
 
-## Current PR #197 observation
+## Archival baseline observations: PR #197
+
+This is the pre-R0 archival baseline. Its timings and cache-state limits are
+not the same-SHA R0 results added later in this report.
 
 The current CI and Windows candidate runs are on the exact revision
 `90300ac5a654b2011a82b9b935422e3c1b629124`.
@@ -43,7 +48,7 @@ current CI run. The earlier 8m 15s figure used the top-level run start and
 therefore included three seconds before the first job; it is not the table's
 job-span metric.
 
-## Prior comparison observations
+## Archival prior comparison observations
 
 These are directional comparisons, not a controlled A/B test: the runs have
 different head SHAs and may have different runner/cache state.
@@ -65,7 +70,7 @@ same-SHA, same-runner, cache-hit evidence. On the same reporter metric, CI wall
 time is 10s (2.0%) faster, with runner-seconds falling from 1,035 to 836
 (19.2%); these are also directional because the revisions differ.
 
-## Observed cache configuration and limits
+## Archival baseline cache configuration and limits
 
 The job JSON exposes cache step names and durations, but not the cache-hit
 outputs. The following is the workflow configuration that produced each
@@ -98,8 +103,9 @@ The reviewed `rust-cache` action sets `CARGO_INCREMENTAL=0` in its source. That
 is an intentional cache/build tradeoff and must be recorded with timing data.
 Its dependency-focused workspace cache can still require workspace crates to
 rebuild, so a warm cache result is not a pure cache-hit speed measurement.
-The actual cache size and eviction behavior remain unmeasured here; this report
-does not assert a current service quota.
+For these archival baseline runs, actual cache archive sizes and eviction
+observations were not recorded. The R0 archive sizes measured below are not
+evidence of archival-baseline hit/miss state.
 
 The proposed workflow changes must record a first-miss run before a warm rerun
 on the same revision, preserving all required checks and recording the actual
@@ -119,6 +125,73 @@ inputs used here: `macos-14`, `windows-latest`, `windows-11-arm`,
 must be recorded for each future run; the proposed pinned revision is not a
 property of these baseline measurements. Runner image/toolchain drift must be
 noted with the measurement.
+
+## R0 measured results
+
+These are later same-head measurements, distinct from the archival baselines
+above. The required checks remained enabled; no gate was removed. A bounded
+cleanup removed only the two superseded pre-final Windows namespace entries
+(cache IDs `7367669305` and `7367635947`, `3,293,808,676` bytes total); the
+measured macOS and final-Windows namespaces were retained.
+
+### Signed macOS test: same-SHA first miss then warm
+
+Run [33986074362](https://github.com/Magnus-Gille/sagascript/actions/runs/33986074362)
+used exact SHA `16e216f9de38ba7d889c43cb1a909222290229b1` on
+`macos-14-arm64` image `20260831.0302.1`.
+
+| Attempt | Job | Cache state | Elapsed |
+| --- | --- | --- | ---: |
+| 1 | `101359680872` | first miss (`No cache found`) | 455s (7m 35s) |
+| 2 | `101361528405` | warm hit; `Cache up-to-date` | 241s (4m 01s) |
+
+Both attempts used the exact Rust-cache key
+`v0-rust-sagascript-test-macos-arm64-Darwin-arm64-2eab217e-3c0a7087` and the
+same runner image. Attempt 1 uploaded a compressed archive of `638,589,073`
+bytes (about 609 MiB); attempt 2 emitted no duplicate upload. Only the
+compressed upload size is reported here; no stored-size value was collected.
+
+The warm result is 214s (47.0%) below the same-SHA first miss. Compared with
+the archival raw-target-cache baseline [33984088875](https://github.com/Magnus-Gille/sagascript/actions/runs/33984088875)
+at 276s, it is 35s (12.7%) faster. The 276s comparison uses a different
+revision/workflow/cache strategy, so it is directional; the same-SHA 455s to
+241s comparison is the stronger cache measurement. **Mac acceptance gate:
+PASS** — 241s is below the 360s (6m) target and does not regress the 276s
+archival baseline.
+
+### Final Windows candidate gate
+
+Final-workflow run [33986720550](https://github.com/Magnus-Gille/sagascript/actions/runs/33986720550)
+used exact SHA `a7d595c3567a3b3743d270a8a22fd0b542b47ee4`. Both attempts
+completed successfully with the same runner images and final cache namespaces:
+
+| Attempt | x64 job / elapsed | ARM64 job / elapsed | Rust-cache state |
+| --- | --- | --- | --- |
+| 1 (first miss) | [101361540562](https://github.com/Magnus-Gille/sagascript/actions/runs/33986720550/job/101361540562) / 1,430s (23m 50s) | [101361540387](https://github.com/Magnus-Gille/sagascript/actions/runs/33986720550/job/101361540387) / 1,157s (19m 17s) | direct misses; both saved |
+| 2 (warm) | [101364930255](https://github.com/Magnus-Gille/sagascript/actions/runs/33986720550/job/101364930255) / 687s (11m 27s) | [101364930401](https://github.com/Magnus-Gille/sagascript/actions/runs/33986720550/job/101364930401) / 601s (10m 01s) | exact hits; restored; up-to-date |
+
+The x64 runner was `windows-2025-vs2026` / `20260824.214.3`, with exact key
+`v0-rust-windows-package-x64-win25-vs2026-20260824.214.3-5fafc8541ef3c9a4f1e599f1fae678867ad684dfe9c7659e1cb26c4b3587af11-Windows_NT-x64-2113753f-3c0a7087`.
+The ARM64 runner was `windows-11-arm64` / `20260830.155.1`, with exact key
+`v0-rust-windows-package-arm64-win11-arm64-20260830.155.1-5fafc8541ef3c9a4f1e599f1fae678867ad684dfe9c7659e1cb26c4b3587af11-Windows_NT-arm64-931dfa08-3c0a7087`.
+Both keys use workflow hash `5fafc8541ef3c9a4f1e599f1fae678867ad684dfe9c7659e1cb26c4b3587af11`.
+
+Attempt 1 saved compressed Rust-cache archives of `1,652,192,855` bytes (x64)
+and `1,641,248,114` bytes (ARM64). Attempt 2 restored exact full matches, then
+reported `Cache up-to-date` with no duplicate save; the collected cache API
+stored sizes match those upload byte counts. Both native architecture/image
+identity checks passed on both attempts; no required native check was removed.
+
+The warm reporter result was `wallSeconds=687` and `runnerSeconds=1288`.
+Against the archival x64 baseline of 1,220s (20m 20s), warm x64 improved by
+533s (43.7%) and is 11m 27s, below the 12m target. Against the same-SHA first
+miss of 1,430s, warm x64 improved by 743s (52.0%). The first miss was 210s
+(17.2%) slower than the archival baseline; that cold-run regression is retained
+here and not hidden by the warm result. **Windows acceptance gate: PASS.**
+
+The earlier first-miss run [33985466337](https://github.com/Magnus-Gille/sagascript/actions/runs/33985466337)
+used the pre-final `d97ef...` namespace and remains excluded from this final
+warm comparison.
 
 ## R0 acceptance targets
 

--- a/docs/ci-performance-r0.md
+++ b/docs/ci-performance-r0.md
@@ -87,6 +87,20 @@ working tree:
   timings are “observed run; actual cache hit/miss unknown,” with the Windows
   native-target scope known from the workflow configuration.
 
+GitHub Actions cache scope matters for the delivery plan: a cache written by a
+pull-request run cannot seed `main` or another pull request. A warm comparison
+must run the workflow again at the exact same head SHA after the first run has
+completed its post-job cache save; cancelling the first run before that save
+leaves the warm run cold. Cache keys are not a substitute for recording the
+actual hit/miss result.
+
+The reviewed `rust-cache` action sets `CARGO_INCREMENTAL=0` in its source. That
+is an intentional cache/build tradeoff and must be recorded with timing data.
+Its dependency-focused workspace cache can still require workspace crates to
+rebuild, so a warm cache result is not a pure cache-hit speed measurement.
+The actual cache size and eviction behavior remain unmeasured here; this report
+does not assert a current service quota.
+
 The proposed workflow changes must record a first-miss run before a warm rerun
 on the same revision, preserving all required checks and recording the actual
 cache hit/miss result. Future timing reports can be reproduced with:
@@ -94,6 +108,10 @@ cache hit/miss result. Future timing reports can be reproduced with:
 ```sh
 gh run view <RUN_ID> --repo Magnus-Gille/sagascript --json databaseId,headSha,jobs | node scripts/ci-run-timings.mjs
 ```
+
+The reporter returns null totals if any job has no complete timestamp pair,
+including jobs that never started. Known individual job durations are retained;
+a skipped or incomplete step does not erase a completed job's measured span.
 
 Stable-toolchain comparisons assume the runner labels and workflow toolchain
 inputs used here: `macos-14`, `windows-latest`, `windows-11-arm`,
@@ -128,3 +146,15 @@ No gate is removed. PR package runs share a PR-number concurrency group; manual
 runs use their unique run ID and do not cancel unrelated builds. The macOS test
 cache remains separate from Windows and the stable release lane, and only
 dependency artifacts are retained by the action's default policy.
+
+The first ARM64 and x64 runs passed the new runner-image identity step. Keep the
+missing-`ImageOS`/`ImageVersion` checks fail-closed; there is no skip or fallback
+path for an unknown native toolchain.
+
+## R0 cache seeding plan
+
+After the R0 workflow changes merge, dispatch the existing Windows candidate
+workflow on `main` once to seed the base cache before the next product PR, then
+verify that a later PR restores it. Do not add a `main` trigger or change
+workflow events for this bootstrap. Use the same `main` bootstrap approach for
+the signed macOS test lane: branch-scoped caches do not cross PR boundaries.

--- a/scripts/ci-run-timings.mjs
+++ b/scripts/ci-run-timings.mjs
@@ -1,0 +1,135 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+function requiredNumber(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a finite number`);
+  }
+  return value;
+}
+
+function optionalNumber(value, label) {
+  if (value === undefined || value === null || value === "") return null;
+  return requiredNumber(value, label);
+}
+
+function optionalString(value, label) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") throw new TypeError(`${label} must be a string or null`);
+  return value;
+}
+
+function timestamp(value, label) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") throw new TypeError(`${label} must be an ISO timestamp or null`);
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) throw new TypeError(`${label} is not a valid timestamp: ${value}`);
+  return milliseconds;
+}
+
+function interval(start, end, label) {
+  const startMilliseconds = timestamp(start, `${label}.startedAt`);
+  const endMilliseconds = timestamp(end, `${label}.completedAt`);
+  if (startMilliseconds === null || endMilliseconds === null) return null;
+  const seconds = (endMilliseconds - startMilliseconds) / 1000;
+  if (seconds < 0) throw new RangeError(`${label} has a negative interval`);
+  return seconds;
+}
+
+function summarizeStep(step, jobLabel) {
+  if (step === null || typeof step !== "object" || Array.isArray(step)) {
+    throw new TypeError(`${jobLabel}.steps entries must be objects`);
+  }
+  const number = requiredNumber(step.number, `${jobLabel}.steps[].number`);
+  return {
+    number,
+    name: optionalString(step.name, `${jobLabel}.steps[${number}].name`),
+    status: optionalString(step.status, `${jobLabel}.steps[${number}].status`),
+    conclusion: optionalString(step.conclusion, `${jobLabel}.steps[${number}].conclusion`),
+    durationSeconds: interval(step.startedAt, step.completedAt, `${jobLabel}.steps[${number}]`),
+  };
+}
+
+function summarizeJob(job) {
+  if (job === null || typeof job !== "object" || Array.isArray(job)) {
+    throw new TypeError("jobs entries must be objects");
+  }
+  const id = requiredNumber(job.databaseId, "job.databaseId");
+  if (!Array.isArray(job.steps)) throw new TypeError(`job ${id}.steps must be an array`);
+  const label = `job ${id}`;
+  const steps = job.steps.map((step) => summarizeStep(step, label));
+  const stepNumbers = new Set();
+  for (const step of steps) {
+    if (stepNumbers.has(step.number)) throw new Error(`${label} has duplicate step number ${step.number}`);
+    stepNumbers.add(step.number);
+  }
+  steps.sort((left, right) => left.number - right.number);
+  return {
+    id,
+    name: optionalString(job.name, `${label}.name`),
+    status: optionalString(job.status, `${label}.status`),
+    conclusion: optionalString(job.conclusion, `${label}.conclusion`),
+    durationSeconds: interval(job.startedAt, job.completedAt, label),
+    steps,
+    _startMilliseconds: timestamp(job.startedAt, `${label}.startedAt`),
+    _endMilliseconds: timestamp(job.completedAt, `${label}.completedAt`),
+  };
+}
+
+export function summarizeRun(run) {
+  if (run === null || typeof run !== "object" || Array.isArray(run)) {
+    throw new TypeError("run must be an object");
+  }
+  const id = optionalNumber(run.databaseId, "run.databaseId");
+  if (!Array.isArray(run.jobs)) throw new TypeError("run.jobs must be an array");
+  const jobs = run.jobs.map(summarizeJob);
+  const jobIds = new Set();
+  for (const job of jobs) {
+    if (jobIds.has(job.id)) throw new Error(`duplicate job databaseId ${job.id}`);
+    jobIds.add(job.id);
+  }
+  jobs.sort((left, right) => left.id - right.id);
+  const completeJobs = jobs.length > 0 && jobs.every((job) => job.durationSeconds !== null);
+  const wallSeconds = completeJobs
+    ? (Math.max(...jobs.map((job) => job._endMilliseconds)) -
+        Math.min(...jobs.map((job) => job._startMilliseconds))) /
+      1000
+    : null;
+  const runnerSeconds = completeJobs
+    ? jobs.reduce((total, job) => total + job.durationSeconds, 0)
+    : null;
+  return {
+    id,
+    headSha: optionalString(run.headSha, "run.headSha"),
+    wallSeconds,
+    runnerSeconds,
+    jobs: jobs.map(({ _startMilliseconds, _endMilliseconds, ...job }) => job),
+  };
+}
+
+function isDirectEntry() {
+  if (!process.argv[1]) return false;
+  const invoked = pathToFileURL(resolve(process.argv[1])).href;
+  const module = pathToFileURL(fileURLToPath(import.meta.url)).href;
+  return invoked === module;
+}
+
+function main() {
+  try {
+    const input = readFileSync(0, "utf8");
+    if (input.trim() === "") throw new Error("stdin JSON is empty");
+    let run;
+    try {
+      run = JSON.parse(input);
+    } catch (error) {
+      throw new Error(`stdin is not valid JSON: ${error.message}`);
+    }
+    process.stdout.write(`${JSON.stringify(summarizeRun(run), null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`ci-run-timings: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectEntry()) main();

--- a/scripts/test-ci-run-timings.mjs
+++ b/scripts/test-ci-run-timings.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { summarizeRun } from "./ci-run-timings.mjs";
+
+const cli = fileURLToPath(new URL("./ci-run-timings.mjs", import.meta.url));
+const time = (minutes, seconds) => `2026-09-05T00:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}Z`;
+
+function job(databaseId, startedAt, completedAt, steps = []) {
+  return { databaseId, name: `job-${databaseId}`, status: "completed", conclusion: "success", startedAt, completedAt, steps };
+}
+
+function deepFreeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+test("summarizes jobs and steps with numeric ordering", () => {
+  const result = summarizeRun({
+    databaseId: 8,
+    headSha: "abc1234",
+    jobs: [
+      job(10, time(0, 0), time(0, 3), [
+        { number: 10, name: "ten", startedAt: time(0, 2), completedAt: time(0, 3) },
+        { number: 2, name: "two", startedAt: time(0, 0), completedAt: time(0, 1) },
+      ]),
+      job(2, time(0, 1), time(0, 2)),
+    ],
+  });
+  assert.deepEqual(result.jobs.map(({ id }) => id), [2, 10]);
+  assert.deepEqual(result.jobs[1].steps.map(({ number }) => number), [2, 10]);
+  assert.equal(result.wallSeconds, 3);
+  assert.equal(result.runnerSeconds, 4);
+});
+
+test("does not mutate a nested unsorted input", () => {
+  const input = {
+    databaseId: 8,
+    jobs: [
+      job(10, time(0, 0), time(0, 3), [
+        { number: 10, name: "ten" },
+        { number: 2, name: "two" },
+      ]),
+      job(2, time(0, 1), time(0, 2)),
+    ],
+  };
+  const original = structuredClone(input);
+  summarizeRun(deepFreeze(input));
+  assert.deepEqual(input, original);
+});
+
+test("uses the parallel wall span and summed runner time", () => {
+  const result = summarizeRun({
+    databaseId: 1,
+    jobs: [job(1, time(0, 0), time(10, 0)), job(2, time(2, 0), time(5, 0))],
+  });
+  assert.equal(result.wallSeconds, 600);
+  assert.equal(result.runnerSeconds, 780);
+});
+
+test("empty and incomplete jobs produce null totals without losing completed job data", () => {
+  assert.deepEqual(summarizeRun({ databaseId: 1, jobs: [] }).jobs, []);
+  const incomplete = summarizeRun({
+    databaseId: 1,
+    jobs: [job(1, time(0, 0), time(0, 3), [{ number: 1, name: "pending" }]), job(2, time(0, 0), null)],
+  });
+  assert.equal(incomplete.jobs[0].durationSeconds, 3);
+  assert.equal(incomplete.jobs[0].steps[0].durationSeconds, null);
+  assert.equal(incomplete.wallSeconds, null);
+  assert.equal(incomplete.runnerSeconds, null);
+});
+
+test("completed job totals survive incomplete or skipped steps", () => {
+  const result = summarizeRun({
+    databaseId: 1,
+    jobs: [job(1, time(0, 0), time(1, 0), [{ number: 1, name: "skipped", status: "completed", conclusion: "skipped" }])],
+  });
+  assert.equal(result.wallSeconds, 60);
+  assert.equal(result.runnerSeconds, 60);
+  assert.equal(result.jobs[0].steps[0].durationSeconds, null);
+});
+
+test("missing optional metadata becomes null", () => {
+  const result = summarizeRun({
+    databaseId: 1,
+    jobs: [{ databaseId: 2, steps: [{ number: 1 }] }],
+  });
+  assert.equal(result.headSha, null);
+  assert.equal(result.jobs[0].name, null);
+  assert.equal(result.jobs[0].status, null);
+  assert.equal(result.jobs[0].conclusion, null);
+  assert.equal(result.jobs[0].durationSeconds, null);
+});
+
+test("rejects invalid dates, negative intervals, duplicate IDs, and invalid shapes", () => {
+  assert.throws(() => summarizeRun({ databaseId: 1, jobs: [{ databaseId: 2, steps: [], startedAt: "nope" }] }), /startedAt is not a valid timestamp/);
+  assert.throws(() => summarizeRun({ databaseId: 1, jobs: [job(2, time(1, 0), time(0, 0))] }), /negative interval/);
+  assert.throws(() => summarizeRun({ databaseId: 1, jobs: [job(2, null, null), job(2, null, null)] }), /duplicate job databaseId/);
+  assert.throws(() => summarizeRun({ databaseId: 1, jobs: [{ databaseId: 2, steps: null }] }), /steps must be an array/);
+  assert.throws(() => summarizeRun({ databaseId: Infinity, jobs: [] }), /finite number/);
+});
+
+test("CLI prints formatted JSON for valid input", () => {
+  const run = { databaseId: 7, headSha: "deadbee", jobs: [job(2, time(0, 0), time(0, 1))] };
+  const result = spawnSync(process.execPath, [cli], { input: JSON.stringify(run), encoding: "utf8" });
+  assert.equal(result.status, 0);
+  assert.equal(JSON.parse(result.stdout).id, 7);
+  assert.match(result.stdout, /\n  "headSha":/);
+  assert.equal(result.stderr, "");
+});
+
+test("CLI reports malformed, invalid, and empty input on stderr without creating output files", () => {
+  for (const input of ["{bad", "{\"databaseId\":1,\"jobs\":null}", ""]) {
+    const result = spawnSync(process.execPath, [cli], { input, encoding: "utf8" });
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /ci-run-timings:/);
+    if (input === "{bad") assert.match(result.stderr, /valid JSON/);
+  }
+});

--- a/scripts/test-pipeline-cache.mjs
+++ b/scripts/test-pipeline-cache.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const rustCacheRef =
+  "Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6";
+
+const [ciWorkflow, testBuildWorkflow, windowsWorkflow] = await Promise.all([
+  readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
+  readFile(new URL("../.github/workflows/test-build.yml", import.meta.url), "utf8"),
+  readFile(new URL("../.github/workflows/windows-package.yml", import.meta.url), "utf8"),
+]);
+
+function section(content, startMarker, endMarker) {
+  const start = content.indexOf(startMarker);
+  const end = content.indexOf(endMarker, start + startMarker.length);
+  assert.ok(start >= 0 && end > start, `section exists: ${startMarker}`);
+  return content.slice(start, end);
+}
+
+test("CI rust caches use the reviewed immutable action revision", () => {
+  const refs = ciWorkflow.match(/uses: Swatinem\/rust-cache@[^\s]+/g) ?? [];
+  assert.equal(refs.length, 3);
+  assert.deepEqual(refs, [`uses: ${rustCacheRef}`, `uses: ${rustCacheRef}`, `uses: ${rustCacheRef}`]);
+});
+
+test("signed test builds use the shared dependency cache without raw target dumps", () => {
+  const cache = section(testBuildWorkflow, "name: Cache Rust dependencies", "name: Install npm dependencies");
+  assert.match(cache, new RegExp(`uses: ${rustCacheRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(cache, /workspaces:\s+src-tauri/);
+  assert.match(cache, /shared-key:\s+sagascript-test-macos-arm64/);
+  assert.doesNotMatch(cache, /actions\/cache|src-tauri\/target/);
+  assert.ok(
+    testBuildWorkflow.indexOf("name: Import Developer ID certificate") >
+      testBuildWorkflow.indexOf("name: Cache Rust dependencies"),
+    "signing must remain after the dependency cache",
+  );
+});
+
+test("Windows native cache is isolated by runner image and toolchain namespace", () => {
+  assert.match(
+    windowsWorkflow,
+    /concurrency:\s*\n\s*group:\s+\$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.run_id \}\}\s*\n\s*cancel-in-progress:\s+true/,
+  );
+
+  const imageStart = windowsWorkflow.indexOf("name: Identify Windows runner image");
+  const cacheStart = windowsWorkflow.indexOf("name: Cache Rust dependencies");
+  const nodeStart = windowsWorkflow.indexOf("name: Install Node.js");
+  const armSetupStart = windowsWorkflow.indexOf("name: Configure native ARM64 C and C++ toolchain");
+  assert.ok(imageStart > armSetupStart && cacheStart > imageStart);
+  assert.ok(nodeStart > cacheStart, "cache must stay before Node setup and after native toolchain setup");
+
+  const imageStep = section(windowsWorkflow, "name: Identify Windows runner image", "name: Cache Rust dependencies");
+  assert.match(imageStep, /\$env:ImageOS/);
+  assert.match(imageStep, /\$env:ImageVersion/);
+  assert.match(imageStep, /IsNullOrWhiteSpace\(\$imageOs\)/);
+  assert.match(imageStep, /IsNullOrWhiteSpace\(\$imageVersion\)/);
+  assert.match(imageStep, /GITHUB_OUTPUT/);
+
+  const cache = section(windowsWorkflow, "name: Cache Rust dependencies", "name: Install npm dependencies");
+  assert.match(cache, new RegExp(`uses: ${rustCacheRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(cache, /workspaces:\s+src-tauri/);
+  assert.match(
+    cache,
+    /shared-key:\s+windows-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ steps\.windows-image\.outputs\.image_os \}\}-\$\{\{ steps\.windows-image\.outputs\.image_version \}\}-\$\{\{ hashFiles\('\.github\/workflows\/windows-package\.yml'\) \}\}/,
+  );
+  assert.ok(
+    windowsWorkflow.indexOf("name: Remove cached installer bundles") > cacheStart,
+    "installer cleanup must remain after the native build gates",
+  );
+});

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -38,15 +38,32 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /CMAKE_CXX_COMPILER_TARGET=aarch64-pc-windows-msvc/);
   assert.match(
     workflow,
-    /hashFiles\('src-tauri\/Cargo\.lock', 'package-lock\.json', '\.github\/workflows\/windows-package\.yml'\)/,
+    /concurrency:\s*\n\s*group:\s+\$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.run_id \}\}\s*\n\s*cancel-in-progress:\s+true/,
   );
-  const cargoCacheStart = workflow.indexOf("name: Cache Cargo registry");
-  const cargoCacheEnd = workflow.indexOf("name: Install npm dependencies", cargoCacheStart);
-  assert.ok(cargoCacheStart >= 0 && cargoCacheEnd > cargoCacheStart);
+  assert.match(workflow, /name: Identify Windows runner image/);
+  assert.match(workflow, /\$env:ImageOS/);
+  assert.match(workflow, /\$env:ImageVersion/);
+  assert.match(workflow, /IsNullOrWhiteSpace\(\$imageOs\)/);
+  assert.match(workflow, /IsNullOrWhiteSpace\(\$imageVersion\)/);
+  assert.match(workflow, /GITHUB_OUTPUT/);
+  const imageStart = workflow.indexOf("name: Identify Windows runner image");
+  const cacheStart = workflow.indexOf("name: Cache Rust dependencies");
+  const nodeStart = workflow.indexOf("name: Install Node.js");
+  assert.ok(imageStart >= 0 && cacheStart > imageStart && nodeStart > cacheStart);
+  const rustCache = workflow.slice(cacheStart, nodeStart);
+  assert.match(
+    rustCache,
+    /uses: Swatinem\/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6/,
+  );
+  assert.match(rustCache, /workspaces:\s+src-tauri/);
+  assert.match(
+    rustCache,
+    /shared-key:\s+windows-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ steps\.windows-image\.outputs\.image_os \}\}-\$\{\{ steps\.windows-image\.outputs\.image_version \}\}-\$\{\{ hashFiles\('\.github\/workflows\/windows-package\.yml'\) \}\}/,
+  );
   assert.doesNotMatch(
-    workflow.slice(cargoCacheStart, cargoCacheEnd),
-    /src-tauri\\target/,
-    "native build output must not be restored across C/C++ toolchain changes",
+    rustCache,
+    /actions\/cache/,
+    "native cache must use the target-aware Rust cache namespace",
   );
   assert.match(workflow, /accept-windows-candidate\.ps1/);
   assert.match(workflow, /norwegian-short-3s\.mp3/);


### PR DESCRIPTION
## Summary

R0 stage of #178: reduce repeated native compilation without removing any required verification.

- Pin CI Rust caches to the immutable action revision already used by release builds.
- Replace the manual macOS Test Build raw target cache with dependency-aware Rust caching.
- Add native Windows dependency caching isolated by architecture, exact runner image, workflow configuration, and Rust/C/C++ environment; fail closed if image identity is absent.
- Cancel only superseded PR package runs; manual runs retain separate concurrency identities.
- Preserve all frontend/Rust tests, native architecture checks, real transcription, installer checks, signing/notarization, and artifact verification.
- Add a dependency-free timing reporter and baseline report for comparable first-miss/warm measurements.

## Verification

- Frontend/workflow regression suite: 62/62 passed.
- Independent timing-reporter contract tests: 5/5 passed.
- Svelte check: 0 errors/warnings; production frontend build passed.
- actionlint passed for all three changed workflows; untouched release.yml retains its pre-existing SC2129 advisory.
- git diff --check passed.
- Reporter exercised against real GitHub baseline JSON.
- Native-image PowerShell step: valid metadata emits exact outputs; empty/whitespace ImageOS or ImageVersion fails before output (5 cases passed).
- Independent review: Claude Fable 5.1 approved the implementation at `16e216f`; Claude Haiku 4.5 approved the pin-comment/cache-seeding follow-up at `a7d595c`; Claude Sonnet 5 approved the final measured-results documentation at `c0fac79` (the requested Haiku invocation routed the substantive review to Sonnet). No blocking findings.
- All three CI platforms passed at `a7d595c`; Windows candidate run `33986720550` passed both first-miss and warm attempts, preserving every native/transcription/installer gate.

## Measurement gate

Baseline Windows x64 package elapsed: 20m20s. Target: warm <=12m, or >=30% reduction (<=14m14s), with all existing checks preserved. Signed macOS test baseline: 4m36s; target warm <=6m without material regression. Historical cache-hit state is not inferred from duration alone.

Measured same-head comparisons:

| Lane | First miss | Warm | Historical baseline | Gate |
| --- | ---: | ---: | ---: | --- |
| Windows x64 | 23m50s | 11m27s | 20m20s | PASS: warm under 12m, 43.7% below baseline |
| Windows ARM64 | 19m17s | 10m01s | 17m00s | Green native candidate |
| Signed macOS | 7m35s | 4m01s | 4m36s | PASS: under 6m, 12.7% below baseline |

Windows: [run 33986720550](https://github.com/Magnus-Gille/sagascript/actions/runs/33986720550), attempts 1/2, exact `a7d595c3567a3b3743d270a8a22fd0b542b47ee4`. Mac: [run 33986074362](https://github.com/Magnus-Gille/sagascript/actions/runs/33986074362), attempts 1/2, exact `16e216f9de38ba7d889c43cb1a909222290229b1`. Cache/image evidence and caveats are in `docs/ci-performance-r0.md`. Cold Windows overhead is recorded, not hidden.

After merge, seed default-branch caches through the existing manual Windows and signed-test workflows on main, then verify later product PR restoration. PR-scoped caches cannot seed main or other PRs.

Archival-baseline comparisons are directional because revisions/cache strategies differ. The stronger controlled comparison is first miss versus warm at the same SHA and runner image.

## Boundaries

No application behavior, dependency version, branch protection, paid runner, signing identity, stable release, or production deployment changes. PR #185 has later Windows acceptance additions; the new cache block and those additions must both survive its later integration.

Refs #178. This is a measured pipeline stage, not a claim that every optional idea in the ticket has been implemented.
