### PR TITLE
feat(cli): report private live-dictation latency (#163)

### DIFF
--- a/docs/latency-measurement.md
+++ b/docs/latency-measurement.md
@@ -1,0 +1,82 @@
+# Live dictation latency measurement (#163)
+
+## Decision and boundaries
+
+Add an offline, CLI-first `sagascript latency-report --input <copied.jsonl>`
+reporter for the existing `dictation_phase_timings` events. It does not start
+the app, capture audio, load models, inspect the default log directory, change
+settings, or contact a remote service. Input must be selected explicitly.
+Keep private recordings, transcripts and real benchmark logs outside Git.
+
+The timer starts when the app enters its stop handler: push-to-talk key-up or
+the second toggle press. OS/input dispatch before that handler is not measured.
+The measured endpoint is **paste-call completion, not visibly rendered text**.
+Neither this report nor CLI transcription throughput proves physical-key-up-
+to-visible-text latency. Signed-app editor observation remains a separate gate.
+No decoder/model defaults change without measured accuracy evidence.
+
+The JSON report has schema version 1 and emits only fixed metric names,
+validated configuration identifiers, numeric aggregates and fixed labels.
+`reporterVersion` identifies the reporting executable, including its build ID.
+Legacy phase events do not identify the source app build, so `sourceBuild` is
+null: never mistake the reporter version for the measured app version. Keep
+datasets from different app builds separate and record the tested app's
+`sagascript --version` beside each private dataset before comparing releases.
+It never echoes raw rows, transcripts, paths, session IDs, device names,
+arbitrary metadata or invalid values in errors. Errors identify the line and
+field, not the rejected value. Unknown events are ignored after valid JSON
+parsing; malformed JSON or malformed relevant events fail the report.
+
+## Cohorts and statistics
+
+Never combine different model, language, warm state, beam size, temperature
+fallback, VAD setting, outcome or paste outcome. Normalize known producer
+display names to existing model IDs and language codes; reject unknown names.
+Missing configuration in early no-speech events remains null, not a default.
+
+Join capture and phase events only by the pair `(appSession, dictationSession)`.
+Those identifiers are internal correlation keys and never appear in output.
+Reject duplicate relevant events with the same pair; support either input
+order. A capture without a phase is counted, not invented as a zero-time
+dictation. A phase without a capture has unknown duration.
+
+Use captured audio duration, not recording wall time, for length cohorts:
+`short` is 0–5,000 ms inclusive, `medium` is over 5,000–15,000 ms inclusive,
+`long` is over 15,000 ms, and `unknown` lacks a paired capture. Keep these
+cohorts separate in every configuration group.
+
+For each phase report count, numeric count, null count, missing count, p50 and
+p95. Null/missing values never become zero. Use nearest-rank percentiles:
+sort ascending, rank = ceil(percentile × count / 100), with one-based ranks.
+Samples must be finite and non-negative. Output is deterministic across input
+ordering. Input is bounded to 32 MiB total and 1 MiB per line.
+
+## Explicit regression checks
+
+A caller may select `--budget-length short|medium|long` together with
+`--max-warm-p95-ms <threshold>` and optional `--min-samples <count>` (default
+20). No machine-specific latency threshold is invented as a product default.
+Both budget selectors are required together; counts must be positive and the
+threshold finite/non-negative.
+
+Only successful, warm, successfully auto-pasted samples of the selected length
+are eligible. Every eligible configuration group must have at least the
+requested numeric samples and p95 at or below the explicit threshold. No
+eligible groups or incomplete eligible metrics fails the check. Emit the JSON
+report even on a budget failure, then exit nonzero. Other cohorts are reported
+but are not claimed to meet that selected budget.
+
+## Remaining physical acceptance
+
+Collect separate controlled cold/warm sessions for short, medium and long
+utterances, using the same model and decoder settings. Compare a Bluetooth
+headset microphone with the built-in microphone without assuming causality.
+Measure visible editor arrival separately; do not label paste-call return as
+that endpoint. Record p50/p95 and sample counts, then choose explicit regression
+thresholds from a repeatable baseline.
+
+Concurrent independent processes can still compete for Metal resources; this
+report does not introduce cross-process inference priority or streaming.
+Avoid concurrent batch inference during a clean baseline, then measure that
+contention separately. Physical latency, fallback accuracy and model-choice
+acceptance remain pending until those controlled measurements exist.

--- a/docs/latency-measurement.md
+++ b/docs/latency-measurement.md
@@ -26,6 +26,12 @@ It never echoes raw rows, transcripts, paths, session IDs, device names,
 arbitrary metadata or invalid values in errors. Errors identify the line and
 field, not the rejected value. Unknown events are ignored after valid JSON
 parsing; malformed JSON or malformed relevant events fail the report.
+Every input line must contain a JSON record: blank or whitespace-only lines are
+malformed. Relevant `capture_stopped` and `dictation_phase_timings` records
+must contain both correlation identifiers, `appSession` and
+`dictationSession`; missing either identifier fails closed. An empty file is a
+valid empty report, but it cannot pass an explicit budget because it has no
+eligible samples.
 
 ## Cohorts and statistics
 
@@ -49,7 +55,8 @@ For each phase report count, numeric count, null count, missing count, p50 and
 p95. Null/missing values never become zero. Use nearest-rank percentiles:
 sort ascending, rank = ceil(percentile × count / 100), with one-based ranks.
 Samples must be finite and non-negative. Output is deterministic across input
-ordering. Input is bounded to 32 MiB total and 1 MiB per line.
+ordering. Input is bounded to 32 MiB total and 1 MiB of record content per
+line, after stripping its optional LF or CRLF line ending.
 
 ## Explicit regression checks
 
@@ -63,8 +70,14 @@ Only successful, warm, successfully auto-pasted samples of the selected length
 are eligible. Every eligible configuration group must have at least the
 requested numeric samples and p95 at or below the explicit threshold. No
 eligible groups or incomplete eligible metrics fails the check. Emit the JSON
-report even on a budget failure, then exit nonzero. Other cohorts are reported
-but are not claimed to meet that selected budget.
+report even on a budget failure, then exit nonzero. The budget object also
+reports `excludedWarmSuccessSamples`: the number of selected-length samples
+with a successful warm transcription but a non-success paste outcome. These
+samples are excluded from eligibility and do not prevent a pass when all
+eligible groups satisfy the requested budget. Other cohorts are reported but
+are not claimed to meet that selected budget. Invalid input or arguments exit
+nonzero without emitting JSON; a failed explicit budget is the exception and
+emits its JSON report before exiting nonzero.
 
 ## Remaining physical acceptance
 

--- a/src-tauri/crates/sagascript-cli/src/latency.rs
+++ b/src-tauri/crates/sagascript-cli/src/latency.rs
@@ -12,7 +12,6 @@ use sagascript_core::settings::{Language, WhisperModel};
 
 use crate::transcribe::model_id_string;
 
-#[path = "latency/percentile.rs"]
 mod percentile;
 
 use percentile::percentile_ms;
@@ -681,7 +680,7 @@ fn read_bounded_line<R: BufRead>(
         if line
             .len()
             .checked_add(take)
-            .is_none_or(|length| length > MAX_LINE_BYTES + 1)
+            .is_none_or(|length| length > MAX_LINE_BYTES + 2)
         {
             return Err(format!(
                 "line {line_number}: input line exceeds the 1 MiB limit"
@@ -704,7 +703,8 @@ fn read_bounded_line<R: BufRead>(
         if line.last() == Some(&b'\r') {
             line.pop();
         }
-    } else if line.len() > MAX_LINE_BYTES {
+    }
+    if line.len() > MAX_LINE_BYTES {
         return Err(format!(
             "line {line_number}: input line exceeds the 1 MiB limit"
         ));
@@ -737,6 +737,20 @@ fn budget_passes(
         }
     }
     eligible_groups > 0
+}
+
+fn excluded_warm_success_samples(report: &Report, length: LengthBucket) -> usize {
+    report
+        .groups
+        .iter()
+        .filter(|group| {
+            group.length_bucket == length
+                && group.outcome == "success"
+                && group.model_was_warm == Some(true)
+                && group.paste_outcome.as_deref() != Some("succeeded")
+        })
+        .map(|group| group.samples)
+        .sum()
 }
 
 pub fn run(args: LatencyReportArgs) -> Result<(), DictationError> {
@@ -777,6 +791,7 @@ pub fn run(args: LatencyReportArgs) -> Result<(), DictationError> {
             threshold,
             args.min_samples,
             budget_passes(&report, length, threshold, args.min_samples),
+            excluded_warm_success_samples(&report, length),
         )),
         (None, None) => None,
         _ => unreachable!("budget arguments validated above"),
@@ -785,12 +800,13 @@ pub fn run(args: LatencyReportArgs) -> Result<(), DictationError> {
     let mut output = serde_json::to_value(&report).map_err(|_| {
         DictationError::TranscriptionFailed("latency report serialization failed".to_string())
     })?;
-    if let Some((length, threshold, min_samples, passed)) = budget {
+    if let Some((length, threshold, min_samples, passed, excluded_samples)) = budget {
         output["budget"] = serde_json::json!({
             "lengthBucket": length,
             "maxWarmP95Ms": threshold,
             "minSamples": min_samples,
             "passed": passed,
+            "excludedWarmSuccessSamples": excluded_samples,
         });
     }
     let encoded = serde_json::to_string(&output).map_err(|_| {

--- a/src-tauri/crates/sagascript-cli/src/latency.rs
+++ b/src-tauri/crates/sagascript-cli/src/latency.rs
@@ -1,0 +1,954 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+
+use sagascript_core::error::DictationError;
+use sagascript_core::settings::{Language, WhisperModel};
+
+use crate::transcribe::model_id_string;
+
+#[path = "latency/percentile.rs"]
+mod percentile;
+
+use percentile::percentile_ms;
+
+const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_LINE_BYTES: usize = 1024 * 1024;
+const MAX_IDENTIFIER_BYTES: usize = 256;
+const METRIC_BOUNDARY: &str = "paste_call_completion_not_visible_text";
+
+const METRIC_FIELDS: [MetricField; 7] = [
+    MetricField::KeyUpToCaptureStopped,
+    MetricField::ModelLoad,
+    MetricField::KeyUpToModelReady,
+    MetricField::Whisper,
+    MetricField::KeyUpToWhisperComplete,
+    MetricField::KeyUpToPasteCompleted,
+    MetricField::Total,
+];
+
+const CONFIG_FIELDS: [&str; 6] = [
+    "model",
+    "language",
+    "modelWasWarm",
+    "beamSize",
+    "temperatureFallback",
+    "vadEnabled",
+];
+
+const PASTE_OUTCOMES: [&str; 6] = [
+    "disabled",
+    "dispatch_failed",
+    "succeeded",
+    "failed",
+    "completion_dropped",
+    "timed_out",
+];
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum LengthBucket {
+    Short,
+    Medium,
+    Long,
+    #[value(skip)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct Report {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u8,
+    #[serde(rename = "reporterVersion")]
+    pub reporter_version: &'static str,
+    #[serde(rename = "metricBoundary")]
+    pub metric_boundary: &'static str,
+    #[serde(rename = "sourceBuild")]
+    pub source_build: Option<&'static str>,
+    #[serde(rename = "inputRecords")]
+    pub input_records: usize,
+    #[serde(rename = "phaseRecords")]
+    pub phase_records: usize,
+    #[serde(rename = "captureWithoutPhases")]
+    pub capture_without_phases: usize,
+    pub groups: Vec<Group>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct Group {
+    pub model: Option<String>,
+    pub language: Option<String>,
+    #[serde(rename = "modelWasWarm")]
+    pub model_was_warm: Option<bool>,
+    #[serde(rename = "beamSize")]
+    pub beam_size: Option<u32>,
+    #[serde(rename = "temperatureFallback")]
+    pub temperature_fallback: Option<bool>,
+    #[serde(rename = "vadEnabled")]
+    pub vad_enabled: Option<bool>,
+    pub outcome: String,
+    #[serde(rename = "pasteOutcome")]
+    pub paste_outcome: Option<String>,
+    #[serde(rename = "lengthBucket")]
+    pub length_bucket: LengthBucket,
+    pub samples: usize,
+    pub phases: PhaseStatsSet,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Default)]
+pub struct PhaseStatsSet {
+    #[serde(rename = "keyUpToCaptureStoppedMs")]
+    pub key_up_to_capture_stopped_ms: MetricStats,
+    #[serde(rename = "modelLoadMs")]
+    pub model_load_ms: MetricStats,
+    #[serde(rename = "keyUpToModelReadyMs")]
+    pub key_up_to_model_ready_ms: MetricStats,
+    #[serde(rename = "whisperMs")]
+    pub whisper_ms: MetricStats,
+    #[serde(rename = "keyUpToWhisperCompleteMs")]
+    pub key_up_to_whisper_complete_ms: MetricStats,
+    #[serde(rename = "keyUpToPasteCompletedMs")]
+    pub key_up_to_paste_completed_ms: MetricStats,
+    #[serde(rename = "totalMs")]
+    pub total_ms: MetricStats,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Default)]
+pub struct MetricStats {
+    pub count: usize,
+    #[serde(rename = "numericCount")]
+    pub numeric_count: usize,
+    #[serde(rename = "nullCount")]
+    pub null_count: usize,
+    #[serde(rename = "missingCount")]
+    pub missing_count: usize,
+    #[serde(rename = "p50Ms")]
+    pub p50_ms: Option<f64>,
+    #[serde(rename = "p95Ms")]
+    pub p95_ms: Option<f64>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct GroupKey {
+    model: Option<String>,
+    language: Option<String>,
+    model_was_warm: Option<bool>,
+    beam_size: Option<u32>,
+    temperature_fallback: Option<bool>,
+    vad_enabled: Option<bool>,
+    outcome: String,
+    paste_outcome: Option<String>,
+    length_bucket: LengthBucket,
+}
+
+#[derive(Debug, Default)]
+struct GroupAccumulator {
+    samples: usize,
+    metrics: [MetricAccumulator; 7],
+}
+
+#[derive(Debug, Default)]
+struct MetricAccumulator {
+    count: usize,
+    numeric_count: usize,
+    null_count: usize,
+    missing_count: usize,
+    values: Vec<f64>,
+}
+
+#[derive(Debug, Clone)]
+struct CaptureRecord {
+    audio_duration_ms: f64,
+}
+
+#[derive(Debug, Clone)]
+struct PhaseRecord {
+    key: CorrelationKey,
+    config: PhaseConfig,
+    metrics: [MetricValue; 7],
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct CorrelationKey {
+    app_session: String,
+    dictation_session: String,
+}
+
+#[derive(Debug, Clone)]
+struct PhaseConfig {
+    model: Option<String>,
+    language: Option<String>,
+    model_was_warm: Option<bool>,
+    beam_size: Option<u32>,
+    temperature_fallback: Option<bool>,
+    vad_enabled: Option<bool>,
+    outcome: String,
+    paste_outcome: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum MetricValue {
+    Missing,
+    Null,
+    Numeric(f64),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MetricField {
+    KeyUpToCaptureStopped,
+    ModelLoad,
+    KeyUpToModelReady,
+    Whisper,
+    KeyUpToWhisperComplete,
+    KeyUpToPasteCompleted,
+    Total,
+}
+
+impl MetricField {
+    const fn key(self) -> &'static str {
+        match self {
+            Self::KeyUpToCaptureStopped => "keyUpToCaptureStoppedMs",
+            Self::ModelLoad => "modelLoadMs",
+            Self::KeyUpToModelReady => "keyUpToModelReadyMs",
+            Self::Whisper => "whisperMs",
+            Self::KeyUpToWhisperComplete => "keyUpToWhisperCompleteMs",
+            Self::KeyUpToPasteCompleted => "keyUpToPasteCompletedMs",
+            Self::Total => "totalMs",
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct LatencyReportArgs {
+    /// Explicit copied JSONL log; the live/default log path is never selected implicitly.
+    #[arg(long, value_name = "PATH")]
+    pub input: PathBuf,
+
+    /// Select the audio-length cohort for the explicit warm-paste budget check.
+    #[arg(long, value_enum, requires = "max_warm_p95_ms")]
+    pub budget_length: Option<LengthBucket>,
+
+    /// Maximum permitted warm paste-call p95 in milliseconds.
+    #[arg(long, value_name = "MS", requires = "budget_length")]
+    pub max_warm_p95_ms: Option<f64>,
+
+    /// Minimum numeric paste-call samples required per eligible group.
+    #[arg(long, default_value_t = 20, requires = "budget_length")]
+    pub min_samples: usize,
+}
+
+/// Summarize explicitly supplied JSONL without consulting app state, settings,
+/// models, the microphone, or a network service.
+pub fn summarize_reader<R: BufRead>(mut reader: R) -> Result<Report, String> {
+    let mut total_bytes = 0usize;
+    let mut line_number = 0usize;
+    let mut input_records = 0usize;
+    let mut captures = HashMap::<CorrelationKey, CaptureRecord>::new();
+    let mut phases = HashMap::<CorrelationKey, PhaseRecord>::new();
+
+    while let Some(line) = read_bounded_line(&mut reader, &mut total_bytes, line_number + 1)? {
+        line_number += 1;
+        let value: Value = serde_json::from_slice(&line).map_err(|error| {
+            format!(
+                "line {line_number}: invalid JSON ({:?} at JSON line {} column {})",
+                error.classify(),
+                error.line(),
+                error.column()
+            )
+        })?;
+        if !value.is_object() {
+            return Err(format!(
+                "line {line_number}: JSON record must be an object"
+            ));
+        }
+        input_records += 1;
+
+        let Some(event) = value.get("event").and_then(Value::as_str) else {
+            continue;
+        };
+        match event {
+            "capture_stopped" => {
+                let key = parse_correlation_key(&value, line_number)?;
+                let data = parse_data_object(&value, line_number)?;
+                let audio_duration_ms =
+                    parse_nonnegative_number(data, "audioDurationMs", line_number)?;
+                if captures
+                    .insert(key, CaptureRecord { audio_duration_ms })
+                    .is_some()
+                {
+                    return Err(format!(
+                        "line {line_number}: duplicate capture_stopped correlation"
+                    ));
+                }
+            }
+            "dictation_phase_timings" => {
+                let key = parse_correlation_key(&value, line_number)?;
+                let data = parse_data_object(&value, line_number)?;
+                let phase = parse_phase(data, key.clone(), line_number)?;
+                if phases.insert(key, phase).is_some() {
+                    return Err(format!(
+                        "line {line_number}: duplicate dictation_phase_timings correlation"
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let capture_without_phases = captures
+        .keys()
+        .filter(|key| !phases.contains_key(*key))
+        .count();
+    let mut groups = BTreeMap::<GroupKey, GroupAccumulator>::new();
+
+    for phase in phases.values() {
+        let length_bucket = captures
+            .get(&phase.key)
+            .map(|capture| length_bucket(capture.audio_duration_ms))
+            .unwrap_or(LengthBucket::Unknown);
+        let key = GroupKey {
+            model: phase.config.model.clone(),
+            language: phase.config.language.clone(),
+            model_was_warm: phase.config.model_was_warm,
+            beam_size: phase.config.beam_size,
+            temperature_fallback: phase.config.temperature_fallback,
+            vad_enabled: phase.config.vad_enabled,
+            outcome: phase.config.outcome.clone(),
+            paste_outcome: phase.config.paste_outcome.clone(),
+            length_bucket,
+        };
+        let accumulator = groups.entry(key).or_default();
+        accumulator.samples += 1;
+        for (index, value) in phase.metrics.iter().enumerate() {
+            accumulator.metrics[index].add(value);
+        }
+    }
+
+    let groups = groups
+        .into_iter()
+        .map(|(key, accumulator)| {
+            Ok(Group {
+                model: key.model,
+                language: key.language,
+                model_was_warm: key.model_was_warm,
+                beam_size: key.beam_size,
+                temperature_fallback: key.temperature_fallback,
+                vad_enabled: key.vad_enabled,
+                outcome: key.outcome,
+                paste_outcome: key.paste_outcome,
+                length_bucket: key.length_bucket,
+                samples: accumulator.samples,
+                phases: PhaseStatsSet::from_accumulators(accumulator.metrics)?,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    Ok(Report {
+        schema_version: 1,
+        reporter_version: crate::LONG_VERSION,
+        metric_boundary: METRIC_BOUNDARY,
+        source_build: None,
+        input_records,
+        phase_records: phases.len(),
+        capture_without_phases,
+        groups,
+    })
+}
+
+impl PhaseStatsSet {
+    fn from_accumulators(metrics: [MetricAccumulator; 7]) -> Result<Self, String> {
+        let mut metrics = metrics.into_iter();
+        Ok(Self {
+            key_up_to_capture_stopped_ms: metrics.next().expect("fixed metric count").finish()?,
+            model_load_ms: metrics.next().expect("fixed metric count").finish()?,
+            key_up_to_model_ready_ms: metrics.next().expect("fixed metric count").finish()?,
+            whisper_ms: metrics.next().expect("fixed metric count").finish()?,
+            key_up_to_whisper_complete_ms: metrics.next().expect("fixed metric count").finish()?,
+            key_up_to_paste_completed_ms: metrics.next().expect("fixed metric count").finish()?,
+            total_ms: metrics.next().expect("fixed metric count").finish()?,
+        })
+    }
+}
+
+impl MetricAccumulator {
+    fn add(&mut self, value: &MetricValue) {
+        self.count += 1;
+        match value {
+            MetricValue::Missing => self.missing_count += 1,
+            MetricValue::Null => self.null_count += 1,
+            MetricValue::Numeric(value) => {
+                self.numeric_count += 1;
+                self.values.push(*value);
+            }
+        }
+    }
+
+    fn finish(self) -> Result<MetricStats, String> {
+        let p50_ms = percentile_ms(&self.values, 50).map_err(|_| "invalid percentile input")?;
+        let p95_ms = percentile_ms(&self.values, 95).map_err(|_| "invalid percentile input")?;
+        Ok(MetricStats {
+            count: self.count,
+            numeric_count: self.numeric_count,
+            null_count: self.null_count,
+            missing_count: self.missing_count,
+            p50_ms,
+            p95_ms,
+        })
+    }
+}
+
+fn parse_phase(
+    data: &serde_json::Map<String, Value>,
+    key: CorrelationKey,
+    line: usize,
+) -> Result<PhaseRecord, String> {
+    let outcome = required_string(data, "outcome", line)?;
+    if !matches!(outcome.as_str(), "no_speech" | "success" | "error") {
+        return Err(format!(
+            "line {line}: field outcome has an unsupported value"
+        ));
+    }
+
+    let paste_outcome = optional_paste_outcome(data, line)?;
+    let has_config = CONFIG_FIELDS.iter().any(|field| data.contains_key(*field));
+    let config = if outcome == "no_speech" && !has_config {
+        if paste_outcome.is_some() {
+            return Err(format!(
+                "line {line}: field pasteOutcome is only valid for success"
+            ));
+        }
+        PhaseConfig {
+            model: None,
+            language: None,
+            model_was_warm: None,
+            beam_size: None,
+            temperature_fallback: None,
+            vad_enabled: None,
+            outcome: outcome.clone(),
+            paste_outcome: None,
+        }
+    } else {
+        let model = normalize_model(required_string(data, "model", line)?, line)?;
+        let language = normalize_language(required_string(data, "language", line)?, line)?;
+        let model_was_warm = required_bool(data, "modelWasWarm", line)?;
+        let beam_size = required_u32(data, "beamSize", line)?;
+        let temperature_fallback = required_bool(data, "temperatureFallback", line)?;
+        let vad_enabled = required_bool(data, "vadEnabled", line)?;
+        if outcome == "success" && paste_outcome.is_none() {
+            return Err(format!(
+                "line {line}: field pasteOutcome is required for success"
+            ));
+        }
+        if outcome != "success" && paste_outcome.is_some() {
+            return Err(format!(
+                "line {line}: field pasteOutcome is only valid for success"
+            ));
+        }
+        PhaseConfig {
+            model: Some(model),
+            language: Some(language),
+            model_was_warm: Some(model_was_warm),
+            beam_size: Some(beam_size),
+            temperature_fallback: Some(temperature_fallback),
+            vad_enabled: Some(vad_enabled),
+            outcome: outcome.clone(),
+            paste_outcome,
+        }
+    };
+
+    let metrics = METRIC_FIELDS.map(|field| parse_metric(data, field, line));
+    let mut parsed = [
+        MetricValue::Missing,
+        MetricValue::Missing,
+        MetricValue::Missing,
+        MetricValue::Missing,
+        MetricValue::Missing,
+        MetricValue::Missing,
+        MetricValue::Missing,
+    ];
+    for (target, result) in parsed.iter_mut().zip(metrics) {
+        *target = result?;
+    }
+
+    Ok(PhaseRecord {
+        key,
+        config,
+        metrics: parsed,
+    })
+}
+
+fn parse_metric(
+    data: &serde_json::Map<String, Value>,
+    field: MetricField,
+    line: usize,
+) -> Result<MetricValue, String> {
+    let Some(value) = data.get(field.key()) else {
+        return Ok(MetricValue::Missing);
+    };
+    if value.is_null() {
+        return Ok(MetricValue::Null);
+    }
+    Ok(MetricValue::Numeric(parse_nonnegative_number(
+        data,
+        field.key(),
+        line,
+    )?))
+}
+
+fn parse_correlation_key(value: &Value, line: usize) -> Result<CorrelationKey, String> {
+    Ok(CorrelationKey {
+        app_session: bounded_identifier(value, "appSession", line)?,
+        dictation_session: bounded_identifier(value, "dictationSession", line)?,
+    })
+}
+
+fn bounded_identifier(value: &Value, field: &str, line: usize) -> Result<String, String> {
+    let Some(value) = value.get(field).and_then(Value::as_str) else {
+        return Err(format!(
+            "line {line}: field {field} must be a non-empty bounded string"
+        ));
+    };
+    if value.trim().is_empty() || value.len() > MAX_IDENTIFIER_BYTES {
+        return Err(format!(
+            "line {line}: field {field} must be a non-empty bounded string"
+        ));
+    }
+    Ok(value.to_owned())
+}
+
+fn parse_data_object(
+    value: &Value,
+    line: usize,
+) -> Result<&serde_json::Map<String, Value>, String> {
+    value
+        .get("data")
+        .and_then(Value::as_object)
+        .ok_or_else(|| format!("line {line}: field data must be an object"))
+}
+
+fn required_string(
+    data: &serde_json::Map<String, Value>,
+    field: &str,
+    line: usize,
+) -> Result<String, String> {
+    data.get(field)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| format!("line {line}: field {field} must be a string"))
+}
+
+fn required_bool(
+    data: &serde_json::Map<String, Value>,
+    field: &str,
+    line: usize,
+) -> Result<bool, String> {
+    data.get(field)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| format!("line {line}: field {field} must be a boolean"))
+}
+
+fn required_u32(
+    data: &serde_json::Map<String, Value>,
+    field: &str,
+    line: usize,
+) -> Result<u32, String> {
+    data.get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| format!("line {line}: field {field} must be a non-negative integer"))
+}
+
+fn parse_nonnegative_number(
+    data: &serde_json::Map<String, Value>,
+    field: &str,
+    line: usize,
+) -> Result<f64, String> {
+    let Some(value) = data.get(field).and_then(Value::as_f64) else {
+        return Err(format!(
+            "line {line}: field {field} must be a finite non-negative number"
+        ));
+    };
+    if !value.is_finite() || value < 0.0 {
+        return Err(format!(
+            "line {line}: field {field} must be a finite non-negative number"
+        ));
+    }
+    Ok(if value == 0.0 { 0.0 } else { value })
+}
+
+fn optional_paste_outcome(
+    data: &serde_json::Map<String, Value>,
+    line: usize,
+) -> Result<Option<String>, String> {
+    let Some(value) = data.get("pasteOutcome") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(value) = value.as_str() else {
+        return Err(format!(
+            "line {line}: field pasteOutcome has an unsupported value"
+        ));
+    };
+    if !PASTE_OUTCOMES.contains(&value) {
+        return Err(format!(
+            "line {line}: field pasteOutcome has an unsupported value"
+        ));
+    }
+    Ok(Some(value.to_owned()))
+}
+
+fn normalize_language(value: String, line: usize) -> Result<String, String> {
+    let languages = [
+        (Language::English, "en"),
+        (Language::Swedish, "sv"),
+        (Language::Norwegian, "no"),
+        (Language::Auto, "auto"),
+    ];
+    languages
+        .into_iter()
+        .find(|(language, _)| language.display_name() == value)
+        .map(|(_, code)| code.to_owned())
+        .ok_or_else(|| format!("line {line}: field language has an unsupported value"))
+}
+
+fn normalize_model(value: String, line: usize) -> Result<String, String> {
+    let languages = [
+        Language::English,
+        Language::Swedish,
+        Language::Norwegian,
+        Language::Auto,
+    ];
+    let mut known = Vec::new();
+    for language in languages {
+        for &model in WhisperModel::models_for_language(language) {
+            if !known.contains(&model) {
+                known.push(model);
+            }
+        }
+    }
+    known
+        .into_iter()
+        .find(|model| model.display_name() == value)
+        .map(model_id_string)
+        .map(str::to_owned)
+        .ok_or_else(|| format!("line {line}: field model has an unsupported value"))
+}
+
+fn length_bucket(audio_duration_ms: f64) -> LengthBucket {
+    if audio_duration_ms <= 5_000.0 {
+        LengthBucket::Short
+    } else if audio_duration_ms <= 15_000.0 {
+        LengthBucket::Medium
+    } else {
+        LengthBucket::Long
+    }
+}
+
+fn read_bounded_line<R: BufRead>(
+    reader: &mut R,
+    total_bytes: &mut usize,
+    line_number: usize,
+) -> Result<Option<Vec<u8>>, String> {
+    let mut line = Vec::with_capacity(4096);
+    let mut ended_with_newline = false;
+    loop {
+        let buffer = reader
+            .fill_buf()
+            .map_err(|error| {
+                format!(
+                    "line {line_number}: input read failed ({:?})",
+                    error.kind()
+                )
+            })?;
+        if buffer.is_empty() {
+            break;
+        }
+        let newline = buffer.iter().position(|byte| *byte == b'\n');
+        let take = newline.map_or(buffer.len(), |index| index + 1);
+        if total_bytes
+            .checked_add(take)
+            .is_none_or(|total| total > MAX_INPUT_BYTES)
+        {
+            return Err("input exceeds the 32 MiB limit".to_string());
+        }
+        if line
+            .len()
+            .checked_add(take)
+            .is_none_or(|length| length > MAX_LINE_BYTES + 1)
+        {
+            return Err(format!(
+                "line {line_number}: input line exceeds the 1 MiB limit"
+            ));
+        }
+        line.extend_from_slice(&buffer[..take]);
+        reader.consume(take);
+        *total_bytes += take;
+        if newline.is_some() {
+            ended_with_newline = true;
+            break;
+        }
+    }
+
+    if line.is_empty() {
+        return Ok(None);
+    }
+    if ended_with_newline {
+        line.pop();
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+    } else if line.len() > MAX_LINE_BYTES {
+        return Err(format!(
+            "line {line_number}: input line exceeds the 1 MiB limit"
+        ));
+    }
+    Ok(Some(line))
+}
+
+fn budget_passes(
+    report: &Report,
+    length: LengthBucket,
+    threshold: f64,
+    min_samples: usize,
+) -> bool {
+    let mut eligible_groups = 0usize;
+    for group in &report.groups {
+        if group.length_bucket != length
+            || group.outcome != "success"
+            || group.model_was_warm != Some(true)
+            || group.paste_outcome.as_deref() != Some("succeeded")
+        {
+            continue;
+        }
+        eligible_groups += 1;
+        let metric = &group.phases.key_up_to_paste_completed_ms;
+        if metric.numeric_count < min_samples
+            || metric.numeric_count != metric.count
+            || metric.p95_ms.is_none_or(|p95| p95 > threshold)
+        {
+            return false;
+        }
+    }
+    eligible_groups > 0
+}
+
+pub fn run(args: LatencyReportArgs) -> Result<(), DictationError> {
+    if args.min_samples == 0 {
+        return Err(DictationError::SettingsError(
+            "min-samples must be positive".to_string(),
+        ));
+    }
+    if args.budget_length.is_some() != args.max_warm_p95_ms.is_some() {
+        return Err(DictationError::SettingsError(
+            "budget-length and max-warm-p95-ms must be supplied together".to_string(),
+        ));
+    }
+    if matches!(args.budget_length, Some(LengthBucket::Unknown)) {
+        return Err(DictationError::SettingsError(
+            "budget-length must be short, medium, or long".to_string(),
+        ));
+    }
+    if let Some(threshold) = args.max_warm_p95_ms {
+        if !threshold.is_finite() || threshold < 0.0 {
+            return Err(DictationError::SettingsError(
+                "max-warm-p95-ms must be finite and non-negative".to_string(),
+            ));
+        }
+    }
+
+    let file = File::open(&args.input).map_err(|error| {
+        DictationError::FileDecodeError(format!(
+            "latency-report input could not be opened ({:?})",
+            error.kind()
+        ))
+    })?;
+    let report = summarize_reader(BufReader::new(file)).map_err(DictationError::FileDecodeError)?;
+
+    let budget = match (args.budget_length, args.max_warm_p95_ms) {
+        (Some(length), Some(threshold)) => Some((
+            length,
+            threshold,
+            args.min_samples,
+            budget_passes(&report, length, threshold, args.min_samples),
+        )),
+        (None, None) => None,
+        _ => unreachable!("budget arguments validated above"),
+    };
+
+    let mut output = serde_json::to_value(&report).map_err(|_| {
+        DictationError::TranscriptionFailed("latency report serialization failed".to_string())
+    })?;
+    if let Some((length, threshold, min_samples, passed)) = budget {
+        output["budget"] = serde_json::json!({
+            "lengthBucket": length,
+            "maxWarmP95Ms": threshold,
+            "minSamples": min_samples,
+            "passed": passed,
+        });
+    }
+    let encoded = serde_json::to_string(&output).map_err(|_| {
+        DictationError::TranscriptionFailed("latency report serialization failed".to_string())
+    })?;
+    println!("{encoded}");
+
+    if output
+        .get("budget")
+        .and_then(|budget| budget.get("passed"))
+        .and_then(Value::as_bool)
+        == Some(false)
+    {
+        return Err(DictationError::SettingsError(
+            "latency budget check failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    fn row(event: &str, data: &str, app: &str, session: &str) -> String {
+        format!(
+            r#"{{"appSession":"{app}","dictationSession":"{session}","event":"{event}","data":{data}}}"#
+        )
+    }
+
+    fn capture(app: &str, session: &str, duration: u32) -> String {
+        row(
+            "capture_stopped",
+            &format!(r#"{{"audioDurationMs":{duration}}}"#),
+            app,
+            session,
+        )
+    }
+
+    fn phase(app: &str, session: &str, outcome: &str, paste: Option<&str>, ms: u32) -> String {
+        let paste = paste.map_or(String::new(), |value| {
+            format!(r#", "pasteOutcome":"{value}""#)
+        });
+        row(
+            "dictation_phase_timings",
+            &format!(
+                r#"{{"outcome":"{outcome}","model":"Whisper Base (EN)","language":"English","modelWasWarm":true,"beamSize":0,"temperatureFallback":true,"vadEnabled":false,"keyUpToCaptureStoppedMs":1,"modelLoadMs":2,"keyUpToModelReadyMs":3,"whisperMs":4,"keyUpToWhisperCompleteMs":5,"keyUpToPasteCompletedMs":{ms},"totalMs":{ms}{paste}}}"#
+            ),
+            app,
+            session,
+        )
+    }
+
+    #[test]
+    fn summarizes_order_independent_join_and_normalizes_metadata() {
+        let input = format!(
+            "{}\n{}\n{}\n",
+            phase("app-a", "dict-a", "success", Some("succeeded"), 42),
+            r#"{"event":"unrelated","data":{"text":"must not leak"}}"#,
+            capture("app-a", "dict-a", 5_000),
+        );
+        let report = summarize_reader(Cursor::new(input)).unwrap();
+        assert_eq!(report.input_records, 3);
+        assert_eq!(report.phase_records, 1);
+        assert_eq!(report.capture_without_phases, 0);
+        assert_eq!(report.groups[0].model.as_deref(), Some("base.en"));
+        assert_eq!(report.groups[0].language.as_deref(), Some("en"));
+        assert_eq!(report.groups[0].length_bucket, LengthBucket::Short);
+        assert_eq!(
+            report.groups[0].phases.key_up_to_paste_completed_ms.p95_ms,
+            Some(42.0)
+        );
+    }
+
+    #[test]
+    fn accepts_early_no_speech_and_counts_missing_metrics() {
+        let input = format!(
+            "{}\n{}\n",
+            capture("app-a", "dict-a", 0),
+            row(
+                "dictation_phase_timings",
+                r#"{"outcome":"no_speech","keyUpToCaptureStoppedMs":10,"modelLoadMs":null,"whisperMs":null,"keyUpToPasteCompletedMs":null,"totalMs":10}"#,
+                "app-a",
+                "dict-a",
+            ),
+        );
+        let report = summarize_reader(Cursor::new(input)).unwrap();
+        let group = &report.groups[0];
+        assert_eq!(group.model, None);
+        assert_eq!(group.phases.key_up_to_whisper_complete_ms.missing_count, 1);
+        assert_eq!(group.phases.model_load_ms.null_count, 1);
+    }
+
+    #[test]
+    fn rejects_duplicate_pairs_unknown_names_and_bad_metrics_without_echoing_values() {
+        let duplicate = format!(
+            "{}\n{}\n",
+            capture("app-a", "dict-a", 100),
+            capture("app-a", "dict-a", 200)
+        );
+        let error = summarize_reader(Cursor::new(duplicate)).unwrap_err();
+        assert!(error.contains("duplicate capture_stopped"));
+        assert!(!error.contains("app-a"));
+
+        let mut unknown = phase("app-a", "dict-a", "success", Some("succeeded"), 1);
+        unknown = unknown.replace("Whisper Base (EN)", "secret-model");
+        let error = summarize_reader(Cursor::new(unknown)).unwrap_err();
+        assert!(error.contains("field model"));
+        assert!(!error.contains("secret-model"));
+
+        let bad = row(
+            "dictation_phase_timings",
+            r#"{"outcome":"error","model":"Whisper Base (EN)","language":"English","modelWasWarm":true,"beamSize":0,"temperatureFallback":true,"vadEnabled":false,"totalMs":true}"#,
+            "app-a",
+            "dict-a",
+        );
+        let error = summarize_reader(Cursor::new(bad)).unwrap_err();
+        assert!(error.contains("field totalMs"));
+        assert!(!error.contains("true"));
+    }
+
+    #[test]
+    fn enforces_boundaries_and_capture_without_phase_count() {
+        let input = format!(
+            "{}\n{}\n{}\n{}\n",
+            capture("app-a", "dict-a", 5_000),
+            capture("app-b", "dict-b", 15_000),
+            capture("app-c", "dict-c", 15_001),
+            row(
+                "dictation_phase_timings",
+                r#"{"outcome":"no_speech","keyUpToCaptureStoppedMs":1,"totalMs":1}"#,
+                "app-a",
+                "dict-a",
+            ),
+        );
+        let report = summarize_reader(Cursor::new(input)).unwrap();
+        assert_eq!(report.capture_without_phases, 2);
+        assert_eq!(report.groups[0].length_bucket, LengthBucket::Short);
+
+        let too_long = format!(
+            "{{\"event\":\"unrelated\",\"data\":\"{}\"}}",
+            "x".repeat(MAX_LINE_BYTES)
+        );
+        assert!(summarize_reader(Cursor::new(too_long)).is_err());
+    }
+
+    #[test]
+    fn budget_requires_warm_successful_paste_groups_and_numeric_samples() {
+        let report = summarize_reader(Cursor::new(format!(
+            "{}\n{}\n",
+            capture("app-a", "dict-a", 100),
+            phase("app-a", "dict-a", "success", Some("succeeded"), 20)
+        )))
+        .unwrap();
+        assert!(budget_passes(&report, LengthBucket::Short, 20.0, 1));
+        assert!(!budget_passes(&report, LengthBucket::Short, 19.0, 1));
+        assert!(!budget_passes(&report, LengthBucket::Medium, 20.0, 1));
+    }
+}

--- a/src-tauri/crates/sagascript-cli/src/latency/percentile.rs
+++ b/src-tauri/crates/sagascript-cli/src/latency/percentile.rs
@@ -1,0 +1,61 @@
+pub(crate) fn percentile_ms(samples: &[f64], percentile: u8) -> Result<Option<f64>, &'static str> {
+    if !(1..=100).contains(&percentile) {
+        return Err("percentile must be between 1 and 100");
+    }
+
+    if samples
+        .iter()
+        .any(|sample| !sample.is_finite() || *sample < 0.0)
+    {
+        return Err("samples must be finite and non-negative");
+    }
+
+    if samples.is_empty() {
+        return Ok(None);
+    }
+
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(f64::total_cmp);
+
+    // Split the multiplication before doing it so the rank calculation stays
+    // within usize even for a very large input slice.
+    let count = sorted.len();
+    let percentile = usize::from(percentile);
+    let rank = (count / 100) * percentile + ((count % 100) * percentile).div_ceil(100);
+    sorted
+        .get(rank.checked_sub(1).ok_or("calculated rank was zero")?)
+        .copied()
+        .map(Some)
+        .ok_or("calculated rank was outside the sample set")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::percentile_ms;
+
+    #[test]
+    fn uses_nearest_rank_without_mutating_samples() {
+        let samples = [9.0, 1.0, 7.0, 5.0];
+
+        assert_eq!(percentile_ms(&samples, 50), Ok(Some(5.0)));
+        assert_eq!(percentile_ms(&samples, 95), Ok(Some(9.0)));
+        assert_eq!(samples, [9.0, 1.0, 7.0, 5.0]);
+    }
+
+    #[test]
+    fn validates_percentile_and_all_samples() {
+        for percentile in [0, 101, 255] {
+            assert!(percentile_ms(&[1.0], percentile).is_err());
+        }
+        for sample in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -0.1] {
+            assert!(percentile_ms(&[1.0, sample, 2.0], 50).is_err());
+        }
+    }
+
+    #[test]
+    fn handles_empty_singleton_duplicates_and_fractions() {
+        assert_eq!(percentile_ms(&[], 50), Ok(None));
+        assert_eq!(percentile_ms(&[f64::MAX], 95), Ok(Some(f64::MAX)));
+        assert_eq!(percentile_ms(&[2.5, 2.5, 2.5], 95), Ok(Some(2.5)));
+    }
+}

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -214,7 +214,7 @@ EXAMPLES:
 
     /// Summarize copied live-dictation latency JSONL without launching the app
     #[command(
-        long_about = "Summarize explicitly copied dictation_phase_timings JSONL. This command never reads the default log directory, starts the app, captures audio, loads a model, changes settings, or contacts a remote service.",
+        long_about = "Summarize explicitly copied dictation_phase_timings JSONL. Valid input emits JSON and exits zero. An explicit budget failure emits the JSON report and exits nonzero; invalid input or arguments exit nonzero without JSON. This command never reads the default log directory, starts the app, captures audio, loads a model, changes settings, or contacts a remote service.",
         after_long_help = "EXAMPLES:\n  sagascript latency-report --input /tmp/sagascript.log\n  sagascript latency-report --input /tmp/sagascript.log --budget-length short --max-warm-p95-ms 800 --min-samples 20"
     )]
     LatencyReport(latency::LatencyReportArgs),

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod glossary;
+pub mod latency;
 pub mod models;
 pub mod open;
 // Live recording is optional (`record` feature, on by default) so a pure
@@ -210,6 +211,13 @@ EXAMPLES:
   sagascript transcribe recordings/ --recursive --jsonl"
     )]
     Transcribe(transcribe::TranscribeArgs),
+
+    /// Summarize copied live-dictation latency JSONL without launching the app
+    #[command(
+        long_about = "Summarize explicitly copied dictation_phase_timings JSONL. This command never reads the default log directory, starts the app, captures audio, loads a model, changes settings, or contacts a remote service.",
+        after_long_help = "EXAMPLES:\n  sagascript latency-report --input /tmp/sagascript.log\n  sagascript latency-report --input /tmp/sagascript.log --budget-length short --max-warm-p95-ms 800 --min-samples 20"
+    )]
+    LatencyReport(latency::LatencyReportArgs),
 
     /// Record from microphone and transcribe
     #[cfg(feature = "record")]
@@ -463,6 +471,7 @@ pub fn run(cli: Cli) {
     let result = match cli.command.unwrap() {
         Command::Transcribe(args) =>
             run_inference_command("transcribe", move || transcribe::run(args)),
+        Command::LatencyReport(args) => latency::run(args),
         #[cfg(feature = "record")]
         Command::Record(args) => run_inference_command("record", move || record::run(args)),
         Command::ListModels(args) => models::list(args),

--- a/src-tauri/crates/sagascript-cli/tests/latency_budget_cli.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_budget_cli.rs
@@ -1,0 +1,357 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
+
+struct Fixture {
+    root: PathBuf,
+    input: PathBuf,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_dir_all(&self.root) {
+            eprintln!("latency fixture cleanup failed: {:?}", error.kind());
+        }
+    }
+}
+
+fn fixture(entries: Vec<Value>) -> Fixture {
+    let id = NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let root = std::env::temp_dir().join(format!(
+        "sagascript-latency-budget-{}-{timestamp}-{id}",
+        std::process::id(),
+    ));
+    fs::create_dir(&root)
+        .unwrap_or_else(|error| panic!("create fixture directory: {:?}", error.kind()));
+    let input = root.join("events.jsonl");
+    let fixture = Fixture { root, input };
+    let contents = entries
+        .into_iter()
+        .map(|entry| serde_json::to_string(&entry).expect("serialize fixture event"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&fixture.input, format!("{contents}\n"))
+        .unwrap_or_else(|error| panic!("write fixture JSONL: {:?}", error.kind()));
+    fixture
+}
+
+fn sample_events(
+    entries: &mut Vec<Value>,
+    index: usize,
+    audio_duration_ms: u64,
+    latency_ms: u64,
+    warm: bool,
+    paste_outcome: &str,
+) {
+    let app_session = format!("app-budget-{index}");
+    let dictation_session = format!("dict-budget-{index}");
+    entries.push(json!({
+        "ts": format!("2026-01-01T00:00:{index:02}Z"),
+        "level": "info",
+        "appSession": app_session,
+        "dictationSession": dictation_session,
+        "category": "Performance",
+        "event": "capture_stopped",
+        "data": {
+            "recordingDurationMs": audio_duration_ms,
+            "audioDurationMs": audio_duration_ms,
+            "audioSamples": audio_duration_ms * 16,
+            "captureRequestToStreamPlayReturnMs": 1,
+            "captureRequestToFirstAudioCallbackMs": 2,
+            "deviceSampleRateHz": 16_000,
+        },
+    }));
+    entries.push(json!({
+        "ts": format!("2026-01-01T00:01:{index:02}Z"),
+        "level": "info",
+        "appSession": app_session,
+        "dictationSession": dictation_session,
+        "category": "Performance",
+        "event": "dictation_phase_timings",
+        "data": {
+            "outcome": "success",
+            "model": "Whisper Base",
+            "language": "English",
+            "modelWasWarm": warm,
+            "beamSize": 1,
+            "temperatureFallback": false,
+            "vadEnabled": false,
+            "keyUpToCaptureStoppedMs": 10,
+            "modelLoadMs": 0,
+            "keyUpToModelReadyMs": 11,
+            "whisperMs": latency_ms.saturating_sub(20),
+            "keyUpToWhisperCompleteMs": latency_ms.saturating_sub(5),
+            "pasteOutcome": paste_outcome,
+            "keyUpToPasteCompletedMs": if paste_outcome == "succeeded" {
+                json!(latency_ms)
+            } else {
+                Value::Null
+            },
+            "totalMs": latency_ms,
+        },
+    }));
+}
+
+fn run_report(input: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_sagascript"))
+        .arg("latency-report")
+        .arg("--input")
+        .arg(input)
+        .args(args)
+        .output()
+        .expect("run sagascript latency-report")
+}
+
+fn parse_report(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "latency-report did not emit JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn assert_budget(output: &Output, expected: bool) -> Value {
+    let report = parse_report(output);
+    assert_eq!(report["budget"]["passed"], expected, "report={report}");
+    report
+}
+
+#[test]
+fn budget_passes_twenty_warm_successful_short_samples_at_exact_threshold() {
+    let mut entries = Vec::new();
+    for index in 0..20 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &["--budget-length", "short", "--max-warm-p95-ms", "100"],
+    );
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_budget(&output, true);
+}
+
+#[test]
+fn budget_failure_still_emits_json_when_p95_is_over_threshold() {
+    let mut entries = Vec::new();
+    for index in 0..18 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    for index in 18..20 {
+        sample_events(&mut entries, index, 1_000, 200, true, "succeeded");
+    }
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &[
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "199",
+            "--min-samples",
+            "20",
+        ],
+    );
+
+    assert!(!output.status.success(), "budget failure must be nonzero");
+    assert_budget(&output, false);
+}
+
+#[test]
+fn budget_fails_when_samples_are_below_the_requested_minimum() {
+    let mut entries = Vec::new();
+    for index in 0..19 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &["--budget-length", "short", "--max-warm-p95-ms", "100"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "insufficient samples must be nonzero"
+    );
+    assert_budget(&output, false);
+}
+
+#[test]
+fn budget_fails_with_no_eligible_warm_samples() {
+    let mut entries = Vec::new();
+    for index in 0..20 {
+        sample_events(&mut entries, index, 1_000, 100, false, "succeeded");
+    }
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &["--budget-length", "short", "--max-warm-p95-ms", "100"],
+    );
+
+    assert!(!output.status.success(), "cold-only budget must be nonzero");
+    assert_budget(&output, false);
+}
+
+#[test]
+fn selected_length_does_not_combine_other_length_samples() {
+    let mut entries = Vec::new();
+    for index in 0..10 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    for index in 10..30 {
+        sample_events(&mut entries, index, 6_000, 100, true, "succeeded");
+    }
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &[
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "100",
+            "--min-samples",
+            "20",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "short cohort must remain under min samples"
+    );
+    assert_budget(&output, false);
+}
+
+#[test]
+fn slow_configuration_group_cannot_be_hidden_by_fast_group() {
+    let mut entries = Vec::new();
+    for index in 0..20 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    sample_events(&mut entries, 20, 1_000, 200, true, "succeeded");
+    let slow_phase = entries.last_mut().expect("slow phase event");
+    slow_phase["data"]["model"] = json!("KB-Whisper Base");
+    slow_phase["data"]["beamSize"] = json!(2);
+
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &[
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "150",
+            "--min-samples",
+            "1",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "slow configuration must fail the budget"
+    );
+    assert_budget(&output, false);
+}
+
+#[test]
+fn incomplete_or_unsuccessful_paste_samples_cannot_pass_budget() {
+    let mut entries = Vec::new();
+    for index in 0..19 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+
+    // A failed paste has a numeric-looking latency but must not count as a
+    // successful sample toward the requested minimum.
+    sample_events(&mut entries, 19, 1_000, 100, true, "failed");
+    entries.last_mut().expect("failed paste phase")["data"]["keyUpToPasteCompletedMs"] = json!(100);
+
+    // A successful phase with its endpoint metric missing is incomplete and
+    // must fail closed rather than being treated as a fast zero/omitted row.
+    sample_events(&mut entries, 20, 1_000, 100, true, "succeeded");
+    entries.last_mut().expect("incomplete phase")["data"]
+        .as_object_mut()
+        .expect("phase data object")
+        .remove("keyUpToPasteCompletedMs");
+
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &[
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "100",
+            "--min-samples",
+            "20",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "incomplete eligible metrics must fail"
+    );
+    assert_budget(&output, false);
+}
+
+#[test]
+fn invalid_budget_options_fail_closed() {
+    let mut entries = Vec::new();
+    sample_events(&mut entries, 0, 1_000, 100, true, "succeeded");
+    let fixture = fixture(entries);
+    let invalid_options = [
+        vec!["--budget-length", "short"],
+        vec!["--max-warm-p95-ms", "100"],
+        vec!["--budget-length", "short", "--max-warm-p95-ms=-1"],
+        vec!["--budget-length", "short", "--max-warm-p95-ms", "NaN"],
+        vec![
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "100",
+            "--min-samples",
+            "0",
+        ],
+    ];
+
+    for options in invalid_options {
+        let output = run_report(&fixture.input, &options);
+        assert!(!output.status.success(), "options should fail: {options:?}");
+    }
+}
+
+#[test]
+fn report_only_mode_works_without_budget_flags() {
+    let mut entries = Vec::new();
+    sample_events(&mut entries, 0, 1_000, 100, true, "succeeded");
+    let fixture = fixture(entries);
+    let output = run_report(&fixture.input, &[]);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    let report = parse_report(&output);
+    assert!(report.is_object());
+}
+
+#[test]
+fn missing_input_fails_without_echoing_private_path() {
+    let sentinel = "PRIVATE_LATENCY_SENTINEL_9f0c";
+    let missing = std::env::temp_dir()
+        .join(sentinel)
+        .join("missing-events.jsonl");
+    let output = run_report(&missing, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(!stdout.contains(sentinel), "stdout echoed private sentinel");
+    assert!(!stderr.contains(sentinel), "stderr echoed private sentinel");
+}

--- a/src-tauri/crates/sagascript-cli/tests/latency_budget_cli.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_budget_cli.rs
@@ -39,7 +39,12 @@ fn fixture(entries: Vec<Value>) -> Fixture {
         .map(|entry| serde_json::to_string(&entry).expect("serialize fixture event"))
         .collect::<Vec<_>>()
         .join("\n");
-    fs::write(&fixture.input, format!("{contents}\n"))
+    let contents = if contents.is_empty() {
+        String::new()
+    } else {
+        format!("{contents}\n")
+    };
+    fs::write(&fixture.input, contents)
         .unwrap_or_else(|error| panic!("write fixture JSONL: {:?}", error.kind()));
     fixture
 }
@@ -55,7 +60,7 @@ fn sample_events(
     let app_session = format!("app-budget-{index}");
     let dictation_session = format!("dict-budget-{index}");
     entries.push(json!({
-        "ts": format!("2026-01-01T00:00:{index:02}Z"),
+        "ts": "2026-01-01T00:00:00Z",
         "level": "info",
         "appSession": app_session,
         "dictationSession": dictation_session,
@@ -71,7 +76,7 @@ fn sample_events(
         },
     }));
     entries.push(json!({
-        "ts": format!("2026-01-01T00:01:{index:02}Z"),
+        "ts": "2026-01-01T00:00:00Z",
         "level": "info",
         "appSession": app_session,
         "dictationSession": dictation_session,
@@ -143,6 +148,33 @@ fn budget_passes_twenty_warm_successful_short_samples_at_exact_threshold() {
 }
 
 #[test]
+fn excluded_warm_success_paste_samples_are_reported_without_affecting_eligibility() {
+    let mut entries = Vec::new();
+    for index in 0..20 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    for index in 20..220 {
+        sample_events(&mut entries, index, 1_000, 100, true, "timed_out");
+    }
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &[
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "100",
+            "--min-samples",
+            "20",
+        ],
+    );
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    let report = assert_budget(&output, true);
+    assert_eq!(report["budget"]["excludedWarmSuccessSamples"], 200);
+}
+
+#[test]
 fn budget_failure_still_emits_json_when_p95_is_over_threshold() {
     let mut entries = Vec::new();
     for index in 0..18 {
@@ -200,7 +232,8 @@ fn budget_fails_with_no_eligible_warm_samples() {
     );
 
     assert!(!output.status.success(), "cold-only budget must be nonzero");
-    assert_budget(&output, false);
+    let report = assert_budget(&output, false);
+    assert_eq!(report["budget"]["excludedWarmSuccessSamples"], 0);
 }
 
 #[test]
@@ -229,7 +262,8 @@ fn selected_length_does_not_combine_other_length_samples() {
         !output.status.success(),
         "short cohort must remain under min samples"
     );
-    assert_budget(&output, false);
+    let report = assert_budget(&output, false);
+    assert_eq!(report["budget"]["excludedWarmSuccessSamples"], 0);
 }
 
 #[test]
@@ -342,6 +376,28 @@ fn report_only_mode_works_without_budget_flags() {
 }
 
 #[test]
+fn empty_input_is_valid_json_but_cannot_pass_a_budget() {
+    let fixture = fixture(Vec::new());
+    let report_output = run_report(&fixture.input, &[]);
+    assert!(
+        report_output.status.success(),
+        "stderr={:?}",
+        report_output.stderr
+    );
+    let report = parse_report(&report_output);
+    assert_eq!(report["inputRecords"], 0);
+    assert!(report["groups"].as_array().is_some_and(Vec::is_empty));
+
+    let budget_output = run_report(
+        &fixture.input,
+        &["--budget-length", "short", "--max-warm-p95-ms", "100"],
+    );
+    assert!(!budget_output.status.success());
+    let budget_report = assert_budget(&budget_output, false);
+    assert_eq!(budget_report["budget"]["excludedWarmSuccessSamples"], 0);
+}
+
+#[test]
 fn missing_input_fails_without_echoing_private_path() {
     let sentinel = "PRIVATE_LATENCY_SENTINEL_9f0c";
     let missing = std::env::temp_dir()
@@ -354,4 +410,5 @@ fn missing_input_fails_without_echoing_private_path() {
     assert!(!output.status.success());
     assert!(!stdout.contains(sentinel), "stdout echoed private sentinel");
     assert!(!stderr.contains(sentinel), "stderr echoed private sentinel");
+    assert!(stdout.trim().is_empty(), "input errors must not emit JSON");
 }

--- a/src-tauri/crates/sagascript-cli/tests/latency_budget_cli.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_budget_cli.rs
@@ -175,6 +175,32 @@ fn excluded_warm_success_paste_samples_are_reported_without_affecting_eligibilit
 }
 
 #[test]
+fn disabled_warm_success_sample_is_excluded_without_affecting_eligibility() {
+    let mut entries = Vec::new();
+    for index in 0..20 {
+        sample_events(&mut entries, index, 1_000, 100, true, "succeeded");
+    }
+    sample_events(&mut entries, 20, 1_000, 100, true, "disabled");
+
+    let fixture = fixture(entries);
+    let output = run_report(
+        &fixture.input,
+        &[
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "100",
+            "--min-samples",
+            "20",
+        ],
+    );
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    let report = assert_budget(&output, true);
+    assert_eq!(report["budget"]["excludedWarmSuccessSamples"], 1);
+}
+
+#[test]
 fn budget_failure_still_emits_json_when_p95_is_over_threshold() {
     let mut entries = Vec::new();
     for index in 0..18 {

--- a/src-tauri/crates/sagascript-cli/tests/latency_limits.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_limits.rs
@@ -3,6 +3,7 @@ use serde_json::{json, Value};
 use std::io::{self, BufReader, Cursor, ErrorKind, Read};
 
 const PRIVATE_SENTINEL: &str = "PRIVATE_LATENCY_LIMIT_SENTINEL_4c2e";
+const MAX_LINE_BYTES: usize = 1024 * 1024;
 
 fn event(app_session: &str, dictation_session: &str, name: &str, data: Value) -> Value {
     json!({
@@ -82,6 +83,53 @@ fn result_error<T>(result: Result<T, String>, message: &str) -> String {
     }
 }
 
+fn unrelated_line_with_content_size(content_size: usize, line_ending: &[u8]) -> Vec<u8> {
+    const PREFIX: &[u8] = br#"{"event":"unrelated","data":{"padding":""#;
+    const SUFFIX: &[u8] = br#""}}"#;
+    assert!(content_size >= PREFIX.len() + SUFFIX.len());
+
+    let mut line = Vec::with_capacity(content_size + line_ending.len());
+    line.extend_from_slice(PREFIX);
+    line.extend(std::iter::repeat_n(
+        b'x',
+        content_size - PREFIX.len() - SUFFIX.len(),
+    ));
+    line.extend_from_slice(SUFFIX);
+    line.extend_from_slice(line_ending);
+    line
+}
+
+struct ChunkedInput {
+    bytes: Vec<u8>,
+    offset: usize,
+    chunk_size: usize,
+}
+
+impl ChunkedInput {
+    fn new(bytes: Vec<u8>, chunk_size: usize) -> Self {
+        Self {
+            bytes,
+            offset: 0,
+            chunk_size,
+        }
+    }
+}
+
+impl Read for ChunkedInput {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self.offset == self.bytes.len() {
+            return Ok(0);
+        }
+        let amount = self
+            .chunk_size
+            .min(buffer.len())
+            .min(self.bytes.len() - self.offset);
+        buffer[..amount].copy_from_slice(&self.bytes[self.offset..self.offset + amount]);
+        self.offset += amount;
+        Ok(amount)
+    }
+}
+
 #[test]
 fn oversized_single_line_is_rejected_without_echoing_payload() {
     let mut padding = "x".repeat(1_048_600);
@@ -96,6 +144,74 @@ fn oversized_single_line_is_rejected_without_echoing_payload() {
     let error = result_error(result, "single line over 1 MiB must be rejected");
     assert!(error.to_ascii_lowercase().contains("line 1"));
     assert!(!error.contains(PRIVATE_SENTINEL));
+}
+
+#[test]
+fn accepts_exact_1_mib_content_for_lf_crlf_eof_and_chunked_input() {
+    for line_ending in [b"\n".as_slice(), b"\r\n".as_slice(), b"".as_slice()] {
+        let report = summarize_reader(Cursor::new(unrelated_line_with_content_size(
+            MAX_LINE_BYTES,
+            line_ending,
+        )))
+        .expect("exact 1 MiB content should be accepted");
+        assert_eq!(report.input_records, 1);
+    }
+
+    let reader = BufReader::new(ChunkedInput::new(
+        unrelated_line_with_content_size(MAX_LINE_BYTES, b"\r\n"),
+        3,
+    ));
+    let report = summarize_reader(reader).expect("chunked CRLF input should be accepted");
+    assert_eq!(report.input_records, 1);
+}
+
+#[test]
+fn rejects_content_over_1_mib_for_line_endings_and_chunked_input() {
+    for line_ending in [b"\n".as_slice(), b"\r\n".as_slice(), b"".as_slice()] {
+        let result = summarize_reader(Cursor::new(unrelated_line_with_content_size(
+            MAX_LINE_BYTES + 1,
+            line_ending,
+        )));
+        assert!(result.is_err(), "over-limit input was accepted");
+    }
+
+    let reader = BufReader::new(ChunkedInput::new(
+        unrelated_line_with_content_size(MAX_LINE_BYTES + 1, b"\r\n"),
+        3,
+    ));
+    assert!(summarize_reader(reader).is_err());
+}
+
+#[test]
+fn blank_and_whitespace_lines_remain_malformed() {
+    for input in [b"\n".to_vec(), b" \t\r\n".to_vec()] {
+        assert!(summarize_reader(Cursor::new(input)).is_err());
+    }
+}
+
+#[test]
+fn relevant_events_require_both_correlation_identifiers() {
+    let mut missing_app = capture_event("app-missing", "dict", 1_000);
+    missing_app
+        .as_object_mut()
+        .expect("capture event object")
+        .remove("appSession");
+    assert!(summarize_reader(Cursor::new(jsonl(&[missing_app]))).is_err());
+
+    let mut missing_dict = success_phase_event("app", "dict-missing");
+    missing_dict
+        .as_object_mut()
+        .expect("phase event object")
+        .remove("dictationSession");
+    assert!(summarize_reader(Cursor::new(jsonl(&[missing_dict]))).is_err());
+}
+
+#[test]
+fn empty_file_is_a_valid_empty_report() {
+    let report = summarize_reader(Cursor::new(Vec::<u8>::new())).expect("empty input is valid");
+    assert_eq!(report.input_records, 0);
+    assert_eq!(report.phase_records, 0);
+    assert!(report.groups.is_empty());
 }
 
 struct RepeatingLines {

--- a/src-tauri/crates/sagascript-cli/tests/latency_limits.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_limits.rs
@@ -1,0 +1,294 @@
+use sagascript_cli::latency::summarize_reader;
+use serde_json::{json, Value};
+use std::io::{self, BufReader, Cursor, ErrorKind, Read};
+
+const PRIVATE_SENTINEL: &str = "PRIVATE_LATENCY_LIMIT_SENTINEL_4c2e";
+
+fn event(app_session: &str, dictation_session: &str, name: &str, data: Value) -> Value {
+    json!({
+        "ts": "2026-01-01T00:00:00.000Z",
+        "level": "info",
+        "appSession": app_session,
+        "dictationSession": dictation_session,
+        "category": "Performance",
+        "event": name,
+        "data": data,
+    })
+}
+
+fn capture_event(app_session: &str, dictation_session: &str, audio_duration_ms: u64) -> Value {
+    event(
+        app_session,
+        dictation_session,
+        "capture_stopped",
+        json!({
+            "recordingDurationMs": audio_duration_ms,
+            "audioDurationMs": audio_duration_ms,
+            "audioSamples": audio_duration_ms * 16,
+            "captureRequestToStreamPlayReturnMs": 1,
+            "captureRequestToFirstAudioCallbackMs": 2,
+            "deviceSampleRateHz": 16_000,
+        }),
+    )
+}
+
+fn success_phase_event(app_session: &str, dictation_session: &str) -> Value {
+    event(
+        app_session,
+        dictation_session,
+        "dictation_phase_timings",
+        json!({
+            "outcome": "success",
+            "model": "Whisper Base",
+            "language": "English",
+            "modelWasWarm": true,
+            "beamSize": 1,
+            "temperatureFallback": false,
+            "vadEnabled": false,
+            "keyUpToCaptureStoppedMs": 10,
+            "modelLoadMs": 0,
+            "keyUpToModelReadyMs": 11,
+            "whisperMs": 20,
+            "keyUpToWhisperCompleteMs": 31,
+            "pasteOutcome": "succeeded",
+            "keyUpToPasteCompletedMs": 42,
+            "totalMs": 42,
+        }),
+    )
+}
+
+fn jsonl(events: &[Value]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for event in events {
+        bytes.extend(serde_json::to_vec(event).expect("serialize test event"));
+        bytes.push(b'\n');
+    }
+    bytes
+}
+
+fn assert_error_without_payload<T>(result: Result<T, String>, payload: &str) {
+    let error = result_error(result, "input should be rejected");
+    assert!(!error.contains(payload), "error echoed rejected payload");
+    assert!(
+        !error.contains(PRIVATE_SENTINEL),
+        "error echoed private sentinel"
+    );
+}
+
+fn result_error<T>(result: Result<T, String>, message: &str) -> String {
+    match result {
+        Ok(_) => panic!("{message}"),
+        Err(error) => error,
+    }
+}
+
+#[test]
+fn oversized_single_line_is_rejected_without_echoing_payload() {
+    let mut padding = "x".repeat(1_048_600);
+    padding.push_str(PRIVATE_SENTINEL);
+    let line = json!({
+        "event": "unrelated",
+        "data": {"padding": padding},
+    });
+    let input = jsonl(&[line]);
+
+    let result = summarize_reader(Cursor::new(input));
+    let error = result_error(result, "single line over 1 MiB must be rejected");
+    assert!(error.to_ascii_lowercase().contains("line 1"));
+    assert!(!error.contains(PRIVATE_SENTINEL));
+}
+
+struct RepeatingLines {
+    line: Vec<u8>,
+    remaining: usize,
+    offset: usize,
+}
+
+impl RepeatingLines {
+    fn new(line: Vec<u8>, remaining: usize) -> Self {
+        Self {
+            line,
+            remaining,
+            offset: 0,
+        }
+    }
+}
+
+impl Read for RepeatingLines {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self.remaining == 0 {
+            return Ok(0);
+        }
+        let amount = (self.line.len() - self.offset).min(buffer.len());
+        buffer[..amount].copy_from_slice(&self.line[self.offset..self.offset + amount]);
+        self.offset += amount;
+        if self.offset == self.line.len() {
+            self.offset = 0;
+            self.remaining -= 1;
+        }
+        Ok(amount)
+    }
+}
+
+#[test]
+fn oversized_total_input_is_rejected_while_streaming_valid_unrelated_jsonl() {
+    let mut line = serde_json::to_vec(&json!({
+        "event": "unrelated",
+        "data": {"private": PRIVATE_SENTINEL},
+    }))
+    .expect("serialize repeated event");
+    line.push(b'\n');
+    let count = (32 * 1024 * 1024 / line.len()) + 1;
+    let reader = BufReader::new(RepeatingLines::new(line, count));
+
+    let result = summarize_reader(reader);
+    let error = result_error(result, "total input over 32 MiB must be rejected");
+    assert!(!error.contains(PRIVATE_SENTINEL));
+}
+
+struct FailingReader;
+
+impl Read for FailingReader {
+    fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::new(
+            ErrorKind::PermissionDenied,
+            "PRIVATE_IO_ERROR_PAYLOAD",
+        ))
+    }
+}
+
+#[test]
+fn read_io_error_preserves_line_and_kind_without_raw_error_payload() {
+    let reader = BufReader::new(FailingReader);
+    let result = summarize_reader(reader);
+    let error = result_error(result, "reader error must be returned");
+    let lower = error.to_ascii_lowercase();
+    assert!(
+        lower.contains("line 1"),
+        "error omitted input line: {error}"
+    );
+    assert!(
+        lower.contains("permission") || lower.contains("denied"),
+        "error omitted I/O kind: {error}"
+    );
+    assert!(!error.contains("PRIVATE_IO_ERROR_PAYLOAD"));
+}
+
+#[test]
+fn malformed_shapes_and_unknown_model_or_language_fail_without_echoing_values() {
+    let malformed_root = json!([]);
+    assert_error_without_payload(
+        summarize_reader(Cursor::new(jsonl(&[malformed_root]))),
+        "[]",
+    );
+
+    let malformed_data = json!({
+        "appSession": "app-malformed-data",
+        "dictationSession": "dict-malformed-data",
+        "event": "dictation_phase_timings",
+        "data": [],
+    });
+    assert_error_without_payload(
+        summarize_reader(Cursor::new(jsonl(&[malformed_data]))),
+        "[]",
+    );
+
+    for (field, value) in [
+        ("model", "PRIVATE_UNKNOWN_MODEL_SENTINEL"),
+        ("language", "PRIVATE_UNKNOWN_LANGUAGE_SENTINEL"),
+    ] {
+        let app = "app-unknown-value";
+        let dict = "dict-unknown-value";
+        let mut phase = success_phase_event(app, dict);
+        phase["data"][field] = json!(value);
+        let input = jsonl(&[capture_event(app, dict, 1_000), phase]);
+        assert_error_without_payload(summarize_reader(Cursor::new(input)), value);
+    }
+}
+
+#[test]
+fn success_with_missing_required_configuration_is_rejected() {
+    let app = "app-missing-config";
+    let dict = "dict-missing-config";
+    let mut phase = success_phase_event(app, dict);
+    phase["data"]
+        .as_object_mut()
+        .expect("phase data object")
+        .remove("model");
+    let input = jsonl(&[capture_event(app, dict, 1_000), phase]);
+
+    let result = summarize_reader(Cursor::new(input));
+    assert!(result.is_err(), "success without model must be rejected");
+}
+
+fn contains_object_with_null_model_and_language(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            let has_null_metadata = object.get("model") == Some(&Value::Null)
+                && object.get("language") == Some(&Value::Null);
+            has_null_metadata
+                || object
+                    .values()
+                    .any(contains_object_with_null_model_and_language)
+        }
+        Value::Array(values) => values
+            .iter()
+            .any(contains_object_with_null_model_and_language),
+        _ => false,
+    }
+}
+
+fn contains_numeric_metric_summary(value: &Value, metric: &str) -> bool {
+    match value {
+        Value::Object(object) => {
+            let metric_is_numeric = object
+                .get(metric)
+                .and_then(Value::as_object)
+                .and_then(|metric| metric.get("p50Ms"))
+                .is_some_and(Value::is_number);
+            metric_is_numeric
+                || object
+                    .values()
+                    .any(|child| contains_numeric_metric_summary(child, metric))
+        }
+        Value::Array(values) => values
+            .iter()
+            .any(|child| contains_numeric_metric_summary(child, metric)),
+        _ => false,
+    }
+}
+
+#[test]
+fn early_no_speech_without_config_is_accepted_with_null_metadata() {
+    let app = "app-legacy-no-speech";
+    let dict = "dict-legacy-no-speech";
+    let phase = event(
+        app,
+        dict,
+        "dictation_phase_timings",
+        json!({
+            "outcome": "no_speech",
+            "keyUpToCaptureStoppedMs": 12,
+            "keyUpToModelReadyMs": null,
+            "modelLoadMs": null,
+            "whisperMs": null,
+            "keyUpToPasteCompletedMs": null,
+            "totalMs": 15,
+        }),
+    );
+    let input = jsonl(&[capture_event(app, dict, 1_000), phase]);
+    let report = summarize_reader(Cursor::new(input)).expect("legacy no-speech record is valid");
+    let value = serde_json::to_value(report).expect("serialize report");
+
+    let reporter_version = value["reporterVersion"]
+        .as_str()
+        .expect("reporterVersion string");
+    assert!(!reporter_version.is_empty());
+    assert_eq!(value["sourceBuild"], Value::Null);
+    assert!(contains_object_with_null_model_and_language(&value));
+    assert!(contains_numeric_metric_summary(&value, "totalMs"));
+    assert!(contains_numeric_metric_summary(
+        &value,
+        "keyUpToCaptureStoppedMs"
+    ));
+}

--- a/src-tauri/crates/sagascript-cli/tests/latency_owner_regressions.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_owner_regressions.rs
@@ -1,0 +1,119 @@
+use std::io::{Cursor, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sagascript_cli::latency::summarize_reader;
+use serde_json::{json, Value};
+
+static NEXT_FILE: AtomicU64 = AtomicU64::new(0);
+
+struct InputFile(PathBuf);
+
+impl InputFile {
+    fn new(rows: &[Value]) -> Self {
+        let id = NEXT_FILE.fetch_add(1, Ordering::Relaxed);
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "sagascript-latency-owner-{}-{stamp}-{id}.jsonl",
+            std::process::id()
+        ));
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("create exclusive fixture");
+        let owned = Self(path);
+        for row in rows {
+            writeln!(file, "{row}").expect("write fixture");
+        }
+        owned
+    }
+}
+
+impl Drop for InputFile {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_file(&self.0) {
+            eprintln!("fixture cleanup failed: {:?}", error.kind());
+        }
+    }
+}
+
+fn phase(index: usize) -> Value {
+    json!({"appSession":"test-app", "dictationSession":format!("dict-{index}"),
+    "event":"dictation_phase_timings", "data":{
+        "outcome":"success", "model":"Whisper Base", "language":"English",
+        "modelWasWarm":true, "beamSize":1, "temperatureFallback":false,
+        "vadEnabled":false, "pasteOutcome":"succeeded",
+        "keyUpToCaptureStoppedMs":1, "modelLoadMs":0, "keyUpToModelReadyMs":2,
+        "whisperMs":90, "keyUpToWhisperCompleteMs":92,
+        "keyUpToPasteCompletedMs":100, "totalMs":100
+    }})
+}
+
+fn capture(index: usize) -> Value {
+    json!({"appSession":"test-app", "dictationSession":format!("dict-{index}"),
+        "event":"capture_stopped", "data":{"audioDurationMs":1000}})
+}
+
+#[test]
+fn budget_rejects_incomplete_group_even_with_enough_numeric_samples() {
+    let mut rows = Vec::new();
+    for index in 0..21 {
+        rows.push(capture(index));
+        let mut row = phase(index);
+        if index == 20 {
+            row["data"]["keyUpToPasteCompletedMs"] = Value::Null;
+        }
+        rows.push(row);
+    }
+    let file = InputFile::new(&rows);
+    let output = Command::new(env!("CARGO_BIN_EXE_sagascript"))
+        .args(["latency-report", "--input"])
+        .arg(&file.0)
+        .args([
+            "--budget-length",
+            "short",
+            "--max-warm-p95-ms",
+            "100",
+            "--min-samples",
+            "20",
+        ])
+        .output()
+        .expect("run report");
+    let report: Value = serde_json::from_slice(&output.stdout).expect("budget result JSON");
+    assert!(!output.status.success(), "incomplete group must not pass");
+    assert_eq!(report["budget"]["passed"], false);
+}
+
+#[test]
+fn unknown_duration_is_not_a_selectable_successful_budget() {
+    let file = InputFile::new(&(0..20).map(phase).collect::<Vec<_>>());
+    let output = Command::new(env!("CARGO_BIN_EXE_sagascript"))
+        .args(["latency-report", "--input"])
+        .arg(&file.0)
+        .args(["--budget-length", "unknown", "--max-warm-p95-ms", "100"])
+        .output()
+        .expect("run report");
+    assert!(
+        !output.status.success(),
+        "unknown length must not be budget-eligible"
+    );
+}
+
+#[test]
+fn non_object_json_is_not_a_log_record() {
+    assert!(summarize_reader(Cursor::new(b"[1,2,3]\n")).is_err());
+}
+
+#[test]
+fn early_no_speech_cannot_claim_a_paste_outcome() {
+    let row = json!({"appSession":"test-app", "dictationSession":"dict-empty",
+        "event":"dictation_phase_timings", "data":{
+            "outcome":"no_speech", "pasteOutcome":"succeeded",
+            "keyUpToCaptureStoppedMs":1, "totalMs":1}});
+    assert!(summarize_reader(Cursor::new(format!("{row}\n"))).is_err());
+}

--- a/src-tauri/crates/sagascript-cli/tests/latency_report.rs
+++ b/src-tauri/crates/sagascript-cli/tests/latency_report.rs
@@ -1,0 +1,280 @@
+use std::io::Cursor;
+
+use sagascript_cli::latency::summarize_reader;
+use serde_json::{json, Value};
+
+fn envelope(app_session: &str, dictation_session: &str, event: &str, data: Value) -> Value {
+    json!({
+        "ts": "2026-09-05T12:00:00Z",
+        "level": "info",
+        "appSession": app_session,
+        "dictationSession": dictation_session,
+        "category": "Performance",
+        "event": event,
+        "data": data,
+    })
+}
+
+fn capture(app_session: &str, dictation_session: &str, audio_duration_ms: u64) -> Value {
+    envelope(
+        app_session,
+        dictation_session,
+        "capture_stopped",
+        json!({
+            "recordingDurationMs": audio_duration_ms + 100,
+            "audioDurationMs": audio_duration_ms,
+            "audioSamples": audio_duration_ms * 16,
+            "captureRequestToStreamPlayReturnMs": 5,
+            "captureRequestToFirstAudioCallbackMs": 7,
+            "deviceSampleRateHz": 16000,
+        }),
+    )
+}
+
+fn phase(app_session: &str, dictation_session: &str, model_was_warm: bool, total_ms: u64) -> Value {
+    envelope(
+        app_session,
+        dictation_session,
+        "dictation_phase_timings",
+        json!({
+            "outcome": "success",
+            "model": "Whisper Base",
+            "language": "English",
+            "modelWasWarm": model_was_warm,
+            "beamSize": 5,
+            "temperatureFallback": false,
+            "vadEnabled": true,
+            "keyUpToCaptureStoppedMs": total_ms,
+            "modelLoadMs": total_ms,
+            "keyUpToModelReadyMs": total_ms,
+            "whisperMs": total_ms,
+            "keyUpToWhisperCompleteMs": total_ms,
+            "keyUpToPasteCompletedMs": total_ms,
+            "totalMs": total_ms,
+            "pasteOutcome": "succeeded",
+        }),
+    )
+}
+
+fn summarize_rows(rows: &[Value]) -> Result<Value, String> {
+    let mut input = String::new();
+    for row in rows {
+        input.push_str(&serde_json::to_string(row).map_err(|error| error.to_string())?);
+        input.push('\n');
+    }
+    summarize_text(&input)
+}
+
+fn summarize_text(input: &str) -> Result<Value, String> {
+    let report = summarize_reader(Cursor::new(input.as_bytes()))?;
+    serde_json::to_value(report).map_err(|error| error.to_string())
+}
+
+fn group<'a>(report: &'a Value, warm: bool, length_bucket: &str) -> &'a Value {
+    report["groups"]
+        .as_array()
+        .expect("groups should be an array")
+        .iter()
+        .find(|candidate| {
+            candidate["model"] == "base"
+                && candidate["language"] == "en"
+                && candidate["modelWasWarm"] == warm
+                && candidate["lengthBucket"] == length_bucket
+        })
+        .unwrap_or_else(|| panic!("missing group {warm}/{length_bucket}: {report}"))
+}
+
+fn phase_metric<'a>(group: &'a Value, field: &str) -> &'a Value {
+    &group["phases"][field]
+}
+
+#[test]
+fn reports_exact_schema_and_nearest_rank_statistics_per_warm_cohort() {
+    let mut rows = Vec::new();
+    for index in 1..=20u64 {
+        let session = format!("cold-{index}");
+        rows.push(capture("app-a", &session, 5_000));
+        rows.push(phase("app-a", &session, false, index));
+    }
+    rows.push(capture("app-a", "warm-1", 5_000));
+    rows.push(phase("app-a", "warm-1", true, 999));
+
+    let report = summarize_rows(&rows).expect("synthetic report should parse");
+    assert_eq!(report["schemaVersion"], 1);
+    assert_eq!(
+        report["metricBoundary"],
+        "paste_call_completion_not_visible_text"
+    );
+    assert_eq!(report["inputRecords"], 42);
+    assert_eq!(report["phaseRecords"], 21);
+
+    let cold = group(&report, false, "short");
+    assert_eq!(cold["samples"], 20);
+    assert_eq!(phase_metric(cold, "totalMs")["count"], 20);
+    assert_eq!(phase_metric(cold, "totalMs")["numericCount"], 20);
+    assert_eq!(phase_metric(cold, "totalMs")["p50Ms"], 10.0);
+    assert_eq!(phase_metric(cold, "totalMs")["p95Ms"], 19.0);
+
+    let warm = group(&report, true, "short");
+    assert_eq!(warm["samples"], 1);
+    assert_eq!(phase_metric(warm, "totalMs")["p50Ms"], 999.0);
+    assert_eq!(phase_metric(warm, "totalMs")["p95Ms"], 999.0);
+}
+
+#[test]
+fn keeps_audio_duration_boundaries_in_separate_length_buckets() {
+    let rows = [("short", 5_000), ("medium", 15_000), ("long", 15_001)]
+        .into_iter()
+        .enumerate()
+        .flat_map(|(index, (expected_bucket, duration))| {
+            let session = format!("boundary-{index}");
+            let rows = [
+                capture("app-boundary", &session, duration),
+                phase("app-boundary", &session, false, duration),
+            ];
+            assert!(!expected_bucket.is_empty());
+            rows
+        })
+        .collect::<Vec<_>>();
+
+    let report = summarize_rows(&rows).expect("boundary fixture should parse");
+    for bucket in ["short", "medium", "long"] {
+        assert_eq!(group(&report, false, bucket)["samples"], 1);
+    }
+}
+
+#[test]
+fn joins_by_both_session_keys_and_is_input_order_invariant() {
+    let rows = vec![
+        capture("app-a", "dict-1", 5_000),
+        phase("app-b", "dict-1", false, 10),
+        capture("app-b", "dict-2", 15_000),
+        phase("app-b", "dict-2", false, 20),
+    ];
+    let forward = summarize_rows(&rows).expect("forward fixture should parse");
+    let reverse_rows = rows.into_iter().rev().collect::<Vec<_>>();
+    let reverse = summarize_rows(&reverse_rows).expect("reverse fixture should parse");
+
+    assert_eq!(forward, reverse);
+    assert_eq!(forward["captureWithoutPhases"], 1);
+    assert_eq!(group(&forward, false, "medium")["samples"], 1);
+    assert_eq!(group(&forward, false, "unknown")["samples"], 1);
+}
+
+#[test]
+fn counts_unmatched_capture_and_unknown_phase_without_inventing_zeroes() {
+    let rows = vec![
+        capture("app-a", "capture-only", 1_000),
+        phase("app-b", "phase-only", false, 25),
+    ];
+
+    let report = summarize_rows(&rows).expect("unmatched fixture should parse");
+    assert_eq!(report["captureWithoutPhases"], 1);
+    let unknown = group(&report, false, "unknown");
+    assert_eq!(unknown["samples"], 1);
+    assert_eq!(phase_metric(unknown, "totalMs")["numericCount"], 1);
+    assert_eq!(phase_metric(unknown, "totalMs")["nullCount"], 0);
+    assert_eq!(phase_metric(unknown, "totalMs")["missingCount"], 0);
+}
+
+#[test]
+fn keeps_null_and_missing_metrics_distinct() {
+    let mut row = phase("app-a", "null-missing", false, 25);
+    let data = row["data"].as_object_mut().expect("phase data object");
+    data.insert("modelLoadMs".to_owned(), Value::Null);
+    data.remove("whisperMs");
+
+    let report = summarize_rows(&[capture("app-a", "null-missing", 1_000), row])
+        .expect("null/missing fixture should parse");
+    let metrics = group(&report, false, "short");
+
+    let null_metric = phase_metric(metrics, "modelLoadMs");
+    assert_eq!(null_metric["count"], 1);
+    assert_eq!(null_metric["numericCount"], 0);
+    assert_eq!(null_metric["nullCount"], 1);
+    assert_eq!(null_metric["missingCount"], 0);
+    assert!(null_metric["p50Ms"].is_null());
+    assert!(null_metric["p95Ms"].is_null());
+
+    let missing_metric = phase_metric(metrics, "whisperMs");
+    assert_eq!(missing_metric["count"], 1);
+    assert_eq!(missing_metric["numericCount"], 0);
+    assert_eq!(missing_metric["nullCount"], 0);
+    assert_eq!(missing_metric["missingCount"], 1);
+    assert!(missing_metric["p50Ms"].is_null());
+    assert!(missing_metric["p95Ms"].is_null());
+}
+
+#[test]
+fn rejects_duplicate_relevant_events_without_echoing_session_ids() {
+    let first = phase("SECRET_APP_MARKER", "SECRET_DICT_MARKER", false, 25);
+    let duplicate = first.clone();
+    let error = summarize_rows(&[
+        capture("SECRET_APP_MARKER", "SECRET_DICT_MARKER", 1_000),
+        first,
+        duplicate,
+    ])
+    .expect_err("duplicate phase events must fail");
+
+    assert!(!error.contains("SECRET_APP_MARKER"));
+    assert!(!error.contains("SECRET_DICT_MARKER"));
+}
+
+#[test]
+fn rejects_malformed_negative_and_wrong_type_relevant_data_without_echoing_values() {
+    let malformed =
+        "{\"event\":\"dictation_phase_timings\",\"data\":{\"totalMs\":\"SECRET_MARKER\"}";
+    let malformed_error = summarize_text(malformed).expect_err("malformed JSON must fail");
+    assert!(!malformed_error.contains("SECRET_MARKER"));
+
+    let mut negative = phase("SECRET_APP_MARKER", "SECRET_DICT_MARKER", false, 25);
+    negative["data"]["totalMs"] = json!(-1);
+    let negative_error = summarize_rows(&[
+        capture("SECRET_APP_MARKER", "SECRET_DICT_MARKER", 1_000),
+        negative,
+    ])
+    .expect_err("negative timing must fail");
+    assert!(!negative_error.contains("SECRET_APP_MARKER"));
+    assert!(!negative_error.contains("SECRET_DICT_MARKER"));
+
+    let mut wrong_type = phase("app-a", "wrong-type", false, 25);
+    wrong_type["data"]["totalMs"] = json!("SECRET_MARKER");
+    let wrong_type_error = summarize_rows(&[capture("app-a", "wrong-type", 1_000), wrong_type])
+        .expect_err("wrong timing type must fail");
+    assert!(!wrong_type_error.contains("SECRET_MARKER"));
+}
+
+#[test]
+fn ignores_unknown_events_and_fields_without_leaking_sensitive_values() {
+    let mut known = phase("app-a", "known", false, 25);
+    known["data"]["transcript"] = json!("TRANSCRIPT_SECRET_MARKER");
+    known["data"]["path"] = json!("/private/SECRET_PATH_MARKER");
+    known["data"]["unknownField"] = json!("UNKNOWN_SECRET_MARKER");
+    let unknown = json!({
+        "ts": "2026-09-05T12:00:00Z",
+        "level": "info",
+        "appSession": "UNKNOWN_SESSION_MARKER",
+        "dictationSession": "UNKNOWN_DICTATION_MARKER",
+        "event": "unrelated_event",
+        "data": {
+            "transcript": "UNKNOWN_TRANSCRIPT_MARKER",
+            "path": "/private/UNKNOWN_PATH_MARKER",
+            "secret": "UNKNOWN_SECRET_MARKER"
+        }
+    });
+
+    let report = summarize_rows(&[capture("app-a", "known", 1_000), known, unknown])
+        .expect("unknown event/field fixture should parse");
+    let serialized = report.to_string();
+    for marker in [
+        "TRANSCRIPT_SECRET_MARKER",
+        "SECRET_PATH_MARKER",
+        "UNKNOWN_SECRET_MARKER",
+        "UNKNOWN_SESSION_MARKER",
+        "UNKNOWN_DICTATION_MARKER",
+        "UNKNOWN_TRANSCRIPT_MARKER",
+        "UNKNOWN_PATH_MARKER",
+    ] {
+        assert!(!serialized.contains(marker), "report leaked {marker}");
+    }
+}


### PR DESCRIPTION
# Offline latency report for copied live-dictation events

## Summary

Adds the privacy-first, offline CLI command `sagascript latency-report
--input <PATH>` for aggregating explicitly copied `dictation_phase_timings`
JSONL. It joins phase and `capture_stopped` events by the bounded pair
`(appSession, dictationSession)`, normalizes known producer display names to
stable model/language identifiers, keeps cohorts separate, and emits fixed
nearest-rank p50/p95 summaries.

The command never starts the app, captures audio, loads a model, reads the
default log directory, changes settings, contacts a remote service, or emits
transcript/session/path/device data. Input is bounded to 32 MiB total and 1 MiB
per line; malformed relevant records, duplicate pairs, unknown identifiers, and
invalid numeric values fail with sanitized line/field diagnostics.

An explicit optional budget checks successful warm samples with
`pasteOutcome=succeeded` for a selected short/medium/long audio-length cohort.
Every eligible configuration group must have complete numeric endpoint metrics,
enough samples, and p95 at or below the caller-supplied threshold. A failed
budget still prints JSON and exits nonzero.

The metric boundary is `paste_call_completion_not_visible_text`: the timer
starts at the app stop-handler entry (push-to-talk key-up or second toggle
press) and ends at paste-call completion. This does not claim physical
key-up-to-visible-text latency. `reporterVersion` identifies the reporting
executable; legacy events have `sourceBuild: null`, so measured datasets must
record and compare the tested app build separately.

## Verification

Base R0: `df3c27b2954b2c9d06ab2ef7aa7d78e0edc3aec3`

Final reviewed head: `ff2c5595836448b7538077ac351a0e13815ef3c9`

- Full Rust verification: 706 tests passed, 0 failed, no skips, using a dedicated
  target after package-specific cleaning forced compilation of this branch.
  The full suite was rerun at final ff2c559; all 13 latency-budget tests and
  CLI all-target clippy also passed in the same isolated target.
- Final-head CI33993432831: Linux, macOS and Windows all passed.
- Final-head Windows candidate33993432807: x64 11m19s, ARM64 10m22s, passed.
- `cargo check --workspace --offline`: passed.
- `cargo clippy --workspace --all-targets --offline -- -D warnings`: passed.
- Lean CLI build: `cargo build -p sagascript-cli --no-default-features --offline` passed.
- Frontend tests: 62 passed.
- `npm run check`: 0 errors and 0 warnings.
- `npm run build`: passed.

## Review status

Independent reviews: **APPROVE** from actual `claude-fable-5-1` on the initial
implementation and actual `claude-sonnet-5` on the follow-up. Sonnet was the
substantive reviewer returned when Haiku was requested; models are reported
from actual usage, not the requested alias. No medium/high findings.

Fable's low/info findings were fixed or explicitly resolved: consistent LF/CRLF
limits, visible excluded-sample count, strict JSONL/correlation semantics, and
exit behavior. Actual Claude Sonnet 5 also approved the final disabled-paste
test-only addition at ff2c559; no grounded defects found. Missing pasteOutcome is invalid for a
success event, not an accepted missing-paste cohort. Constant test timestamps
are intentional: correlation uses the two session identifiers, not time.

One earlier model output contained no completed review and was discarded.
Shared local Cargo targets also caused cross-worktree test reuse; that evidence
was discarded and replaced with isolated clean-package verification above.

M5 provenance: the mellum percentile scaffold was partially useful and adopted
for the bounded percentile helper. A separate qwen3-coder-next-80b checklist
was consulted; its suggested `paste_method` field was outside the event/report
contract and was not adopted.

## Scope

Refs #163. This PR does not close the issue: signed-app visible-text arrival,
Bluetooth versus built-in microphone comparison, Metal contention, fallback
accuracy, and model-choice acceptance remain separate physical/measurement
gates.
