### PR TITLE
fix: bind personal glossary aliases to explicit language profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ sagascript config set language sv
 sagascript config get hotkey
 sagascript config path
 
-# Manage the external personal dictionary
+# Manage the external personal dictionary (global entries are hint-only)
 sagascript glossary path
-sagascript glossary add OpenRouter --alias 'open router'
+sagascript glossary add OpenRouter
 
 # Use one shortcut for English and another for Swedish
 sagascript config profiles create swedish --name Swedish --hotkey 'Option+Space' --language sv
 sagascript config profiles list
+# Enable deterministic aliases only in the explicit-language profile
+sagascript glossary add OpenRouter --alias 'open router' --profile swedish
 
 # Generate shell completions
 sagascript completions zsh > ~/.zfunc/_sagascript

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,10 @@ identical.
 
 The JSON file contains application settings and dictation profiles. The plain
 text glossary files contain one dictionary entry per line. `glossary.txt` is
-global; `glossaries/<profile-id>.txt` is combined only with that profile.
+the legacy global hint source; `glossaries/<profile-id>.txt` is used for
+deterministic aliases only when that known profile with an explicit language is
+selected. Global aliases remain stored, visible, and editable, but are
+hint-only. No aliases are assigned automatically after language detection.
 
 Use the CLI to discover the effective paths rather than duplicating the
 resolution rules in scripts:
@@ -35,6 +38,13 @@ sagascript config path
 sagascript glossary path
 sagascript glossary path --profile swedish
 ```
+
+Use the global file for decoder hints, or pass `--profile ID` to manage a
+profile-scoped dictionary whose explicit aliases can correct that profile's
+transcript. A non-empty one-run `--hint`/`--prompt` replaces the saved global
+hint text and is itself hint-only; empty or whitespace-only input keeps the
+saved global hints. Entries are not reassigned between scopes, deleted, or
+automatically assigned a profile/language.
 
 The GUI and CLI watch and update the same files. Atomic writes preserve
 user-managed symlinks, so the files can be checked into a dotfiles repository.

--- a/docs/glossary-scoping-decision.md
+++ b/docs/glossary-scoping-decision.md
@@ -1,0 +1,103 @@
+# Personal dictionary scope (#150)
+
+Decision, 2026-09-06: reuse explicit-language profile dictionaries. Do not add
+a competing language-section grammar or infer language metadata for old aliases.
+
+## Evaluation and baseline
+
+At6cedf58, global `initial_prompt`/`glossary.txt` and a selected profile dictionary
+are concatenated before parsing. `merge = merch` in global scope therefore
+authorizes the same deterministic replacement for Swedish and English live
+profiles, CLI record and batch. GUI file transcription uses the global or
+one-run prompt only, despite earlier documentation suggesting profile parity.
+Existing profile aliases are already restricted to an explicit-language profile;
+unknown/Auto profile dictionaries are ignored. Two profiles may share a language
+but need different terminology, so automatically choosing by detected language
+would be ambiguous. Cross-language examples also include Swedish mishearings of
+English product names and a preferred technical term colliding with ordinary
+English words. Model recognition and deterministic postprocessing are distinct:
+this change prevents automatic replacement leakage, not all decoder hint bias.
+
+The regression suite must first reproduce the global Swedish/English collision,
+then cover all effective-source consumers with no models or audio. Existing
+matcher guarantees (whole terms/phrases, Unicode case equivalence, longest-first,
+non-cascading, ambiguity rejection and fragment boundaries) remain authoritative.
+
+## Chosen contract
+
+- Global dictionary is hint-only. Parse legacy entries and use their existing
+  decoder prompt (preferred canonical terms), not their alias mappings, when
+  composing an effective transcription glossary. Plain terms retain their hints.
+- Only the selected known, non-Auto profile contributes deterministic aliases.
+  Profiles of the same language remain independent. No selected profile means
+  no deterministic aliases, including batch Auto after language detection.
+  Unknown language/profile never selects a fallback alias dictionary.
+- Explicit one-run prompt, when nonempty, replaces the global hint source, not
+  the selected profile. It is also hint-only. To disable profile aliases, select
+  no profile. Empty/whitespace one-run input keeps the normal saved global hints.
+- No stored text is rewritten/deleted or automatically assigned to a language.
+  Old global aliases become inactive replacements but remain visible/editable
+  and continue supplying their preferred terms as hints. Users explicitly copy
+  desired entries into a language profile. Existing profile dictionaries retain
+  their explicit scope. Surface the global hint-only rule in UI and CLI help.
+- Changing the language of a profile with a nonempty dictionary is rejected
+  before mutation. This includes the legacy top-level language setter/default
+  profile path. Clear or move the dictionary explicitly first. Removed-profile
+  dictionaries remain retained/reserved by the existing persistence rules.
+  Reset-all validates its proposed default profile before mutation and cannot
+  reactivate an orphaned default dictionary or change its language implicitly.
+- Conflicting aliases inside the effective selected source remain fail-closed;
+  no new scope overrides or cascading rewriting. Storage is still plain global
+  glossary.txt plus existing glossaries/<profile-id>.txt, not a new format.
+
+## CLI and GUI parity
+
+CLI already has glossary path/list/add/remove/clear/suggest --profile ID and
+record/transcribe --profile ID. Preserve that inventory, reject unknown/Auto
+profiles before audio/model/file work, and route effective source composition
+through the shared Settings helper rather than parsing raw global text.
+
+Settings Personal dictionary gets a scope selector: Global hints, or each
+explicit-language profile. Editing a profile saves through a validated
+set_profile_glossary command using the existing atomic settings store. Global
+and profile text remain separately visible. Leaving an edited field saves only
+the scope that was edited; changing the scope never copies text into another
+dictionary. GUI saves include the original per-scope source as a compare-and-set
+baseline. Concurrent changes to that same file reject the save atomically;
+the typed draft is retained with visible conflict guidance. Clean fields follow
+settings reloads. Unrelated dictionary changes do not block a save.
+
+GUI file transcription gets an optional profile selector. Explicit profile
+selection fixes its language and dictionary together; no profile uses the saved
+default language plus hint-only global prompt, not a previously active hotkey
+profile's transient language. This keeps the displayed scope and backend in
+agreement. Language/model/dictionary are snapshotted before file decoding. The one-run hint field
+uses the same composition rule as CLI. Record/live already pass their active
+profile. Teach's existing CLI/backend profile behavior remains scoped; do not
+restore the removed Teach tab.
+
+## Verification and rollout
+
+### Migration note for users
+
+Your global glossary remains stored and editable. Plain terms still act as
+local Whisper hints. An old global entry such as `merge = merch` now supplies
+the preferred term as a hint, but no longer authorizes automatic replacement.
+
+To enable that replacement for Swedish, copy the entry into your Swedish
+profile dictionary in Settings, or use the glossary CLI with `--profile ID`.
+An English profile without that alias will not apply this dictionary replacement.
+Alias scope is never inferred automatically; no files are deleted and this
+change introduces no model downloads or cloud processing.
+
+Run model-free red/green collisions, original plain-hint equivalence, preserved
+legacy storage, nonempty language-change guard (no partial mutation), unknown
+and Auto scope, per-profile isolation, one-run prompt and GUI/CLI file parity,
+Unicode/phrase/segment-boundary/ambiguity tests. Run all workspace checks plus
+frontend checks and visual inspection, actual independent Claude review and
+all platform CI. No model defaults, downloads, cloud or recordings are changed.
+
+This is an intentional fail-closed change in legacy unscoped replacement
+behavior. Release notes must explain migration before users test R2. Reverting
+the code restores prior global replacements; dictionary text remains intact,
+but that rollback reintroduces the cross-language risk. Prefer fixing forward.

--- a/docs/personal-glossary.md
+++ b/docs/personal-glossary.md
@@ -1,22 +1,27 @@
 # Personal glossary architecture
 
 Sagascript keeps the legacy `initial_prompt` setting as a backward-compatible
-in-memory interface for vocabulary guidance. Its persisted source is the
-human-editable `glossary.txt` file in the XDG configuration directory. Existing
-embedded comma- or newline-separated terms are migrated and continue to be
-passed to Whisper unchanged.
+interface for vocabulary guidance. Its persisted source is the human-editable
+`glossary.txt` file in the XDG configuration directory. Existing embedded
+comma- or newline-separated terms remain stored and continue to be passed to
+Whisper as decoder hints; global aliases are no longer deterministic
+replacements.
 
-New entries learned through **Teach Sagascript** are stored in
-`glossaries/<profile-id>.txt`. At transcription time, the global dictionary is
-combined with only the active profile's entries. Conflicting aliases still fail
-closed. This prevents a correction learned for one language/profile from
-silently rewriting another profile's output.
+Entries reviewed through the CLI `glossary suggest` training workflow (and the
+underlying backend suggestion support) are stored in
+`glossaries/<profile-id>.txt`. The former GUI **Teach Sagascript** tab is not
+currently exposed. At transcription time, only a selected known profile with
+an explicit non-Auto language contributes deterministic aliases.
+The global dictionary and a one-run prompt remain hint-only; no profile means
+no deterministic aliases, including after Auto language detection. Conflicting
+aliases still fail closed. This prevents a correction learned for one
+language/profile from silently rewriting another profile's output.
 
 Removing a profile makes its scoped entries inactive but does not silently
 delete the user's vocabulary. Its old profile ID remains reserved, preventing
 a later profile from accidentally reactivating those aliases.
 
-An entry may optionally authorize deterministic correction:
+A profile-scoped entry may optionally authorize deterministic correction:
 
 ```text
 OpenRouter = open router | open vrouter
@@ -25,13 +30,15 @@ Cloudflare = cloud flare
 ```
 
 The text to the left is the canonical output. Text to the right contains exact
-aliases separated by `|`. Only entries with explicit aliases can rewrite a
-transcript. This keeps arbitrary prose and legacy prompts hint-only.
+aliases separated by `|`. Only entries with explicit aliases in the selected
+explicit-language profile can rewrite a transcript. Global entries, one-run
+prompt text, arbitrary prose, and legacy prompts remain hint-only.
 
 ## Pipeline
 
-1. Parse the persisted dictionary in `sagascript-core`.
-2. Strip aliases from the decoder prompt so Whisper sees only preferred terms.
+1. Parse the persisted global and profile sources in `sagascript-core`.
+2. Keep global and one-run terms as decoder hints; strip aliases from the
+   decoder prompt so Whisper sees preferred terms.
 3. Transcribe locally as before.
 4. Find case-insensitive, whole-word or whole-phrase alias matches in the raw
    transcript. Resolve longest matches first against the original text.
@@ -45,14 +52,29 @@ additional confidence-gated one-edit correction for plain single-word hints.
 
 ## Interfaces
 
-- **Settings → Personal dictionary** edits the persistent source.
-- **Teach** records locally, keeps raw and effective transcripts ephemeral,
-  compares the effective transcript with the user's correction, and applies
-  only explicitly reviewed candidates to the selected profile.
-- **Transcribe → Extra context for this file** remains a one-run override.
+- **Settings → Personal dictionary** edits the persistent source through a
+  Global hints scope or a selected explicit-language profile scope. The global
+  file remains visible and editable; clearing or migrating it is not required
+  to disable its aliases.
+  If that same dictionary changes through the CLI while you are editing, the
+  GUI rejects the stale save and preserves your draft. Copy your edits, then
+  switch away and reselect the scope to load the current stored text before
+  reconciling them. An unrelated profile's changes do not block your save.
+- The CLI `glossary suggest` workflow records/transcribes locally, keeps raw and
+  effective transcripts ephemeral, compares the effective transcript with the
+  user's correction, and applies only explicitly reviewed candidates to the
+  selected profile. The former GUI Teach tab is not part of the current
+  surface.
+- **Transcribe → Profile (optional)** selects the file's language and profile
+  dictionary together. With no profile, the saved/default language is used and
+  the global dictionary remains hint-only.
+- **Transcribe → Extra context for this file** remains a one-run, hint-only
+  override. It replaces the saved global hint source but never activates
+  global aliases; a selected profile's aliases remain in scope.
 - `sagascript glossary path [--profile ID]` prints the exact external file.
 - `sagascript glossary list|add|remove|clear [--profile ID]` manages either the
-  legacy global dictionary or one profile.
+  legacy global dictionary or one profile. Omitting `--profile` stores global
+  hint terms; deterministic aliases require a known explicit-language profile.
 - `sagascript glossary suggest training.wav --corrected corrected.txt --profile ID`
   transcribes audio/video locally and prints conservative candidates without
   writing. A `.txt` or `.md` transcript is also accepted. Add `--apply` to
@@ -66,7 +88,8 @@ additional confidence-gated one-edit correction for plain single-word hints.
   from the process working directory. While the override is active, Sagascript
   does not inspect or migrate legacy settings. This is useful for automation,
   end-to-end tests, and disposable training profiles.
-- `sagascript config set initial_prompt ...` remains supported for scripts.
+- `sagascript config set initial_prompt ...` remains supported for scripts as a
+  global decoder hint source; it does not activate global aliases.
 
 The CLI exposes the complete review workflow without requiring an interactive
 prompt. Run `glossary suggest` as a dry run, then either apply every displayed

--- a/scripts/test-language-glossary.mjs
+++ b/scripts/test-language-glossary.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const settingsSource = await readFile(
+  new URL("../src/lib/Settings.svelte", import.meta.url),
+  "utf8",
+);
+const apiSource = await readFile(
+  new URL("../src/lib/api.ts", import.meta.url),
+  "utf8",
+);
+
+test("profile glossary API preserves the validated camelCase command payload", () => {
+  assert.match(
+    apiSource,
+    /export async function setProfileGlossary\(profileId: string, source: string, expectedSource\?: string\): Promise<void> \{\s*return invoke\("set_profile_glossary", \{ profileId, source, expectedSource \}\);/,
+  );
+  assert.match(
+    apiSource,
+    /export async function setInitialPrompt\(prompt: string, expectedSource\?: string\): Promise<void> \{\s*return invoke\("set_initial_prompt", \{ prompt, expectedSource \}\);/,
+  );
+});
+
+test("file transcription carries an optional profile without changing no-profile behavior", () => {
+  assert.match(apiSource, /options\?: \{ prompt\?: string; diarize\?: boolean; profileId\?: string \}/);
+  assert.match(apiSource, /profileId: options\?\.profileId \?\? null/);
+  assert.match(settingsSource, /const profileId = selectedTranscribeProfile\(\)\?\.id/);
+  assert.match(settingsSource, /profileId: profileId \?\? undefined/);
+  assert.match(settingsSource, /No profile \(use selected language\)/);
+});
+
+test("dictionary scope exposes only explicit profiles and keeps migration guidance visible", () => {
+  assert.match(settingsSource, /function explicitProfiles\(source: Settings \| null = settings\)/);
+  assert.match(settingsSource, /profile\.language !== "auto"/);
+  assert.match(settingsSource, /let glossaryScopeId: string = \$state\(""\)/);
+  assert.match(settingsSource, /<select id="dictionary-scope" value=\{glossaryScopeId\} onchange=\{onGlossaryScopeChange\}>/);
+  assert.match(settingsSource, /<option value="">Global hints<\/option>/);
+  assert.match(settingsSource, /Global entries are hint-only and remain stored/);
+  assert.match(settingsSource, /copy an entry into the explicit-language profile/);
+});
+
+test("a real profile named global does not collide with the global hints scope", () => {
+  assert.match(settingsSource, /scopeId === ""/);
+  assert.doesNotMatch(settingsSource, /profile\.id\s*!==\s*"global"/);
+  assert.match(settingsSource, /profileForId\(scopeId, source\)/);
+});
+
+test("scope switching is local and stale saves cannot overwrite a newer scope", () => {
+  const switchStart = settingsSource.indexOf("function onGlossaryScopeChange");
+  const switchEnd = settingsSource.indexOf("\n  }", switchStart);
+  assert.ok(switchStart >= 0 && switchEnd > switchStart);
+  const switchSource = settingsSource.slice(switchStart, switchEnd);
+  assert.doesNotMatch(switchSource, /setInitialPrompt|setProfileGlossary|applySetting/);
+  assert.match(settingsSource, /let glossaryScopeGeneration = 0/);
+  assert.match(settingsSource, /generation !== glossaryScopeGeneration[\s\S]*scopeId !== glossaryScopeId[\s\S]*draftGeneration !== glossaryDraftGeneration/);
+  assert.match(settingsSource, /!conflict[\s\S]*glossaryDraft = glossarySourceForScope/);
+});
+
+test("clean scopes follow persisted refreshes while dirty and newer drafts survive old failures", () => {
+  assert.match(settingsSource, /let lastStoredGlossarySources: Record<string, string> = \{\}/);
+  assert.match(settingsSource, /const previousStored = lastStoredGlossarySources\[currentScope\]/);
+  assert.match(settingsSource, /glossaryDraft === previousStored/);
+  assert.match(settingsSource, /lastStoredGlossarySources\[currentScope\] = currentStored/);
+  assert.match(settingsSource, /let glossaryDraftGeneration = 0/);
+  assert.match(settingsSource, /glossaryDraftGeneration \+= 1/);
+  assert.match(settingsSource, /const draftGeneration = glossaryDraftGeneration/);
+  assert.match(settingsSource, /draftGeneration !== glossaryDraftGeneration[\s\S]*return;/);
+});
+
+test("dictionary saves use the edit baseline and preserve concurrent conflicts", () => {
+  assert.match(settingsSource, /let glossaryEditBaseline: \{ scopeId: string; source: string; generation: number \} \| null = null/);
+  assert.match(settingsSource, /const editBaseline = glossaryEditBaseline/);
+  assert.match(settingsSource, /editBaseline\.generation <= draftGeneration/);
+  assert.match(settingsSource, /setInitialPrompt\(value, expectedSource\)/);
+  assert.match(settingsSource, /setProfileGlossary\(scopeId, value, expectedSource\)/);
+  assert.match(settingsSource, /async function refreshDictionaryAfterConflict\(primaryError: string\)/);
+  assert.match(settingsSource, /settings = await getSettings\(\);[\s\S]*settingsError = primaryError/);
+  assert.match(settingsSource, /const saveError = \{ value: "" \};/);
+  assert.match(settingsSource, /const conflict = saveError\.value\.startsWith\(dictionaryConflictPrefix\)/);
+  assert.match(settingsSource, /glossaryEditBaseline === editBaseline/);
+  assert.match(settingsSource, /glossaryEditBaseline = \{ \.\.\.editBaseline, source: value \}/);
+  assert.match(settingsSource, /if \(saved\) \{[\s\S]*glossaryEditBaseline = null;/);
+  assert.match(settingsSource, /!conflict/);
+  assert.match(settingsSource, /if \(settingsError\.startsWith\(dictionaryConflictPrefix\)\) settingsError = ""/);
+  assert.match(settingsSource, /This dictionary changed elsewhere\. Your draft is preserved[\s\S]*close and reopen Settings/);
+  assert.match(settingsSource, /let orphanGlossaryDraft: \{ scopeId: string; draft: string \} \| null = \$state\(null\)/);
+  assert.match(settingsSource, /Unsaved draft for removed profile/);
+  assert.match(settingsSource, /it is never saved automatically into Global hints/);
+});
+
+test("selected profile fixes the file language and dictionary together", () => {
+  assert.match(settingsSource, /languageLabel\(transcribeLanguage\(\)\)/);
+  assert.match(settingsSource, /return selectedTranscribeProfile\(\)\?\.language \?\? settings\?\.language \?\? "auto"/);
+  assert.match(settingsSource, /This profile fixes the file language and uses its personal dictionary/);
+  assert.match(settingsSource, /Temporary hint-only context for this import/);
+});

--- a/scripts/test-language-glossary.mjs
+++ b/scripts/test-language-glossary.mjs
@@ -53,8 +53,8 @@ test("scope switching is local and stale saves cannot overwrite a newer scope", 
   const switchSource = settingsSource.slice(switchStart, switchEnd);
   assert.doesNotMatch(switchSource, /setInitialPrompt|setProfileGlossary|applySetting/);
   assert.match(settingsSource, /let glossaryScopeGeneration = 0/);
-  assert.match(settingsSource, /generation !== glossaryScopeGeneration[\s\S]*scopeId !== glossaryScopeId[\s\S]*draftGeneration !== glossaryDraftGeneration/);
-  assert.match(settingsSource, /!conflict[\s\S]*glossaryDraft = glossarySourceForScope/);
+  assert.match(settingsSource, /function isCurrentGlossaryRequest\(request: GlossarySaveRequest\)[\s\S]*request\.generation === glossaryScopeGeneration[\s\S]*request\.scopeId === glossaryScopeId[\s\S]*request\.draftGeneration === glossaryDraftGeneration/);
+  assert.doesNotMatch(settingsSource, /else if \(!conflict && settings\)[\s\S]*glossaryDraft = glossarySourceForScope/);
 });
 
 test("clean scopes follow persisted refreshes while dirty and newer drafts survive old failures", () => {
@@ -64,8 +64,9 @@ test("clean scopes follow persisted refreshes while dirty and newer drafts survi
   assert.match(settingsSource, /lastStoredGlossarySources\[currentScope\] = currentStored/);
   assert.match(settingsSource, /let glossaryDraftGeneration = 0/);
   assert.match(settingsSource, /glossaryDraftGeneration \+= 1/);
-  assert.match(settingsSource, /const draftGeneration = glossaryDraftGeneration/);
-  assert.match(settingsSource, /draftGeneration !== glossaryDraftGeneration[\s\S]*return;/);
+  assert.match(settingsSource, /draftGeneration: glossaryDraftGeneration/);
+  assert.match(settingsSource, /let requestIsCurrent\s*=\s*[\s\S]*draftGeneration === glossaryDraftGeneration/);
+  assert.match(settingsSource, /if \(!requestIsCurrent\) return;/);
 });
 
 test("dictionary saves use the edit baseline and preserve concurrent conflicts", () => {
@@ -74,19 +75,46 @@ test("dictionary saves use the edit baseline and preserve concurrent conflicts",
   assert.match(settingsSource, /editBaseline\.generation <= draftGeneration/);
   assert.match(settingsSource, /setInitialPrompt\(value, expectedSource\)/);
   assert.match(settingsSource, /setProfileGlossary\(scopeId, value, expectedSource\)/);
-  assert.match(settingsSource, /async function refreshDictionaryAfterConflict\(primaryError: string\)/);
+  assert.match(settingsSource, /async function refreshDictionaryAfterConflict\(primaryError: string, request: GlossarySaveRequest\)/);
   assert.match(settingsSource, /settings = await getSettings\(\);[\s\S]*settingsError = primaryError/);
   assert.match(settingsSource, /const saveError = \{ value: "" \};/);
   assert.match(settingsSource, /const conflict = saveError\.value\.startsWith\(dictionaryConflictPrefix\)/);
   assert.match(settingsSource, /glossaryEditBaseline === editBaseline/);
   assert.match(settingsSource, /glossaryEditBaseline = \{ \.\.\.editBaseline, source: value \}/);
   assert.match(settingsSource, /if \(saved\) \{[\s\S]*glossaryEditBaseline = null;/);
-  assert.match(settingsSource, /!conflict/);
-  assert.match(settingsSource, /if \(settingsError\.startsWith\(dictionaryConflictPrefix\)\) settingsError = ""/);
+  assert.match(settingsSource, /settingsError = saved \? "" : saveError\.value/);
+  assert.match(settingsSource, /if \(previousConflict\) \{[\s\S]*settingsError = ""/);
   assert.match(settingsSource, /This dictionary changed elsewhere\. Your draft is preserved[\s\S]*close and reopen Settings/);
-  assert.match(settingsSource, /let orphanGlossaryDraft: \{ scopeId: string; draft: string \} \| null = \$state\(null\)/);
-  assert.match(settingsSource, /Unsaved draft for removed profile/);
-  assert.match(settingsSource, /it is never saved automatically into Global hints/);
+  assert.match(settingsSource, /type RecoveredGlossaryDraft = \{ scopeId: string; draft: string; conflicted: boolean \}/);
+  assert.match(settingsSource, /let recoveredGlossaryDrafts: RecoveredGlossaryDraft\[\] = \$state\(\[\]\)/);
+  assert.match(settingsSource, /function rememberGlossaryRecovery\(scopeId: string, draft: string, conflicted = false\)/);
+  assert.match(settingsSource, /recovery\.scopeId === scopeId && recovery\.draft === draft/);
+  assert.match(settingsSource, /Unsaved draft.*glossaryScopeLabel\(recovery\.scopeId\)/s);
+  assert.match(settingsSource, /never saved or copied automatically into another dictionary/);
+});
+
+test("late saves preserve scoped drafts without replacing newer scope state", () => {
+  assert.match(settingsSource, /async function refreshDictionaryAfterConflict\(primaryError: string, request: GlossarySaveRequest\)/);
+  assert.match(settingsSource, /refreshDictionaryAfterConflict\(saveError\.value, request\)/);
+  assert.match(settingsSource, /if \(isCurrentGlossaryRequest\(request\)\) \{[\s\S]*glossaryConflictScopeId = request\.scopeId;/);
+  assert.match(settingsSource, /else \{\s*rememberGlossaryRecovery\(request\.scopeId, request\.value, true\);/);
+  assert.match(settingsSource, /function isCurrentGlossaryRequest\(request: GlossarySaveRequest\)/);
+  assert.match(settingsSource, /requestIsCurrent = isCurrentGlossaryRequest\(request\);/);
+  assert.match(settingsSource, /if \(!requestIsCurrent\) return;/);
+  assert.match(settingsSource, /const previousConflict = glossaryConflictScopeId === previousScope/);
+  assert.match(settingsSource, /rememberGlossaryRecovery\(previousScope, glossaryDraft, previousConflict\)/);
+  assert.match(settingsSource, /recoveredGlossaryDrafts as recovery \(recovery\.scopeId \+ "\\u0000" \+ recovery\.draft\)/);
+});
+
+test("clean unchanged blur does not invoke a dictionary save", () => {
+  assert.match(settingsSource, /if \(!editBaseline && value === \(lastStoredGlossarySources\[scopeId\] \?\? glossarySourceForScope\(scopeId\)\)\) return;/);
+  assert.match(settingsSource, /setProfileGlossary\(scopeId, value, expectedSource\), saveError, false/);
+});
+
+test("non-CAS dictionary failures retain the typed draft and baseline", () => {
+  assert.match(settingsSource, /settingsError = saved \? "" : saveError\.value/);
+  assert.doesNotMatch(settingsSource, /else if \(!conflict && settings\)[\s\S]*glossaryDraft = glossarySourceForScope/);
+  assert.match(settingsSource, /else if \(!saved && !requestIsCurrent\) \{\s*rememberGlossaryRecovery\(scopeId, value\);/);
 });
 
 test("selected profile fixes the file language and dictionary together", () => {

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -377,7 +377,9 @@ fn apply_setting_value(
 ) -> Result<(), DictationError> {
     match key {
         "language" => {
-            settings.set_legacy_language(parse_enum_value::<Language>(value, "language")?);
+            settings
+                .set_legacy_language(parse_enum_value::<Language>(value, "language")?)
+                .map_err(DictationError::SettingsError)?;
         }
         "whisper_model" => {
             settings.whisper_model = parse_enum_value::<WhisperModel>(value, "whisper_model")?;
@@ -429,35 +431,75 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
             eprintln!("Reset hotkey to {}", settings::store::load().hotkey);
             return Ok(());
         }
-        let settings = settings::store::update(|settings| match key {
+        let settings = settings::store::try_update(|settings| match key {
             "language" => settings.set_legacy_language(defaults.language),
-            "whisper_model" => settings.whisper_model = defaults.whisper_model,
-            "hotkey_mode" => settings.hotkey_mode = defaults.hotkey_mode,
-            "show_overlay" => settings.show_overlay = defaults.show_overlay,
-            "auto_paste" => settings.auto_paste = defaults.auto_paste,
-            "auto_select_model" => settings.auto_select_model = defaults.auto_select_model,
+            "whisper_model" => {
+                settings.whisper_model = defaults.whisper_model;
+                Ok(())
+            }
+            "hotkey_mode" => {
+                settings.hotkey_mode = defaults.hotkey_mode;
+                Ok(())
+            }
+            "show_overlay" => {
+                settings.show_overlay = defaults.show_overlay;
+                Ok(())
+            }
+            "auto_paste" => {
+                settings.auto_paste = defaults.auto_paste;
+                Ok(())
+            }
+            "auto_select_model" => {
+                settings.auto_select_model = defaults.auto_select_model;
+                Ok(())
+            }
             "hotkey" => unreachable!("hotkey reset handled transactionally above"),
-            "initial_prompt" => settings.initial_prompt = defaults.initial_prompt,
-            "beam_size" => settings.beam_size = defaults.beam_size,
-            "temperature_fallback" => settings.temperature_fallback = defaults.temperature_fallback,
-            "vad_enabled" => settings.vad_enabled = defaults.vad_enabled,
+            "initial_prompt" => {
+                settings.initial_prompt = defaults.initial_prompt;
+                Ok(())
+            }
+            "beam_size" => {
+                settings.beam_size = defaults.beam_size;
+                Ok(())
+            }
+            "temperature_fallback" => {
+                settings.temperature_fallback = defaults.temperature_fallback;
+                Ok(())
+            }
+            "vad_enabled" => {
+                settings.vad_enabled = defaults.vad_enabled;
+                Ok(())
+            }
             _ => unreachable!(),
         })
         .map_err(DictationError::SettingsError)?;
         eprintln!("Reset {key} to {}", get_setting_value(&settings, key));
     } else {
-        settings::store::update(|current| {
-            let initial_prompt = std::mem::take(&mut current.initial_prompt);
-            let profile_glossaries = std::mem::take(&mut current.profile_glossaries);
-            *current = Settings {
-                initial_prompt,
-                profile_glossaries,
-                ..Default::default()
-            };
+        settings::store::try_update(|current| {
+            reset_all_settings(current)?;
+            Ok(())
         })
         .map_err(DictationError::SettingsError)?;
         eprintln!("All application settings reset to defaults; personal dictionaries preserved");
     }
+    Ok(())
+}
+
+fn reset_all_settings(current: &mut Settings) -> Result<(), String> {
+    let defaults = Settings::default();
+    let mut validation = current.clone();
+    validation.replace_hotkey_profiles(vec![HotkeyProfile::legacy_default(
+        defaults.hotkey.clone(),
+        defaults.language,
+    )])?;
+
+    let initial_prompt = std::mem::take(&mut current.initial_prompt);
+    let profile_glossaries = std::mem::take(&mut current.profile_glossaries);
+    *current = Settings {
+        initial_prompt,
+        profile_glossaries,
+        ..defaults
+    };
     Ok(())
 }
 
@@ -736,6 +778,144 @@ mod tests {
     fn parse_enum_value_invalid_language() {
         let result = parse_enum_value::<Language>("de", "language");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn language_change_with_profile_dictionary_is_rejected_without_mutation() {
+        let mut settings = Settings::default();
+        settings.hotkey_profiles = vec![HotkeyProfile {
+            id: "default".to_string(),
+            name: "Default".to_string(),
+            shortcut: settings.hotkey.clone(),
+            language: Language::Swedish,
+        }];
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+        let before = settings.clone();
+
+        let error = apply_setting_value(&mut settings, "language", "en").unwrap_err();
+
+        assert!(error.to_string().contains("personal dictionary"));
+        assert_eq!(settings.language, before.language);
+        assert_eq!(settings.hotkey_profiles, before.hotkey_profiles);
+        assert_eq!(settings.profile_glossaries, before.profile_glossaries);
+    }
+
+    #[test]
+    fn reset_all_without_dictionaries_uses_defaults_and_preserves_global_source() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            initial_prompt: "Codex".to_string(),
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "Option+Space".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+
+        reset_all_settings(&mut settings).unwrap();
+
+        assert_eq!(settings.language, Settings::default().language);
+        assert!(settings.hotkey_profiles.is_empty());
+        assert_eq!(settings.initial_prompt, "Codex");
+        assert!(settings.profile_glossaries.is_empty());
+    }
+
+    #[test]
+    fn reset_all_preserves_same_language_active_default_dictionary() {
+        let mut settings = Settings {
+            hotkey_profiles: vec![HotkeyProfile::legacy_default(
+                "Option+Space".to_string(),
+                Language::English,
+            )],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+
+        reset_all_settings(&mut settings).unwrap();
+
+        assert!(settings.hotkey_profiles.is_empty());
+        assert_eq!(settings.language, Language::English);
+        assert_eq!(
+            settings.profile_glossaries.get("default").map(String::as_str),
+            Some("merge = merch")
+        );
+    }
+
+    #[test]
+    fn reset_all_rejects_default_language_change_with_active_dictionary_atomically() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            hotkey_profiles: vec![HotkeyProfile::legacy_default(
+                "Option+Space".to_string(),
+                Language::Swedish,
+            )],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+        let before = settings.clone();
+
+        let error = reset_all_settings(&mut settings).unwrap_err();
+
+        assert!(error.contains("personal dictionary"));
+        assert_eq!(settings.language, before.language);
+        assert_eq!(settings.hotkey_profiles, before.hotkey_profiles);
+        assert_eq!(settings.profile_glossaries, before.profile_glossaries);
+    }
+
+    #[test]
+    fn reset_all_keeps_removed_profile_dictionary_inactive() {
+        let mut settings = Settings {
+            hotkey_profiles: vec![HotkeyProfile::legacy_default(
+                "Option+Space".to_string(),
+                Language::English,
+            )],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("removed".to_string(), "merge = merch".to_string());
+
+        reset_all_settings(&mut settings).unwrap();
+
+        assert!(settings.hotkey_profiles.is_empty());
+        assert_eq!(
+            settings.profile_glossaries.get("removed").map(String::as_str),
+            Some("merge = merch")
+        );
+        assert_eq!(settings.effective_glossary_source(Some("removed")), "");
+    }
+
+    #[test]
+    fn reset_all_rejects_orphan_default_dictionary_atomically() {
+        let mut settings = Settings {
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "Option+Space".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+        let before = settings.clone();
+
+        let error = reset_all_settings(&mut settings).unwrap_err();
+
+        assert!(error.contains("inactive personal dictionary"));
+        assert_eq!(settings.language, before.language);
+        assert_eq!(settings.hotkey_profiles, before.hotkey_profiles);
+        assert_eq!(settings.initial_prompt, before.initial_prompt);
+        assert_eq!(settings.profile_glossaries, before.profile_glossaries);
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -871,6 +871,25 @@ mod tests {
     }
 
     #[test]
+    fn reset_all_rejects_implicit_swedish_default_dictionary_atomically() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            hotkey_profiles: Vec::new(),
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".into(), "merge = merch".into());
+        let before = settings.clone();
+        let error = reset_all_settings(&mut settings).unwrap_err();
+        assert!(error.contains("personal dictionary"));
+        assert_eq!(settings.language, before.language);
+        assert_eq!(settings.hotkey_profiles, before.hotkey_profiles);
+        assert_eq!(settings.profile_glossaries, before.profile_glossaries);
+        assert_eq!(settings.initial_prompt, before.initial_prompt);
+    }
+
+    #[test]
     fn reset_all_keeps_removed_profile_dictionary_inactive() {
         let mut settings = Settings {
             hotkey_profiles: vec![HotkeyProfile::legacy_default(

--- a/src-tauri/crates/sagascript-cli/src/glossary.rs
+++ b/src-tauri/crates/sagascript-cli/src/glossary.rs
@@ -12,7 +12,7 @@ use sagascript_core::transcription::{
     WhisperBackend,
 };
 
-use crate::transcribe::model_id_string;
+use crate::transcribe::{effective_glossary, model_id_string};
 
 #[derive(Args)]
 pub struct GlossaryArgs {
@@ -22,19 +22,23 @@ pub struct GlossaryArgs {
 
 #[derive(Subcommand)]
 pub enum GlossaryAction {
-    /// Print the external personal-dictionary file path
+    /// Print the external personal-dictionary file path. The global file is
+    /// legacy storage and supplies hint terms; use `--profile ID` for aliases.
     Path {
         /// Print this profile's dictionary path instead of the global path
         #[arg(long)]
         profile: Option<String>,
     },
-    /// List canonical terms and their explicit aliases
+    /// List canonical terms and their explicit aliases. The legacy global
+    /// dictionary is retained and displayed, but its aliases are hint-only;
+    /// deterministic replacement requires `--profile ID`.
     List {
         /// Show entries saved only for this dictation profile
         #[arg(long)]
         profile: Option<String>,
     },
-    /// Add a term or merge aliases into an existing term
+    /// Add a term or merge aliases into an existing term. Global aliases are
+    /// retained for compatibility but are hint-only at transcription time.
     Add {
         /// Preferred spelling written to the transcript
         term: String,
@@ -45,14 +49,16 @@ pub enum GlossaryAction {
         #[arg(long)]
         profile: Option<String>,
     },
-    /// Remove a canonical term and all of its aliases
+    /// Remove a canonical term and all of its aliases from the selected scope
     Remove {
         term: String,
         /// Remove from this dictation profile instead of the legacy global dictionary
         #[arg(long)]
         profile: Option<String>,
     },
-    /// Remove every entry from the selected personal dictionary
+    /// Remove every entry from the selected personal dictionary. Clearing the
+    /// global dictionary is optional migration cleanup; it is not required to
+    /// disable its aliases.
     Clear {
         /// Confirm destructive removal of the selected dictionary
         #[arg(long)]
@@ -203,7 +209,7 @@ fn suggest(
 
     let stored = settings::store::load();
     validate_learning_profile(&stored, profile)?;
-    let glossary = Glossary::parse(&stored.effective_glossary_source(Some(profile)));
+    let glossary = effective_glossary(&stored, Some(profile), None, None)?;
     let heard = load_training_input(heard_path, &stored, profile, &glossary)?;
     let suggestions = suggest_glossary_candidates(&heard, &corrected, &glossary);
 
@@ -216,7 +222,8 @@ fn suggest(
         let reviewed = suggestions.clone();
         settings::store::try_update(|latest| {
             validate_learning_profile(latest, profile).map_err(|error| error.to_string())?;
-            let effective = Glossary::parse(&latest.effective_glossary_source(Some(profile)));
+            let effective = effective_glossary(latest, Some(profile), None, None)
+                .map_err(|error| error.to_string())?;
             let current = suggest_glossary_candidates(&heard, &corrected, &effective);
             if current != reviewed {
                 return Err(
@@ -430,5 +437,18 @@ mod tests {
             .unwrap()
             .clear();
         assert_eq!(stored.profile_glossaries.get("removed").unwrap(), "");
+    }
+
+    #[test]
+    fn legacy_global_alias_remains_stored_but_is_hint_only() {
+        let stored = settings::Settings {
+            initial_prompt: "merge = merch".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(glossary_source(&stored, None).unwrap(), "merge = merch");
+        let effective = effective_glossary(&stored, None, None, None).unwrap();
+        assert_eq!(effective.correct_text("merch").0, "merch");
+        assert!(effective.decoder_prompt().is_some());
     }
 }

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -400,10 +400,10 @@ EXAMPLES:
     )]
     Config(config::ConfigArgs),
 
-    /// Manage the persistent personal dictionary used by live and batch transcription
+    /// Manage global hint terms and explicit profile-scoped aliases used by live and batch transcription
     #[command(
-        long_about = "Add preferred spellings and optional exact mishearings. Plain terms prime Whisper; aliases also authorize deterministic local corrections before output.",
-        after_long_help = "EXAMPLES:\n  sagascript glossary path\n  sagascript glossary path --profile swedish\n  sagascript glossary list\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter'\n  sagascript glossary add merge --alias merch --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish --apply\n  sagascript glossary remove OpenRouter\n  sagascript glossary clear --yes"
+        long_about = "Add preferred spellings and optional exact mishearings. Global and one-run terms prime Whisper as hint-only context; deterministic aliases require a selected known profile with an explicit language. No stored text is migrated or deleted.",
+        after_long_help = "EXAMPLES:\n  sagascript glossary path\n  sagascript glossary path --profile swedish\n  sagascript glossary list\n  sagascript glossary add OpenRouter\n  sagascript glossary add OpenRouter --alias 'open router' --alias 'open vrouter' --profile swedish\n  sagascript glossary add merge --alias merch --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish\n  sagascript glossary suggest heard.txt --corrected corrected.txt --profile swedish --apply\n  sagascript glossary remove OpenRouter --profile swedish\n  sagascript glossary clear --yes"
     )]
     Glossary(glossary::GlossaryArgs),
 

--- a/src-tauri/crates/sagascript-cli/src/record.rs
+++ b/src-tauri/crates/sagascript-cli/src/record.rs
@@ -13,8 +13,8 @@ use sagascript_core::transcription::model;
 use sagascript_core::transcription::{Glossary, TranscribeOptions, WhisperBackend};
 
 use super::transcribe::{
-    copy_to_clipboard, model_id_string, parse_language, resolve_effective_model, resolve_profile,
-    resolve_effective_prompt,
+    copy_to_clipboard, effective_glossary, model_id_string, parse_language,
+    resolve_effective_model, resolve_profile,
 };
 
 #[derive(Args)]
@@ -72,18 +72,16 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
         (None, None) => stored.language,
     };
     let save_only = args.output.is_some();
-    // Effective hint/prompt: --prompt-file, else --hint/--prompt, else the saved
-    // initial_prompt. Resolved up front so a bad --prompt-file fails before we
-    // spend time recording — but skipped entirely on the save-only path, which
-    // never transcribes, so `--output` isn't blocked by an unusable hint file.
-    let effective_prompt = if save_only {
-        None
+    // Resolve the effective source before model work or recording. Save-only
+    // output never transcribes, so it intentionally does not read a hint file.
+    let glossary = if save_only {
+        Glossary::parse("")
     } else {
-        let stored_prompt = stored.effective_glossary_source(args.profile.as_deref());
-        resolve_effective_prompt(
+        effective_glossary(
+            &stored,
+            args.profile.as_deref(),
             args.prompt.as_deref(),
             args.prompt_file.as_deref(),
-            &stored_prompt,
         )?
     };
 
@@ -160,7 +158,6 @@ pub fn run(args: RecordArgs) -> Result<(), DictationError> {
     let backend = WhisperBackend::new();
     backend.load_model(model)?;
 
-    let glossary = Glossary::parse(effective_prompt.as_deref().unwrap_or_default());
     let decoder_prompt = glossary.decoder_prompt();
     let prompt = decoder_prompt.as_deref();
     let opts = TranscribeOptions {

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -228,6 +228,25 @@ enum BatchItem {
 }
 
 pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
+    let stored = sagascript_core::settings::store::load();
+    let profile = args
+        .profile
+        .as_deref()
+        .map(|profile_id| resolve_profile(&stored, profile_id))
+        .transpose()?;
+    let language = match (&profile, &args.language) {
+        (Some(profile), _) => profile.language,
+        (None, Some(language)) => parse_language(language)?,
+        (None, None) => stored.language,
+    };
+
+    let glossary = effective_glossary(
+        &stored,
+        args.profile.as_deref(),
+        args.prompt.as_deref(),
+        args.prompt_file.as_deref(),
+    )?;
+
     let files = expand_inputs(&args.files, args.recursive)?;
     if files.is_empty() {
         return Err(DictationError::FileDecodeError(
@@ -245,18 +264,6 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
             "--diarize is only available when transcribing one file".to_string(),
         ));
     }
-
-    let stored = sagascript_core::settings::store::load();
-    let profile = args
-        .profile
-        .as_deref()
-        .map(|profile_id| resolve_profile(&stored, profile_id))
-        .transpose()?;
-    let language = match (&profile, &args.language) {
-        (Some(profile), _) => profile.language,
-        (None, Some(language)) => parse_language(language)?,
-        (None, None) => stored.language,
-    };
     let model = resolve_effective_model(
         args.model.as_deref(),
         language,
@@ -264,22 +271,13 @@ pub fn run(args: TranscribeArgs) -> Result<(), DictationError> {
         stored.whisper_model,
     )?;
 
-    // Resolve and validate this before decoding or loading a model: an invalid
-    // opt-in correction request should not spend time on transcription first.
-    let stored_prompt = stored.effective_glossary_source(args.profile.as_deref());
-    let effective_prompt = resolve_effective_prompt(
-        args.prompt.as_deref(),
-        args.prompt_file.as_deref(),
-        &stored_prompt,
-    )?;
-    let glossary = Glossary::parse(effective_prompt.as_deref().unwrap_or_default());
     let correction_vocabulary = if args.correct_hints {
-        effective_prompt.as_deref().ok_or_else(|| {
-            DictationError::SettingsError(
-                "--correct-hints requires a non-empty --hint/--prompt (or saved initial_prompt)"
+        if glossary.decoder_prompt().is_none() {
+            return Err(DictationError::SettingsError(
+                "--correct-hints requires a non-empty --hint/--prompt, saved initial_prompt, or selected profile dictionary"
                     .to_string(),
-            )
-        })?;
+            ));
+        }
         let vocabulary = glossary.single_word_terms();
         if vocabulary.is_empty() {
             return Err(DictationError::SettingsError(
@@ -1534,21 +1532,24 @@ pub fn resolve_effective_model(
     }
 }
 
-/// Resolves the effective initial prompt (a.k.a. the "hint") for a run, in
-/// precedence order:
-///   1. `--prompt-file` / `--hint-file` — the file's contents (trimmed;
-///      an empty or whitespace-only file yields no hint).
-///   2. `--hint` / `--prompt` — the inline string (an explicit empty string
-///      suppresses the hint and does *not* fall back to the saved setting).
-///   3. the saved `initial_prompt` setting (empty ⇒ no hint).
-///
-/// Returns `Ok(None)` when no source provides a non-empty prompt. Shared by
-/// `transcribe::run()` and `record::run()` so both surfaces prime the decoder
-/// identically — keep their call sites pointed here rather than re-deriving it.
-pub fn resolve_effective_prompt(
+/// Resolve a non-empty one-run hint and compose it through Settings' scoped
+/// glossary helper. The helper owns legacy-global hint-only behavior and
+/// selected explicit-profile aliases; CLI never parses those sources directly.
+pub(crate) fn effective_glossary(
+    stored: &Settings,
+    profile_id: Option<&str>,
     cli_prompt: Option<&str>,
     cli_prompt_file: Option<&Path>,
-    stored_initial_prompt: &str,
+) -> Result<Glossary, DictationError> {
+    let one_run_prompt = resolve_one_run_prompt(cli_prompt, cli_prompt_file)?;
+    let source =
+        stored.effective_glossary_source_with_prompt(profile_id, one_run_prompt.as_deref());
+    Ok(Glossary::parse(&source))
+}
+
+fn resolve_one_run_prompt(
+    cli_prompt: Option<&str>,
+    cli_prompt_file: Option<&Path>,
 ) -> Result<Option<String>, DictationError> {
     if let Some(path) = cli_prompt_file {
         let contents = std::fs::read_to_string(path).map_err(|e| {
@@ -1560,12 +1561,11 @@ pub fn resolve_effective_prompt(
         let trimmed = contents.trim();
         return Ok((!trimmed.is_empty()).then(|| trimmed.to_string()));
     }
-    if let Some(p) = cli_prompt {
-        // An explicit `--hint ""` means "no hint", not "use the saved setting".
-        return Ok((!p.is_empty()).then(|| p.to_string()));
-    }
-    let saved = stored_initial_prompt.trim();
-    Ok((!saved.is_empty()).then(|| saved.to_string()))
+    let Some(prompt) = cli_prompt else {
+        return Ok(None);
+    };
+    let trimmed = prompt.trim();
+    Ok((!trimmed.is_empty()).then(|| trimmed.to_string()))
 }
 
 pub fn parse_model(s: &str) -> Result<WhisperModel, DictationError> {
@@ -1991,38 +1991,22 @@ mod tests {
         assert_eq!(segments[0].text, " Grimner");
     }
 
-    // -- resolve_effective_prompt --
+    // -- resolve_one_run_prompt --
 
     #[test]
-    fn effective_prompt_cli_flag_wins_over_stored() {
-        let got = resolve_effective_prompt(Some("Notre Dame"), None, "saved vocab").unwrap();
+    fn one_run_prompt_inline_is_trimmed() {
+        let got = resolve_one_run_prompt(Some("  Notre Dame  "), None).unwrap();
         assert_eq!(got.as_deref(), Some("Notre Dame"));
     }
 
     #[test]
-    fn effective_prompt_falls_back_to_stored() {
-        let got = resolve_effective_prompt(None, None, "  saved vocab  ").unwrap();
-        // Stored value is trimmed.
-        assert_eq!(got.as_deref(), Some("saved vocab"));
+    fn one_run_prompt_empty_input_is_deferred_to_saved_settings() {
+        assert!(resolve_one_run_prompt(None, None).unwrap().is_none());
+        assert!(resolve_one_run_prompt(Some("   "), None).unwrap().is_none());
     }
 
     #[test]
-    fn effective_prompt_none_when_all_empty() {
-        assert!(resolve_effective_prompt(None, None, "").unwrap().is_none());
-        assert!(resolve_effective_prompt(None, None, "   ")
-            .unwrap()
-            .is_none());
-    }
-
-    #[test]
-    fn effective_prompt_explicit_empty_flag_suppresses_stored() {
-        // `--hint ""` means "no hint" — it must NOT fall through to the setting.
-        let got = resolve_effective_prompt(Some(""), None, "saved vocab").unwrap();
-        assert!(got.is_none());
-    }
-
-    #[test]
-    fn effective_prompt_file_wins_and_is_trimmed() {
+    fn one_run_prompt_file_wins_and_is_trimmed() {
         let dir = std::env::temp_dir();
         let path = dir.join(format!(
             "sagascript_hint_test_{}_{}.txt",
@@ -2031,15 +2015,15 @@ mod tests {
         ));
         std::fs::write(&path, "  Estrid, Grimnir\n").unwrap();
 
-        // File beats both the inline flag and the stored setting.
-        let got = resolve_effective_prompt(Some("inline"), Some(&path), "saved").unwrap();
+        // File beats the inline flag; saved settings are composed by the core helper.
+        let got = resolve_one_run_prompt(Some("inline"), Some(&path)).unwrap();
         assert_eq!(got.as_deref(), Some("Estrid, Grimnir"));
 
         std::fs::remove_file(&path).ok();
     }
 
     #[test]
-    fn effective_prompt_empty_file_yields_none() {
+    fn one_run_prompt_empty_file_is_deferred_to_saved_settings() {
         let dir = std::env::temp_dir();
         let path = dir.join(format!(
             "sagascript_hint_test_{}_{}.txt",
@@ -2048,17 +2032,103 @@ mod tests {
         ));
         std::fs::write(&path, "   \n\t").unwrap();
 
-        let got = resolve_effective_prompt(None, Some(&path), "saved").unwrap();
+        let got = resolve_one_run_prompt(None, Some(&path)).unwrap();
         assert!(got.is_none());
 
         std::fs::remove_file(&path).ok();
     }
 
     #[test]
-    fn effective_prompt_missing_file_errors() {
+    fn one_run_prompt_missing_file_errors() {
         let path = Path::new("/nonexistent/sagascript/hint/vocab.txt");
-        let err = resolve_effective_prompt(None, Some(path), "saved").unwrap_err();
+        let err = resolve_one_run_prompt(None, Some(path)).unwrap_err();
         assert!(matches!(err, DictationError::FileDecodeError(_)));
+    }
+
+    #[test]
+    fn scoped_glossary_keeps_global_aliases_hint_only_and_profiles_isolated() {
+        let mut settings = Settings {
+            initial_prompt: "merge = merch\nOpenRouter".to_string(),
+            hotkey_profiles: vec![
+                HotkeyProfile {
+                    id: "swedish".to_string(),
+                    name: "Swedish".to_string(),
+                    shortcut: "F13".to_string(),
+                    language: Language::Swedish,
+                },
+                HotkeyProfile {
+                    id: "english".to_string(),
+                    name: "English".to_string(),
+                    shortcut: "F14".to_string(),
+                    language: Language::English,
+                },
+            ],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("swedish".to_string(), "merge = merch".to_string());
+
+        let global = effective_glossary(&settings, None, None, None).unwrap();
+        assert_eq!(global.correct_text("merch").0, "merch");
+
+        let swedish = effective_glossary(&settings, Some("swedish"), None, None).unwrap();
+        assert_eq!(swedish.correct_text("merch").0, "merge");
+
+        let english = effective_glossary(&settings, Some("english"), None, None).unwrap();
+        assert_eq!(english.correct_text("merch").0, "merch");
+    }
+
+    #[test]
+    fn one_run_prompt_replaces_global_hint_but_keeps_profile_scope() {
+        let mut settings = Settings {
+            initial_prompt: "merge = merch".to_string(),
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "F13".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("swedish".to_string(), "fika = coffee".to_string());
+
+        let glossary = effective_glossary(
+            &settings,
+            Some("swedish"),
+            Some("  OpenRouter = router  "),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(glossary.correct_text("merch").0, "merch");
+        assert_eq!(glossary.correct_text("coffee").0, "fika");
+
+        let empty_override = effective_glossary(&settings, Some("swedish"), Some("  \n"), None)
+            .unwrap();
+        assert_eq!(empty_override.correct_text("merch").0, "merch");
+        assert_eq!(empty_override.correct_text("coffee").0, "fika");
+    }
+
+    #[test]
+    fn auto_or_missing_profile_never_infers_alias_scope() {
+        let mut settings = Settings {
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "F13".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("swedish".to_string(), "merge = merch".to_string());
+
+        let glossary = effective_glossary(&settings, None, None, None).unwrap();
+        assert_eq!(glossary.correct_text("merch").0, "merch");
     }
 
     // -- parse_language --

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{canonical_hotkey, validate_hotkey};
 
-use crate::download::DownloadIntegrity;
+use crate::{download::DownloadIntegrity, transcription::Glossary};
 
 #[cfg(target_os = "macos")]
 const WHISPER_CPP_REVISION: &str = "5359861c739e955e79d9a303bcbc70fb988958b1";
@@ -553,10 +553,28 @@ impl Default for Settings {
 
 impl Settings {
     /// Combine the legacy global dictionary with the selected profile's
-    /// private additions. Keeping the legacy value first preserves existing
-    /// decoder hints while the glossary matcher fails closed on conflicts.
+    /// private additions. The legacy source is hint-only: aliases from the
+    /// unscoped compatibility dictionary must not become replacements in an
+    /// explicitly selected language profile.
     pub fn effective_glossary_source(&self, profile_id: Option<&str>) -> String {
-        let global = self.initial_prompt.trim();
+        self.effective_glossary_source_with_prompt(profile_id, None)
+    }
+
+    /// Compose the glossary source for one transcription without mutating
+    /// stored settings. A non-empty one-run prompt replaces the saved global
+    /// hint source; the selected known, explicit-language profile remains the
+    /// only source of deterministic alias replacements.
+    pub fn effective_glossary_source_with_prompt(
+        &self,
+        profile_id: Option<&str>,
+        prompt: Option<&str>,
+    ) -> String {
+        let base_source = prompt
+            .filter(|candidate| !candidate.trim().is_empty())
+            .unwrap_or(self.initial_prompt.as_str());
+        let global = Glossary::parse(base_source)
+            .decoder_prompt()
+            .unwrap_or_default();
         let scoped_profile_id = profile_id.filter(|requested_id| {
             self.resolved_hotkey_profiles().iter().any(|profile| {
                 profile.id == **requested_id && profile.language != Language::Auto
@@ -568,11 +586,11 @@ impl Settings {
             .map(str::trim)
             .unwrap_or_default();
 
-        match (global.is_empty(), scoped.is_empty()) {
+        match (global.trim().is_empty(), scoped.is_empty()) {
             (true, true) => String::new(),
-            (false, true) => global.to_string(),
+            (false, true) => global,
             (true, false) => scoped.to_string(),
-            (false, false) => format!("{global}\n{scoped}"),
+            (false, false) => format!("{}\n{scoped}", global.trim()),
         }
     }
 
@@ -677,11 +695,31 @@ impl Settings {
             .find(|profile| canonical_hotkey(&profile.shortcut).ok().as_deref() == Some(target.as_str()))
     }
 
-    pub fn set_legacy_language(&mut self, language: Language) {
+    pub fn set_legacy_language(&mut self, language: Language) -> Result<(), String> {
+        let current_legacy_language = if self.hotkey_profiles.is_empty() {
+            Some(self.language)
+        } else {
+            self.hotkey_profiles
+                .iter()
+                .find(|profile| profile.id == "default")
+                .map(|profile| profile.language)
+        };
+        if current_legacy_language.is_some_and(|current| current != language)
+            && self
+                .profile_glossaries
+                .get("default")
+                .is_some_and(|source| !source.trim().is_empty())
+        {
+            return Err(
+                "Profile 'default' has a personal dictionary; clear it before changing the profile language"
+                    .to_string(),
+            );
+        }
         self.language = language;
         if let Some(profile) = self.hotkey_profiles.iter_mut().find(|profile| profile.id == "default") {
             profile.language = language;
         }
+        Ok(())
     }
 
     pub fn set_legacy_hotkey(&mut self, shortcut: String) {
@@ -1159,13 +1197,76 @@ mod tests {
 
         assert_eq!(
             settings.effective_glossary_source(Some("swedish")),
-            "Codex = code x\nmergea = mördsa"
+            "Codex\nmergea = mördsa"
         );
         assert_eq!(
             settings.effective_glossary_source(Some("english")),
-            "Codex = code x\nLovable = love a ball"
+            "Codex\nLovable = love a ball"
         );
-        assert_eq!(settings.effective_glossary_source(None), "Codex = code x");
+        assert_eq!(settings.effective_glossary_source(None), "Codex");
+    }
+
+    #[test]
+    fn global_aliases_are_hint_only_and_do_not_leak_between_profiles() {
+        let mut settings = Settings {
+            initial_prompt: "merge = merch".to_string(),
+            hotkey_profiles: vec![
+                HotkeyProfile {
+                    id: "swedish".to_string(),
+                    name: "Swedish".to_string(),
+                    shortcut: "Control+Shift+Space".to_string(),
+                    language: Language::Swedish,
+                },
+                HotkeyProfile {
+                    id: "english".to_string(),
+                    name: "English".to_string(),
+                    shortcut: "Control+Option+Space".to_string(),
+                    language: Language::English,
+                },
+            ],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("swedish".to_string(), "merge = merch".to_string());
+
+        let swedish = Glossary::parse(&settings.effective_glossary_source(Some("swedish")));
+        let english = Glossary::parse(&settings.effective_glossary_source(Some("english")));
+        assert_eq!(swedish.correct_text("merch").0, "merge");
+        assert_eq!(english.correct_text("merch").0, "merch");
+        assert_eq!(settings.effective_glossary_source(Some("english")), "merge");
+    }
+
+    #[test]
+    fn effective_glossary_deduplicates_global_and_profile_canonicals() {
+        let mut settings = Settings {
+            initial_prompt: "Codex = code x\nmerge = merch".to_string(),
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "Control+Shift+Space".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+        settings.profile_glossaries.insert(
+            "swedish".to_string(),
+            "merge = merch\nOpenRouter = open router".to_string(),
+        );
+
+        let glossary = Glossary::parse(&settings.effective_glossary_source(Some("swedish")));
+        assert_eq!(
+            glossary.single_word_terms(),
+            vec!["Codex", "merge", "OpenRouter"]
+        );
+        assert_eq!(
+            glossary.decoder_prompt().as_deref(),
+            Some("Codex, merge, OpenRouter")
+        );
+        assert_eq!(
+            glossary.correct_text("code x merch open router").0,
+            "code x merge OpenRouter"
+        );
     }
 
     #[test]
@@ -1197,11 +1298,49 @@ mod tests {
 
         assert_eq!(
             settings.effective_glossary_source(Some("default")),
-            "Codex = code x"
+            "Codex"
         );
         assert_eq!(
             settings.effective_glossary_source(Some("removed")),
-            "Codex = code x"
+            "Codex"
+        );
+    }
+
+    #[test]
+    fn one_run_prompt_replaces_global_hints_but_keeps_selected_profile_aliases() {
+        let mut settings = Settings {
+            initial_prompt: "Global = alias".to_string(),
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "Control+Shift+Space".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("swedish".to_string(), "Profile = misheard".to_string());
+
+        assert_eq!(
+            settings.effective_glossary_source_with_prompt(
+                Some("swedish"),
+                Some("OneRun = spelling")
+            ),
+            "OneRun\nProfile = misheard"
+        );
+        assert_eq!(
+            settings.effective_glossary_source_with_prompt(Some("swedish"), Some("  \n")),
+            "Global\nProfile = misheard"
+        );
+        assert_eq!(
+            settings.effective_glossary_source_with_prompt(None, Some("OneRun = spelling")),
+            "OneRun"
+        );
+        assert_eq!(settings.initial_prompt, "Global = alias");
+        assert_eq!(
+            settings.profile_glossaries.get("swedish").map(String::as_str),
+            Some("Profile = misheard")
         );
     }
 
@@ -1277,6 +1416,91 @@ mod tests {
         assert!(error.contains("personal dictionary"));
         assert!(error.contains("language"));
         assert_eq!(settings.language, Language::Swedish);
+    }
+
+    #[test]
+    fn legacy_language_change_with_implicit_default_dictionary_is_atomic() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+
+        let error = settings.set_legacy_language(Language::English).unwrap_err();
+
+        assert!(error.contains("personal dictionary"));
+        assert_eq!(settings.language, Language::Swedish);
+        assert!(settings.hotkey_profiles.is_empty());
+        assert_eq!(
+            settings.profile_glossaries.get("default").map(String::as_str),
+            Some("merge = merch")
+        );
+    }
+
+    #[test]
+    fn legacy_language_change_with_explicit_default_dictionary_is_atomic() {
+        let mut settings = Settings {
+            language: Language::English,
+            hotkey_profiles: vec![HotkeyProfile::legacy_default(
+                "Control+Shift+Space".to_string(),
+                Language::Swedish,
+            )],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+
+        let error = settings.set_legacy_language(Language::English).unwrap_err();
+
+        assert!(error.contains("personal dictionary"));
+        assert_eq!(settings.language, Language::English);
+        assert_eq!(settings.hotkey_profiles[0].language, Language::Swedish);
+    }
+
+    #[test]
+    fn legacy_language_change_allows_orphan_dictionary_without_default_profile() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "swedish".to_string(),
+                name: "Swedish".to_string(),
+                shortcut: "Control+Shift+Space".to_string(),
+                language: Language::Swedish,
+            }],
+            ..Default::default()
+        };
+        settings
+            .profile_glossaries
+            .insert("default".to_string(), "merge = merch".to_string());
+
+        settings.set_legacy_language(Language::English).unwrap();
+
+        assert_eq!(settings.language, Language::English);
+        assert_eq!(settings.hotkey_profiles[0].language, Language::Swedish);
+        assert_eq!(
+            settings.profile_glossaries.get("default").map(String::as_str),
+            Some("merge = merch")
+        );
+    }
+
+    #[test]
+    fn legacy_language_change_without_dictionary_updates_legacy_profile() {
+        let mut settings = Settings {
+            language: Language::Swedish,
+            hotkey_profiles: vec![HotkeyProfile::legacy_default(
+                "Control+Shift+Space".to_string(),
+                Language::Swedish,
+            )],
+            ..Default::default()
+        };
+
+        settings.set_legacy_language(Language::English).unwrap();
+
+        assert_eq!(settings.language, Language::English);
+        assert_eq!(settings.hotkey_profiles[0].language, Language::English);
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/settings/store.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/store.rs
@@ -516,6 +516,12 @@ fn normalize_glossary_file(contents: String) -> String {
     contents.trim_end_matches(['\r', '\n']).to_string()
 }
 
+/// Compare editor baselines using the existing glossary file round-trip rule.
+/// Only trailing CR/LF is normalized; spaces and internal line breaks matter.
+pub fn glossary_sources_match(left: &str, right: &str) -> bool {
+    left.trim_end_matches(['\r', '\n']) == right.trim_end_matches(['\r', '\n'])
+}
+
 fn glossary_file_contents(source: &str) -> String {
     let source = source.trim_end_matches(['\r', '\n']);
     if source.is_empty() {
@@ -1074,6 +1080,63 @@ mod tests {
             assert_eq!(persisted.hotkey, "Super+Q");
             let reloaded = load_from(&path);
             assert_eq!(reloaded.hotkey, "Super+Q");
+        });
+    }
+
+    #[test]
+    fn dictionary_compare_and_set_survives_external_file_round_trip() {
+        with_temp_settings(|path| {
+            let first = try_update_at(&path, |settings| {
+                settings.initial_prompt = "OpenRouter\n\n".into();
+                settings
+                    .profile_glossaries
+                    .insert("swedish".into(), "merge = merch\r\n".into());
+                settings
+                    .profile_glossaries
+                    .insert("empty".into(), String::new());
+                Ok(())
+            })
+            .unwrap();
+            let second = try_update_at(&path, |settings| {
+                if !glossary_sources_match(&settings.initial_prompt, &first.initial_prompt)
+                    || !glossary_sources_match(
+                        &settings.profile_glossaries["swedish"],
+                        &first.profile_glossaries["swedish"],
+                    )
+                {
+                    return Err("Spurious dictionary conflict after file round trip".into());
+                }
+                assert_eq!(
+                    settings.profile_glossaries.get("empty").map(String::as_str),
+                    Some("")
+                );
+                assert!(!settings.profile_glossaries.contains_key("absent"));
+                settings.initial_prompt = "OpenRouter\nCodex\n".into();
+                settings
+                    .profile_glossaries
+                    .insert("swedish".into(), "merge = merch\nCodex = code x\n".into());
+                Ok(())
+            })
+            .unwrap();
+            let loaded = load_from(&path);
+            assert!(glossary_sources_match(
+                &loaded.initial_prompt,
+                &second.initial_prompt
+            ));
+            assert!(glossary_sources_match(
+                &loaded.profile_glossaries["swedish"],
+                &second.profile_glossaries["swedish"]
+            ));
+            assert_eq!(
+                loaded.profile_glossaries.get("empty").map(String::as_str),
+                Some("")
+            );
+            assert!(!loaded.profile_glossaries.contains_key("absent"));
+            assert!(!glossary_sources_match("OpenRouter ", "OpenRouter"));
+            assert!(!glossary_sources_match(
+                "OpenRouter\nCodex",
+                "OpenRouter Codex"
+            ));
         });
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1275,7 +1275,9 @@ fn ensure_expected_dictionary_source(
     current_source: &str,
     expected_source: Option<&str>,
 ) -> Result<(), String> {
-    if expected_source.is_some_and(|expected| expected != current_source) {
+    if expected_source.is_some_and(|expected| {
+        !sagascript_core::settings::store::glossary_sources_match(expected, current_source)
+    }) {
         return Err(format!(
             "{DICTIONARY_CHANGED_ELSEWHERE_PREFIX} the persisted source no longer matches the editor baseline"
         ));
@@ -1311,7 +1313,10 @@ fn reconcile_global_dictionary_after_conflict(
     expected_source: &str,
     persisted_source: &str,
 ) {
-    if settings.initial_prompt == expected_source {
+    if sagascript_core::settings::store::glossary_sources_match(
+        &settings.initial_prompt,
+        expected_source,
+    ) {
         settings.initial_prompt = persisted_source.to_string();
     }
 }
@@ -1327,7 +1332,7 @@ fn reconcile_profile_dictionary_after_conflict(
         .get(profile_id)
         .map(String::as_str)
         .unwrap_or_default();
-    if current_source != expected_source {
+    if !sagascript_core::settings::store::glossary_sources_match(current_source, expected_source) {
         return;
     }
 
@@ -1432,6 +1437,20 @@ pub async fn set_profile_glossary(
 #[cfg(test)]
 mod dictionary_compare_and_set_tests {
     use super::*;
+
+    #[test]
+    fn dictionary_cas_matches_the_stores_trailing_newline_normalization() {
+        assert!(ensure_expected_dictionary_source("OpenRouter", Some("OpenRouter\n\n")).is_ok());
+        assert!(
+            ensure_expected_dictionary_source("merge = merch", Some("merge = merch\r\n")).is_ok()
+        );
+        assert!(ensure_expected_dictionary_source("", Some("\r\n")).is_ok());
+        assert!(ensure_expected_dictionary_source("OpenRouter ", Some("OpenRouter")).is_err());
+        assert!(
+            ensure_expected_dictionary_source("OpenRouter\nmerge", Some("OpenRouter merge"))
+                .is_err()
+        );
+    }
 
     fn profile_settings() -> Settings {
         Settings {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -20,11 +20,11 @@ use sagascript_core::settings::{
     validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
 };
 use sagascript_core::transcription::{
-    suggest_glossary_candidates, Glossary, GlossarySuggestion, GlossarySuggestionKind,
+    model, recommended_parallel_chunks, ContextProfile, TranscribeOptions, WhisperBackend,
+    FILE_TRANSCRIBE_BEAM,
 };
 use sagascript_core::transcription::{
-    model, recommended_parallel_chunks, ContextProfile, FILE_TRANSCRIBE_BEAM, TranscribeOptions,
-    WhisperBackend,
+    suggest_glossary_candidates, Glossary, GlossarySuggestion, GlossarySuggestionKind,
 };
 
 /// Build the per-transcription options from the current settings. Resolves the
@@ -76,17 +76,53 @@ pub(crate) fn build_file_transcribe_options(
 }
 
 pub(crate) fn effective_file_glossary(settings: &Settings, prompt: Option<&str>) -> Glossary {
-    let source = prompt
-        .map(str::trim)
-        .filter(|prompt| !prompt.is_empty())
-        .unwrap_or(settings.initial_prompt.trim());
-    Glossary::parse(source)
+    Glossary::parse(&settings.effective_glossary_source_with_prompt(None, prompt))
+}
+
+struct FileTranscriptionContext {
+    language: Language,
+    model: WhisperModel,
+    glossary: Glossary,
+    options: TranscribeOptions,
+}
+
+/// Freeze language, model and dictionary together before file decoding begins.
+/// A missing/Auto profile is rejected rather than silently borrowing aliases.
+fn file_transcription_context(
+    settings: &Settings,
+    profile_id: Option<&str>,
+    prompt: Option<&str>,
+) -> Result<FileTranscriptionContext, String> {
+    let language = if let Some(id) = profile_id {
+        ensure_known_profile(settings, id)?;
+        settings
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .find(|profile| profile.id == id)
+            .ok_or_else(|| format!("Unknown dictation profile '{id}'"))?
+            .language
+    } else {
+        settings.language
+    };
+    let glossary =
+        Glossary::parse(&settings.effective_glossary_source_with_prompt(profile_id, prompt));
+    let mut options = build_file_transcribe_options(settings, prompt.map(str::to_owned));
+    options.prompt = glossary.decoder_prompt();
+    Ok(FileTranscriptionContext {
+        language,
+        model: settings.effective_model_for(language),
+        glossary,
+        options,
+    })
 }
 
 pub(crate) fn apply_glossary(text: String, glossary: &Glossary) -> String {
     let (corrected, corrections) = glossary.correct_text(&text);
     if !corrections.is_empty() {
-        info!(correction_count = corrections.len(), "Applied personal glossary corrections");
+        info!(
+            correction_count = corrections.len(),
+            "Applied personal glossary corrections"
+        );
     }
     corrected
 }
@@ -101,7 +137,10 @@ mod glossary_options_tests {
             initial_prompt: "OpenRouter = open router | open vrouter\nmerge = merch".to_string(),
             ..Settings::default()
         };
-        assert_eq!(build_transcribe_options(&settings).prompt.as_deref(), Some("OpenRouter, merge"));
+        assert_eq!(
+            build_transcribe_options(&settings).prompt.as_deref(),
+            Some("OpenRouter, merge")
+        );
     }
 
     #[test]
@@ -146,13 +185,155 @@ mod glossary_options_tests {
             ..Settings::default()
         };
         let prompt = Some("Cloudflare = cloud flare".to_string());
-        assert_eq!(build_file_transcribe_options(&settings, prompt).prompt.as_deref(), Some("Cloudflare"));
+        assert_eq!(
+            build_file_transcribe_options(&settings, prompt)
+                .prompt
+                .as_deref(),
+            Some("Cloudflare")
+        );
     }
 
     #[test]
     fn correction_helper_applies_explicit_aliases() {
         let glossary = Glossary::parse("merge = merch");
-        assert_eq!(apply_glossary("Merch it".to_string(), &glossary), "merge it");
+        assert_eq!(
+            apply_glossary("Merch it".to_string(), &glossary),
+            "merge it"
+        );
+    }
+
+    #[test]
+    fn gui_file_global_alias_does_not_rewrite_english() {
+        let settings = Settings {
+            initial_prompt: "merge = merch".to_string(),
+            ..Settings::default()
+        };
+        let glossary = effective_file_glossary(&settings, None);
+        assert_eq!(
+            apply_glossary("company merch".into(), &glossary),
+            "company merch"
+        );
+        assert_eq!(glossary.decoder_prompt().as_deref(), Some("merge"));
+    }
+
+    fn scoped_file_settings() -> Settings {
+        let mut settings = Settings {
+            language: Language::English,
+            initial_prompt: "Codex = code x\nmerge = merch".into(),
+            hotkey_profiles: vec![
+                HotkeyProfile {
+                    id: "swedish".into(),
+                    name: "Swedish".into(),
+                    shortcut: "Super+S".into(),
+                    language: Language::Swedish,
+                },
+                HotkeyProfile {
+                    id: "english".into(),
+                    name: "English".into(),
+                    shortcut: "Super+E".into(),
+                    language: Language::English,
+                },
+                HotkeyProfile {
+                    id: "automatic".into(),
+                    name: "Automatic".into(),
+                    shortcut: "Super+A".into(),
+                    language: Language::Auto,
+                },
+            ],
+            ..Settings::default()
+        };
+        settings.profile_glossaries.insert(
+            "swedish".into(),
+            "merge = merch\nOpenRouter = open router".into(),
+        );
+        settings
+            .profile_glossaries
+            .insert("automatic".into(), "merge = merch".into());
+        settings
+    }
+
+    #[test]
+    fn gui_file_profile_pins_language_model_and_dictionary_together() {
+        let settings = scoped_file_settings();
+        let context = file_transcription_context(&settings, Some("swedish"), None).unwrap();
+        assert_eq!(context.language, Language::Swedish);
+        assert_eq!(
+            context.model,
+            settings.effective_model_for(Language::Swedish)
+        );
+        assert_eq!(
+            apply_glossary("merch open router".into(), &context.glossary),
+            "merge OpenRouter"
+        );
+        assert_eq!(context.options.prompt, context.glossary.decoder_prompt());
+        for profile in [None, Some("english")] {
+            let context = file_transcription_context(&settings, profile, None).unwrap();
+            assert_eq!(context.language, Language::English);
+            assert_eq!(
+                apply_glossary("company merch".into(), &context.glossary),
+                "company merch"
+            );
+        }
+    }
+
+    #[test]
+    fn gui_file_override_is_hint_only_but_keeps_explicit_profile_aliases() {
+        let context = file_transcription_context(
+            &scoped_file_settings(),
+            Some("swedish"),
+            Some("Cloudflare = cloud flare"),
+        )
+        .unwrap();
+        assert_eq!(
+            apply_glossary("cloud flare merch".into(), &context.glossary),
+            "cloud flare merge"
+        );
+        assert_eq!(
+            context.options.prompt.as_deref(),
+            Some("Cloudflare, merge, OpenRouter")
+        );
+    }
+
+    #[test]
+    fn gui_file_rejects_unknown_and_auto_profile_before_io() {
+        let settings = scoped_file_settings();
+        assert!(file_transcription_context(&settings, Some("missing"), None).is_err());
+        assert!(file_transcription_context(&settings, Some("automatic"), None).is_err());
+        let auto = Settings {
+            language: Language::Auto,
+            ..settings
+        };
+        let context = file_transcription_context(&auto, None, None).unwrap();
+        assert_eq!(context.language, Language::Auto);
+        assert_eq!(apply_glossary("merch".into(), &context.glossary), "merch");
+    }
+
+    #[test]
+    fn profile_dictionary_save_validates_without_partial_mutation() {
+        let mut settings = scoped_file_settings();
+        let original = settings.profile_glossaries.clone();
+        for profile in ["missing", "automatic"] {
+            assert!(
+                set_profile_glossary_in(&mut settings, profile, "new = old".into(), None).is_err()
+            );
+            assert_eq!(settings.profile_glossaries, original);
+        }
+        set_profile_glossary_in(&mut settings, "english", "OpenAI = open a i".into(), None)
+            .unwrap();
+        assert_eq!(settings.profile_glossaries["english"], "OpenAI = open a i");
+        assert_eq!(settings.profile_glossaries["swedish"], original["swedish"]);
+        assert_eq!(settings.initial_prompt, "Codex = code x\nmerge = merch");
+    }
+
+    #[test]
+    fn scoped_file_glossary_preserves_cross_fragment_phrase_matching() {
+        let context =
+            file_transcription_context(&scoped_file_settings(), Some("swedish"), None).unwrap();
+        let (fragments, corrections) = context
+            .glossary
+            .correct_fragments(&["open", " router merch"]);
+        assert_eq!(fragments.concat(), "OpenRouter merge");
+        assert_eq!(corrections.len(), 2);
     }
 }
 
@@ -247,8 +428,8 @@ fn set_language_for_controller(
     app: &tauri::AppHandle,
     language: Language,
 ) -> Result<(), String> {
-    let persisted = sagascript_core::settings::store::update(|settings| {
-        settings.set_legacy_language(language);
+    let persisted = sagascript_core::settings::store::try_update(|settings| {
+        settings.set_legacy_language(language)
     })?;
     let mut ctrl = controller.lock().unwrap();
     ctrl.update_settings(persisted.clone());
@@ -325,8 +506,15 @@ pub async fn set_hotkey(
     shortcut: String,
 ) -> Result<(), String> {
     validate_hotkey(&shortcut)?;
-    let mut profiles = controller.lock().unwrap().settings().resolved_hotkey_profiles();
-    let profile_index = profiles.iter().position(|profile| profile.id == "default").unwrap_or(0);
+    let mut profiles = controller
+        .lock()
+        .unwrap()
+        .settings()
+        .resolved_hotkey_profiles();
+    let profile_index = profiles
+        .iter()
+        .position(|profile| profile.id == "default")
+        .unwrap_or(0);
     profiles[profile_index].shortcut = shortcut;
     set_hotkey_profiles(app, controller, health, profiles).await
 }
@@ -340,7 +528,10 @@ pub async fn set_hotkey_profiles(
 ) -> Result<(), String> {
     use tauri::Emitter;
     Settings::validate_hotkey_profiles(&profiles)?;
-    let new_shortcuts: Vec<String> = profiles.iter().map(|profile| profile.shortcut.clone()).collect();
+    let new_shortcuts: Vec<String> = profiles
+        .iter()
+        .map(|profile| profile.shortcut.clone())
+        .collect();
     let new_primary = profiles
         .iter()
         .find(|profile| profile.id == "default")
@@ -378,7 +569,10 @@ pub async fn set_hotkey_profiles(
             .update_settings(persisted.clone());
         let change = health.record(&new_primary, None, old_operational);
         if change.changed {
-            let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+            let _ = app.emit(
+                crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+                &change.status,
+            );
         }
         crate::update_profiles_menu(&app, &persisted.resolved_hotkey_profiles());
         return Ok(());
@@ -412,9 +606,14 @@ pub async fn set_hotkey_profiles(
                 OperationalHotkey::Unknown,
             );
             if change.changed {
-                let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+                let _ = app.emit(
+                    crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+                    &change.status,
+                );
             }
-            return Err(format!("Failed to register hotkey profiles: {error}; cleanup failed: {cleanup_error}"));
+            return Err(format!(
+                "Failed to register hotkey profiles: {error}; cleanup failed: {cleanup_error}"
+            ));
         }
         let change = match &old_operational {
             OperationalHotkey::Registered(old_shortcuts) => match crate::hotkey::register_shortcuts(&app, old_shortcuts) {
@@ -435,7 +634,10 @@ pub async fn set_hotkey_profiles(
             OperationalHotkey::Unknown => unreachable!("unknown state returned above"),
         };
         if change.changed {
-            let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+            let _ = app.emit(
+                crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+                &change.status,
+            );
         }
         return Err(format!("Failed to register hotkey profiles: {error}"));
     }
@@ -465,12 +667,29 @@ pub async fn set_hotkey_profiles(
                 None
             };
             let unknown = unregister_error.is_some();
-            let restored_operational = if unknown { OperationalHotkey::Unknown } else if rollback_error.is_some() { OperationalHotkey::Inactive } else { old_operational.clone() };
-            let health_error = unknown.then(|| "failed to unregister unpersisted hotkeys; operational state is unknown".to_string())
-                .or_else(|| rollback_error.as_ref().map(|error| format!("failed to restore previous hotkeys: {error}")));
+            let restored_operational = if unknown {
+                OperationalHotkey::Unknown
+            } else if rollback_error.is_some() {
+                OperationalHotkey::Inactive
+            } else {
+                old_operational.clone()
+            };
+            let health_error = unknown
+                .then(|| {
+                    "failed to unregister unpersisted hotkeys; operational state is unknown"
+                        .to_string()
+                })
+                .or_else(|| {
+                    rollback_error
+                        .as_ref()
+                        .map(|error| format!("failed to restore previous hotkeys: {error}"))
+                });
             let change = health.record(&old_shortcut, health_error, restored_operational);
             if change.changed {
-                let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+                let _ = app.emit(
+                    crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+                    &change.status,
+                );
             }
             return Err(format!("Failed to persist hotkey profiles: {save_error}"));
         }
@@ -488,12 +707,18 @@ pub async fn set_hotkey_profiles(
         OperationalHotkey::registered_many(&new_shortcuts),
     );
     if change.changed {
-        let _ = app.emit(crate::events::event::HOTKEY_REGISTRATION_CHANGED, &change.status);
+        let _ = app.emit(
+            crate::events::event::HOTKEY_REGISTRATION_CHANGED,
+            &change.status,
+        );
     }
 
     crate::update_profiles_menu(&app, &persisted.resolved_hotkey_profiles());
 
-    info!("Hotkey profiles changed: {} registered", new_shortcuts.len());
+    info!(
+        "Hotkey profiles changed: {} registered",
+        new_shortcuts.len()
+    );
     Ok(())
 }
 
@@ -519,8 +744,7 @@ pub async fn retry_hotkey_registration(
         let app_for_install = app.clone();
         let (installed_tx, installed_rx) = std::sync::mpsc::channel();
         app.run_on_main_thread(move || {
-            let result =
-                crate::hotkey::install_bare_function_key_monitor(&app_for_install);
+            let result = crate::hotkey::install_bare_function_key_monitor(&app_for_install);
             let _ = installed_tx.send(result);
         })
         .map_err(|error| error.to_string())?;
@@ -653,7 +877,9 @@ async fn stop_and_transcribe_impl(
         };
         let language = ctrl.language();
         let effective_model = ctrl.settings().effective_model_for(language);
-        let profile_id = ctrl.active_hotkey_profile().map(|profile| profile.id.as_str());
+        let profile_id = ctrl
+            .active_hotkey_profile()
+            .map(|profile| profile.id.as_str());
         let opts = build_transcribe_options_for_profile(ctrl.settings(), profile_id);
         let glossary = Glossary::parse(&ctrl.settings().effective_glossary_source(profile_id));
         (audio, language, effective_model, opts, glossary)
@@ -682,7 +908,8 @@ async fn stop_and_transcribe_impl(
         // exit after abort and log whether the lock was released.
         let whisper_ref = whisper.inner().clone();
         let mut fut = tokio::task::spawn_blocking(move || {
-            let mut timings = sagascript_core::transcription::whisper_backend::DictationTimings::default();
+            let mut timings =
+                sagascript_core::transcription::whisper_backend::DictationTimings::default();
             let result = whisper_ref.transcribe_live_dictation(
                 effective_model,
                 &audio,
@@ -747,7 +974,10 @@ async fn stop_and_transcribe_impl(
         .as_ref()
         .map(|transcript| transcript.effective_text.clone())
         .map_err(Clone::clone);
-    controller.lock().unwrap().finish_transcription(completion)?;
+    controller
+        .lock()
+        .unwrap()
+        .finish_transcription(completion)?;
     training_result
 }
 
@@ -783,11 +1013,7 @@ pub async fn transcribe_training_file(
             profile.language,
             ctrl.settings().effective_model_for(profile.language),
             build_transcribe_options_for_profile(ctrl.settings(), Some(&profile_id)),
-            Glossary::parse(
-                &ctrl
-                    .settings()
-                    .effective_glossary_source(Some(&profile_id)),
-            ),
+            Glossary::parse(&ctrl.settings().effective_glossary_source(Some(&profile_id))),
         )
     };
 
@@ -801,15 +1027,11 @@ pub async fn transcribe_training_file(
     let duration_seconds = (audio.len() / 16_000) as u64;
     let timeout = Duration::from_secs((duration_seconds * 6).max(TRANSCRIPTION_TIMEOUT_SECS));
     let mut task = tokio::task::spawn_blocking(move || {
-        whisper_ref.with_model(
-            effective_model,
-            ContextProfile::FlashAttention,
-            |backend| {
-                backend.transcribe_sync_with_options(&audio, language, &opts, move |progress| {
-                    let _ = progress_app.emit("transcription-progress", progress);
-                })
-            },
-        )
+        whisper_ref.with_model(effective_model, ContextProfile::FlashAttention, |backend| {
+            backend.transcribe_sync_with_options(&audio, language, &opts, move |progress| {
+                let _ = progress_app.emit("transcription-progress", progress);
+            })
+        })
     });
 
     let result = match tokio::time::timeout(timeout, &mut task).await {
@@ -1007,13 +1229,124 @@ pub async fn set_show_overlay(
 pub async fn set_initial_prompt(
     controller: State<'_, SharedController>,
     prompt: String,
+    expected_source: Option<String>,
 ) -> Result<(), String> {
-    let persisted = sagascript_core::settings::store::update(|settings| {
-        settings.initial_prompt = prompt.clone();
-    })?;
-    let mut ctrl = controller.lock().unwrap();
-    ctrl.settings_mut().initial_prompt = persisted.initial_prompt;
-    info!("Initial prompt set ({} chars)", prompt.len());
+    let mut conflict_source = None;
+    let persisted = sagascript_core::settings::store::try_update(|settings| {
+        let current_source = expected_source
+            .as_ref()
+            .map(|_| settings.initial_prompt.clone());
+        match set_initial_prompt_in(settings, &prompt, expected_source.as_deref()) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                if error.starts_with(DICTIONARY_CHANGED_ELSEWHERE_PREFIX) {
+                    conflict_source = current_source;
+                }
+                Err(error)
+            }
+        }
+    });
+    match persisted {
+        Ok(persisted) => {
+            let mut ctrl = controller.lock().unwrap();
+            ctrl.settings_mut().initial_prompt = persisted.initial_prompt;
+            info!("Initial prompt set ({} chars)", prompt.len());
+            Ok(())
+        }
+        Err(error) => {
+            if let (Some(expected), Some(persisted_source)) =
+                (expected_source.as_deref(), conflict_source.as_deref())
+            {
+                let mut ctrl = controller.lock().unwrap();
+                reconcile_global_dictionary_after_conflict(
+                    ctrl.settings_mut(),
+                    expected,
+                    persisted_source,
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+const DICTIONARY_CHANGED_ELSEWHERE_PREFIX: &str = "Dictionary changed elsewhere:";
+
+fn ensure_expected_dictionary_source(
+    current_source: &str,
+    expected_source: Option<&str>,
+) -> Result<(), String> {
+    if expected_source.is_some_and(|expected| expected != current_source) {
+        return Err(format!(
+            "{DICTIONARY_CHANGED_ELSEWHERE_PREFIX} the persisted source no longer matches the editor baseline"
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DictionarySourceSnapshot {
+    present: bool,
+    source: String,
+}
+
+fn profile_dictionary_source_snapshot(
+    settings: &Settings,
+    profile_id: &str,
+) -> DictionarySourceSnapshot {
+    settings
+        .profile_glossaries
+        .get(profile_id)
+        .map(|source| DictionarySourceSnapshot {
+            present: true,
+            source: source.clone(),
+        })
+        .unwrap_or_else(|| DictionarySourceSnapshot {
+            present: false,
+            source: String::new(),
+        })
+}
+
+fn reconcile_global_dictionary_after_conflict(
+    settings: &mut Settings,
+    expected_source: &str,
+    persisted_source: &str,
+) {
+    if settings.initial_prompt == expected_source {
+        settings.initial_prompt = persisted_source.to_string();
+    }
+}
+
+fn reconcile_profile_dictionary_after_conflict(
+    settings: &mut Settings,
+    profile_id: &str,
+    expected_source: &str,
+    persisted_source: &DictionarySourceSnapshot,
+) {
+    let current_source = settings
+        .profile_glossaries
+        .get(profile_id)
+        .map(String::as_str)
+        .unwrap_or_default();
+    if current_source != expected_source {
+        return;
+    }
+
+    if persisted_source.present {
+        settings
+            .profile_glossaries
+            .insert(profile_id.to_string(), persisted_source.source.clone());
+    } else {
+        settings.profile_glossaries.remove(profile_id);
+    }
+}
+
+fn set_initial_prompt_in(
+    settings: &mut Settings,
+    prompt: &str,
+    expected_source: Option<&str>,
+) -> Result<(), String> {
+    ensure_expected_dictionary_source(&settings.initial_prompt, expected_source)?;
+    settings.initial_prompt = prompt.to_string();
     Ok(())
 }
 
@@ -1025,10 +1358,269 @@ fn ensure_known_profile(settings: &Settings, profile_id: &str) -> Result<(), Str
         .ok_or_else(|| format!("Unknown dictation profile '{profile_id}'"))?;
     if profile.language == Language::Auto {
         return Err(
-            "Teach Sagascript requires a profile with an explicit language".to_string(),
+            "Personal dictionary aliases require a profile with an explicit language".to_string(),
         );
     }
     Ok(())
+}
+
+fn set_profile_glossary_in(
+    settings: &mut Settings,
+    profile_id: &str,
+    source: String,
+    expected_source: Option<&str>,
+) -> Result<(), String> {
+    ensure_known_profile(settings, profile_id)?;
+    let current_source = settings
+        .profile_glossaries
+        .get(profile_id)
+        .map(String::as_str)
+        .unwrap_or_default();
+    ensure_expected_dictionary_source(current_source, expected_source)?;
+    settings
+        .profile_glossaries
+        .insert(profile_id.to_owned(), source);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_profile_glossary(
+    controller: State<'_, SharedController>,
+    profile_id: String,
+    source: String,
+    expected_source: Option<String>,
+) -> Result<(), String> {
+    let source_len = source.chars().count();
+    let mut conflict_source = None;
+    let persisted = sagascript_core::settings::store::try_update(|settings| {
+        let current_source = expected_source
+            .as_ref()
+            .map(|_| profile_dictionary_source_snapshot(settings, &profile_id));
+        match set_profile_glossary_in(settings, &profile_id, source, expected_source.as_deref()) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                if error.starts_with(DICTIONARY_CHANGED_ELSEWHERE_PREFIX) {
+                    conflict_source = current_source;
+                }
+                Err(error)
+            }
+        }
+    });
+    match persisted {
+        Ok(persisted) => {
+            controller.lock().unwrap().update_settings(persisted);
+            info!(source_len, "Profile personal dictionary updated");
+            Ok(())
+        }
+        Err(error) => {
+            if let (Some(expected), Some(persisted_source)) =
+                (expected_source.as_deref(), conflict_source.as_ref())
+            {
+                let mut ctrl = controller.lock().unwrap();
+                reconcile_profile_dictionary_after_conflict(
+                    ctrl.settings_mut(),
+                    &profile_id,
+                    expected,
+                    persisted_source,
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod dictionary_compare_and_set_tests {
+    use super::*;
+
+    fn profile_settings() -> Settings {
+        Settings {
+            hotkey_profiles: vec![HotkeyProfile {
+                id: "english".to_string(),
+                name: "English".to_string(),
+                shortcut: "Option+Space".to_string(),
+                language: Language::English,
+            }],
+            ..Settings::default()
+        }
+    }
+
+    #[test]
+    fn stale_global_source_is_rejected_without_mutation() {
+        let mut settings = Settings {
+            initial_prompt: "remote".to_string(),
+            ..Settings::default()
+        };
+        let before = settings.clone();
+
+        let error = set_initial_prompt_in(&mut settings, "local", Some("old")).unwrap_err();
+
+        assert!(error.starts_with("Dictionary changed elsewhere:"));
+        assert_eq!(settings.initial_prompt, before.initial_prompt);
+        assert_eq!(settings.profile_glossaries, before.profile_glossaries);
+    }
+
+    #[test]
+    fn stale_profile_source_is_rejected_without_mutation() {
+        let mut settings = profile_settings();
+        settings
+            .profile_glossaries
+            .insert("english".to_string(), "remote".to_string());
+        let before = settings.clone();
+
+        let error =
+            set_profile_glossary_in(&mut settings, "english", "local".to_string(), Some("old"))
+                .unwrap_err();
+
+        assert!(error.starts_with("Dictionary changed elsewhere:"));
+        assert_eq!(settings.initial_prompt, before.initial_prompt);
+        assert_eq!(settings.profile_glossaries, before.profile_glossaries);
+    }
+
+    #[test]
+    fn matching_expected_sources_write_both_dictionary_scopes() {
+        let mut settings = profile_settings();
+        settings.initial_prompt = "global old".to_string();
+        settings
+            .profile_glossaries
+            .insert("english".to_string(), "profile old".to_string());
+
+        set_initial_prompt_in(&mut settings, "global new", Some("global old")).unwrap();
+        set_profile_glossary_in(
+            &mut settings,
+            "english",
+            "profile new".to_string(),
+            Some("profile old"),
+        )
+        .unwrap();
+
+        assert_eq!(settings.initial_prompt, "global new");
+        assert_eq!(settings.profile_glossaries["english"], "profile new");
+    }
+
+    #[test]
+    fn omitted_expected_source_preserves_legacy_writes() {
+        let mut settings = profile_settings();
+        settings.initial_prompt = "global old".to_string();
+        settings
+            .profile_glossaries
+            .insert("english".to_string(), "profile old".to_string());
+
+        set_initial_prompt_in(&mut settings, "global new", None).unwrap();
+        set_profile_glossary_in(&mut settings, "english", "profile new".to_string(), None).unwrap();
+
+        assert_eq!(settings.initial_prompt, "global new");
+        assert_eq!(settings.profile_glossaries["english"], "profile new");
+    }
+
+    #[test]
+    fn unrelated_scope_change_does_not_block_compare_and_set() {
+        let mut settings = profile_settings();
+        settings.initial_prompt = "global changed elsewhere".to_string();
+        settings
+            .profile_glossaries
+            .insert("english".to_string(), "profile old".to_string());
+
+        set_profile_glossary_in(
+            &mut settings,
+            "english",
+            "profile new".to_string(),
+            Some("profile old"),
+        )
+        .unwrap();
+
+        assert_eq!(settings.initial_prompt, "global changed elsewhere");
+        assert_eq!(settings.profile_glossaries["english"], "profile new");
+    }
+
+    #[test]
+    fn global_conflict_refreshes_stale_controller_field_without_touching_profiles() {
+        let mut controller_settings = profile_settings();
+        controller_settings.initial_prompt = "editor baseline".to_string();
+        controller_settings
+            .profile_glossaries
+            .insert("english".to_string(), "unchanged profile".to_string());
+
+        reconcile_global_dictionary_after_conflict(
+            &mut controller_settings,
+            "editor baseline",
+            "fresh persisted source",
+        );
+
+        assert_eq!(controller_settings.initial_prompt, "fresh persisted source");
+        assert_eq!(
+            controller_settings.profile_glossaries["english"],
+            "unchanged profile"
+        );
+    }
+
+    #[test]
+    fn global_conflict_does_not_clobber_a_newer_controller_field() {
+        let mut controller_settings = profile_settings();
+        controller_settings.initial_prompt = "newer controller value".to_string();
+
+        reconcile_global_dictionary_after_conflict(
+            &mut controller_settings,
+            "editor baseline",
+            "fresh persisted source",
+        );
+
+        assert_eq!(controller_settings.initial_prompt, "newer controller value");
+    }
+
+    #[test]
+    fn profile_conflict_preserves_persisted_presence_and_rejects_newer_controller_value() {
+        let mut stale_controller = profile_settings();
+        stale_controller
+            .profile_glossaries
+            .insert("english".to_string(), "editor baseline".to_string());
+        let missing = DictionarySourceSnapshot {
+            present: false,
+            source: String::new(),
+        };
+        reconcile_profile_dictionary_after_conflict(
+            &mut stale_controller,
+            "english",
+            "editor baseline",
+            &missing,
+        );
+        assert!(!stale_controller.profile_glossaries.contains_key("english"));
+
+        stale_controller
+            .profile_glossaries
+            .insert("english".to_string(), "editor baseline".to_string());
+        let explicitly_empty = DictionarySourceSnapshot {
+            present: true,
+            source: String::new(),
+        };
+        reconcile_profile_dictionary_after_conflict(
+            &mut stale_controller,
+            "english",
+            "editor baseline",
+            &explicitly_empty,
+        );
+        assert_eq!(
+            stale_controller.profile_glossaries.get("english"),
+            Some(&String::new())
+        );
+
+        stale_controller
+            .profile_glossaries
+            .insert("english".to_string(), "newer controller value".to_string());
+        reconcile_profile_dictionary_after_conflict(
+            &mut stale_controller,
+            "english",
+            "editor baseline",
+            &DictionarySourceSnapshot {
+                present: true,
+                source: "fresh persisted source".to_string(),
+            },
+        );
+        assert_eq!(
+            stale_controller.profile_glossaries["english"],
+            "newer controller value"
+        );
+    }
 }
 
 fn apply_reviewed_training_candidates(
@@ -1057,8 +1649,7 @@ fn apply_reviewed_training_candidates(
         });
         if conflicts_with_existing_alias || conflicts_with_reviewed_alias {
             return Err(
-                "Edited preferred spelling conflicts with a personal dictionary alias"
-                    .to_string(),
+                "Edited preferred spelling conflicts with a personal dictionary alias".to_string(),
             );
         }
         let Some((index, _)) = allowed.iter().enumerate().find(|(index, original)| {
@@ -1073,8 +1664,7 @@ fn apply_reviewed_training_candidates(
                 }
         }) else {
             return Err(
-                "Dictionary suggestions changed; review the corrected transcript again"
-                    .to_string(),
+                "Dictionary suggestions changed; review the corrected transcript again".to_string(),
             );
         };
         matched[index] = true;
@@ -1088,7 +1678,10 @@ fn apply_reviewed_training_candidates(
     for candidate in accepted {
         match candidate.kind {
             GlossarySuggestionKind::Alias => {
-                scoped.upsert(candidate.canonical.clone(), vec![candidate.observed.clone()]);
+                scoped.upsert(
+                    candidate.canonical.clone(),
+                    vec![candidate.observed.clone()],
+                );
             }
             GlossarySuggestionKind::HintOnly => {
                 scoped.upsert(candidate.canonical.clone(), Vec::new());
@@ -1114,8 +1707,7 @@ fn validate_edited_training_candidate(candidate: &GlossarySuggestion) -> Result<
             .any(|character| matches!(character, '\n' | '\r' | ',' | '=' | '|'))
     {
         return Err(
-            "Edited dictionary terms must be 1-4 words without glossary delimiters"
-                .to_string(),
+            "Edited dictionary terms must be 1-4 words without glossary delimiters".to_string(),
         );
     }
     Ok(())
@@ -1147,13 +1739,7 @@ pub async fn apply_training_glossary(
 
     let accepted_count = accepted.len();
     let persisted = sagascript_core::settings::store::try_update(|settings| {
-        apply_reviewed_training_candidates(
-            settings,
-            &heard,
-            &corrected,
-            &profile_id,
-            &accepted,
-        )
+        apply_reviewed_training_candidates(settings, &heard, &corrected, &profile_id, &accepted)
     })?;
 
     controller.lock().unwrap().settings_mut().profile_glossaries = persisted.profile_glossaries;
@@ -1172,18 +1758,15 @@ mod training_glossary_tests {
         let corrected = "Jag heter Magnus Gille.";
         let candidates = suggest_glossary_candidates(heard, corrected, &Glossary::default());
 
-        apply_reviewed_training_candidates(
-            &mut settings,
-            heard,
-            corrected,
-            "default",
-            &candidates,
-        )
-        .unwrap();
+        apply_reviewed_training_candidates(&mut settings, heard, corrected, "default", &candidates)
+            .unwrap();
 
         assert_eq!(settings.initial_prompt, "");
         assert_eq!(
-            settings.profile_glossaries.get("default").map(String::as_str),
+            settings
+                .profile_glossaries
+                .get("default")
+                .map(String::as_str),
             Some("Gille = Jille")
         );
     }
@@ -1223,32 +1806,26 @@ mod training_glossary_tests {
         let mut edited = original.clone();
         edited.canonical = "Lovable.dev".to_string();
         let mut settings = Settings::default();
-        apply_reviewed_training_candidates(
-            &mut settings,
-            heard,
-            corrected,
-            "default",
-            &[edited],
-        )
-        .unwrap();
+        apply_reviewed_training_candidates(&mut settings, heard, corrected, "default", &[edited])
+            .unwrap();
         assert_eq!(
-            settings.profile_glossaries.get("default").map(String::as_str),
+            settings
+                .profile_glossaries
+                .get("default")
+                .map(String::as_str),
             Some("Lovable.dev = Love a ball")
         );
 
         let mut as_hint = original;
         as_hint.kind = GlossarySuggestionKind::HintOnly;
         let mut settings = Settings::default();
-        apply_reviewed_training_candidates(
-            &mut settings,
-            heard,
-            corrected,
-            "default",
-            &[as_hint],
-        )
-        .unwrap();
+        apply_reviewed_training_candidates(&mut settings, heard, corrected, "default", &[as_hint])
+            .unwrap();
         assert_eq!(
-            settings.profile_glossaries.get("default").map(String::as_str),
+            settings
+                .profile_glossaries
+                .get("default")
+                .map(String::as_str),
             Some("Lovable")
         );
     }
@@ -1277,17 +1854,18 @@ mod training_glossary_tests {
     }
 
     #[test]
-    fn edited_canonical_cannot_shadow_an_existing_alias() {
-        let mut settings = Settings {
-            initial_prompt: "Existing = dangerous".to_string(),
-            ..Default::default()
-        };
+    fn edited_canonical_cannot_shadow_an_existing_profile_alias() {
+        let mut settings = Settings::default();
+        settings
+            .profile_glossaries
+            .insert("default".into(), "Existing = dangerous".into());
+        let original = settings.profile_glossaries.clone();
         let heard = "Magnus Jille";
         let corrected = "Magnus Gille";
         let mut candidate = suggest_glossary_candidates(
             heard,
             corrected,
-            &Glossary::parse(&settings.initial_prompt),
+            &Glossary::parse(&settings.effective_glossary_source(Some("default"))),
         )
         .into_iter()
         .next()
@@ -1304,7 +1882,36 @@ mod training_glossary_tests {
         .unwrap_err();
 
         assert!(error.contains("conflicts"));
-        assert!(settings.profile_glossaries.is_empty());
+        assert_eq!(settings.profile_glossaries, original);
+    }
+
+    #[test]
+    fn inactive_global_alias_does_not_block_reviewed_profile_term() {
+        let mut settings = Settings {
+            initial_prompt: "Existing = dangerous".to_string(),
+            ..Default::default()
+        };
+        let heard = "Magnus Jille";
+        let corrected = "Magnus Gille";
+        let mut candidate = suggest_glossary_candidates(
+            heard,
+            corrected,
+            &Glossary::parse(&settings.effective_glossary_source(Some("default"))),
+        )
+        .into_iter()
+        .next()
+        .unwrap();
+        candidate.canonical = "Dangerous".to_string();
+        apply_reviewed_training_candidates(
+            &mut settings,
+            heard,
+            corrected,
+            "default",
+            &[candidate],
+        )
+        .unwrap();
+        assert_eq!(settings.initial_prompt, "Existing = dangerous");
+        assert_eq!(settings.profile_glossaries["default"], "Dangerous = Jille");
     }
 }
 
@@ -1370,8 +1977,19 @@ pub async fn transcribe_file(
     file_path: String,
     prompt: Option<String>,
     diarize: Option<bool>,
+    profile_id: Option<String>,
 ) -> Result<String, String> {
     use tauri::Emitter;
+
+    let FileTranscriptionContext {
+        language,
+        model: effective_model,
+        glossary,
+        options: mut opts,
+    } = {
+        let ctrl = controller.lock().unwrap();
+        file_transcription_context(ctrl.settings(), profile_id.as_deref(), prompt.as_deref())?
+    };
 
     let path = std::path::PathBuf::from(&file_path);
 
@@ -1388,23 +2006,12 @@ pub async fn transcribe_file(
     // File transcription (beam search / diarization) is far slower than live
     // dictation, so scale the timeout by the decoded duration rather than using
     // the short live-dictation timeout (which beam search could otherwise hit).
-    let file_timeout = Duration::from_secs(
-        ((audio.len() / 16_000) as u64 * 6).max(TRANSCRIPTION_TIMEOUT_SECS),
-    );
+    let file_timeout =
+        Duration::from_secs(((audio.len() / 16_000) as u64 * 6).max(TRANSCRIPTION_TIMEOUT_SECS));
 
     // Suppress unused-variable warning on `diarize` when the diarization feature is off
     #[cfg(not(feature = "diarization"))]
     let _ = &diarize;
-
-    // Get transcription settings
-    let (language, effective_model, glossary) = {
-        let ctrl = controller.lock().unwrap();
-        (
-            ctrl.language(),
-            ctrl.settings().effective_model(),
-            effective_file_glossary(ctrl.settings(), prompt.as_deref()),
-        )
-    };
 
     #[cfg(feature = "diarization")]
     let context_profile = ContextProfile::for_diarization(diarize.unwrap_or(false));
@@ -1421,10 +2028,10 @@ pub async fn transcribe_file(
     #[cfg(feature = "diarization")]
     if diarize.unwrap_or(false) {
         use sagascript_core::diarization::{
-            DiarizeConfig, TimestampedSegment,
             diarize as run_diarize,
             merge::{consolidate, merge_with_transcript},
-            model::{DiarizationModel, download_model as download_diarization_model},
+            model::{download_model as download_diarization_model, DiarizationModel},
+            DiarizeConfig, TimestampedSegment,
         };
 
         // Checking diarization in the file-transcription UI is an explicit
@@ -1456,17 +2063,13 @@ pub async fn transcribe_file(
         // Segment-level timestamps can span multiple speaker turns and would
         // cause maximum-overlap merging to collapse the GUI output to one label.
         let mut transcribe_fut = tokio::task::spawn_blocking(move || {
-            whisper_ref.with_model(
-                effective_model,
-                ContextProfile::TokenAlignment,
-                |backend| {
-                    backend.transcribe_sync_for_diarization(
-                        &audio_for_transcribe,
-                        language,
-                        prompt_ref.as_deref(),
-                    )
-                },
-            )
+            whisper_ref.with_model(effective_model, ContextProfile::TokenAlignment, |backend| {
+                backend.transcribe_sync_for_diarization(
+                    &audio_for_transcribe,
+                    language,
+                    prompt_ref.as_deref(),
+                )
+            })
         });
 
         let timeout = file_timeout;
@@ -1565,10 +2168,6 @@ pub async fn transcribe_file(
 
     // Standard (non-diarize) transcription path. File transcription defaults to
     // beam search (quality over latency).
-    let mut opts = {
-        let ctrl = controller.lock().unwrap();
-        build_file_transcribe_options(ctrl.settings(), prompt)
-    };
     opts.parallel_chunks =
         recommended_parallel_chunks(audio.len(), effective_model, opts.beam_size);
     let _ = app.emit(crate::events::event::STATE_CHANGED, "transcribing");
@@ -1813,17 +2412,15 @@ mod macos_mic {
     /// Ensure AVFoundation framework is loaded (required for AVCaptureDevice class lookup).
     fn ensure_avfoundation_loaded() {
         static LOAD: Once = Once::new();
-        LOAD.call_once(|| {
-            unsafe {
-                let ns_bundle_class = Class::get("NSBundle").expect("NSBundle class");
-                let path: *mut Object = msg_send![
-                    Class::get("NSString").expect("NSString"),
-                    stringWithUTF8String: c"/System/Library/Frameworks/AVFoundation.framework".as_ptr()
-                ];
-                let bundle: *mut Object = msg_send![ns_bundle_class, bundleWithPath: path];
-                if !bundle.is_null() {
-                    let _loaded: bool = msg_send![bundle, load];
-                }
+        LOAD.call_once(|| unsafe {
+            let ns_bundle_class = Class::get("NSBundle").expect("NSBundle class");
+            let path: *mut Object = msg_send![
+                Class::get("NSString").expect("NSString"),
+                stringWithUTF8String: c"/System/Library/Frameworks/AVFoundation.framework".as_ptr()
+            ];
+            let bundle: *mut Object = msg_send![ns_bundle_class, bundleWithPath: path];
+            if !bundle.is_null() {
+                let _loaded: bool = msg_send![bundle, load];
             }
         });
     }
@@ -1954,7 +2551,7 @@ mod macos_mic {
 
     #[cfg(test)]
     mod tests {
-        use super::{AccessRequestDecision, access_request_decision, authorization_status_label};
+        use super::{access_request_decision, authorization_status_label, AccessRequestDecision};
 
         #[test]
         fn maps_avfoundation_authorization_constants_correctly() {
@@ -1972,8 +2569,14 @@ mod macos_mic {
 
         #[test]
         fn request_decision_live_queries_undetermined_and_cached_denied() {
-            assert_eq!(access_request_decision(0), AccessRequestDecision::QuerySystem);
-            assert_eq!(access_request_decision(2), AccessRequestDecision::QuerySystem);
+            assert_eq!(
+                access_request_decision(0),
+                AccessRequestDecision::QuerySystem
+            );
+            assert_eq!(
+                access_request_decision(2),
+                AccessRequestDecision::QuerySystem
+            );
         }
 
         #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -949,6 +949,7 @@ fn main() {
             commands::set_auto_paste,
             commands::set_show_overlay,
             commands::set_initial_prompt,
+            commands::set_profile_glossary,
             commands::suggest_training_glossary,
             commands::apply_training_glossary,
             commands::set_beam_size,

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -161,7 +161,15 @@
   let glossaryDraftGeneration = 0;
   let lastStoredGlossarySources: Record<string, string> = {};
   let glossaryEditBaseline: { scopeId: string; source: string; generation: number } | null = null;
-  let orphanGlossaryDraft: { scopeId: string; draft: string } | null = $state(null);
+  type RecoveredGlossaryDraft = { scopeId: string; draft: string; conflicted: boolean };
+  type GlossarySaveRequest = {
+    scopeId: string;
+    generation: number;
+    draftGeneration: number;
+    value: string;
+  };
+  let recoveredGlossaryDrafts: RecoveredGlossaryDraft[] = $state([]);
+  let glossaryConflictScopeId: string | null = $state(null);
 
   const dictionaryConflictPrefix = "Dictionary changed elsewhere:";
 
@@ -181,6 +189,38 @@
 
   function isValidGlossaryScope(scopeId: string, source: Settings | null = settings): boolean {
     return scopeId === "" || profileForId(scopeId, source) !== null;
+  }
+
+  function glossaryScopeLabel(scopeId: string, source: Settings | null = settings): string {
+    if (scopeId === "") return "Global hints";
+    return profileForId(scopeId, source)?.name ?? scopeId;
+  }
+
+  function rememberGlossaryRecovery(scopeId: string, draft: string, conflicted = false): void {
+    const existing = recoveredGlossaryDrafts.find(
+      (recovery) => recovery.scopeId === scopeId && recovery.draft === draft,
+    );
+    if (existing) {
+      if (conflicted && !existing.conflicted) {
+        recoveredGlossaryDrafts = recoveredGlossaryDrafts.map((recovery) =>
+          recovery === existing ? { ...recovery, conflicted: true } : recovery,
+        );
+      }
+      return;
+    }
+    recoveredGlossaryDrafts = [...recoveredGlossaryDrafts, { scopeId, draft, conflicted }];
+  }
+
+  function removeGlossaryRecovery(scopeId: string, draft: string): void {
+    recoveredGlossaryDrafts = recoveredGlossaryDrafts.filter(
+      (recovery) => recovery.scopeId !== scopeId || recovery.draft !== draft,
+    );
+  }
+
+  function isCurrentGlossaryRequest(request: GlossarySaveRequest): boolean {
+    return request.generation === glossaryScopeGeneration
+      && request.scopeId === glossaryScopeId
+      && request.draftGeneration === glossaryDraftGeneration;
   }
 
   function selectedTranscribeProfile(): HotkeyProfile | null {
@@ -214,13 +254,18 @@
           || (glossaryDraftInitialized && glossaryDraft !== (previousStored ?? currentStored))
         );
       if (removedProfileHasDraft) {
-        orphanGlossaryDraft = { scopeId: currentScope, draft: glossaryDraft };
+        rememberGlossaryRecovery(
+          currentScope,
+          glossaryDraft,
+          glossaryConflictScopeId === currentScope && settingsError.startsWith(dictionaryConflictPrefix),
+        );
       }
       glossaryScopeGeneration += 1;
       glossaryScopeId = "";
       glossaryDraft = currentSettings.initial_prompt;
       glossaryDraftGeneration += 1;
       glossaryEditBaseline = null;
+      glossaryConflictScopeId = null;
     }
     if (currentTranscribeProfile && !profileForId(currentTranscribeProfile, currentSettings)) {
       transcribeProfileId = null;
@@ -371,8 +416,12 @@
    * bindings re-render from state, so a native control that already shows
    * the rejected value snaps back). Never re-throws.
    */
-  async function applySetting(mutate: () => Promise<void>, errorSink?: { value: string }): Promise<boolean> {
-    settingsError = "";
+  async function applySetting(
+    mutate: () => Promise<void>,
+    errorSink?: { value: string },
+    reportError = true,
+  ): Promise<boolean> {
+    if (reportError) settingsError = "";
     try {
       await mutate();
       settings = await getSettings();
@@ -380,7 +429,7 @@
       return true;
     } catch (e: any) {
       const message = typeof e === "string" ? e : e?.message || "Failed to save setting.";
-      settingsError = message;
+      if (reportError) settingsError = message;
       if (errorSink) errorSink.value = message;
       if (settings) settings = { ...settings };
       return false;
@@ -481,21 +530,31 @@
     await applySetting(() => setShowOverlay(next));
   }
 
-  async function refreshDictionaryAfterConflict(primaryError: string) {
+  async function refreshDictionaryAfterConflict(primaryError: string, request: GlossarySaveRequest) {
     try {
       settings = await getSettings();
     } catch (error) {
       console.warn("Could not refresh the dictionary after a concurrent change", error);
     }
-    // The conflict belongs to this save request. Preserve it even if the
-    // fresh read or a concurrent settings operation changed shared UI state.
-    settingsError = primaryError;
+    // A stale request still refreshes the source of truth, but cannot replace
+    // a newer scope's error or draft. The recovery item carries its context.
+    if (isCurrentGlossaryRequest(request)) {
+      settingsError = primaryError;
+      glossaryConflictScopeId = request.scopeId;
+    } else {
+      rememberGlossaryRecovery(request.scopeId, request.value, true);
+    }
   }
 
   async function onInitialPromptBlur(e: Event) {
-    const scopeId = glossaryScopeId;
-    const generation = glossaryScopeGeneration;
-    const draftGeneration = glossaryDraftGeneration;
+    const request: GlossarySaveRequest = {
+      scopeId: glossaryScopeId,
+      generation: glossaryScopeGeneration,
+      draftGeneration: glossaryDraftGeneration,
+      value: (e.target as HTMLTextAreaElement).value,
+    };
+    const scopeId = request.scopeId;
+    const draftGeneration = request.draftGeneration;
     const value = (e.target as HTMLTextAreaElement).value;
     const editBaseline = glossaryEditBaseline;
     const expectedSource = editBaseline?.scopeId === scopeId
@@ -504,15 +563,26 @@
       : lastStoredGlossarySources[scopeId] ?? glossarySourceForScope(scopeId);
     glossaryDraft = value;
     if (!settings || !isValidGlossaryScope(scopeId)) return;
+    if (!editBaseline && value === (lastStoredGlossarySources[scopeId] ?? glossarySourceForScope(scopeId))) return;
 
     const saveError = { value: "" };
     const saved = await applySetting(() => scopeId === ""
       ? setInitialPrompt(value, expectedSource)
-      : setProfileGlossary(scopeId, value, expectedSource), saveError);
+      : setProfileGlossary(scopeId, value, expectedSource), saveError, false);
     const conflict = saveError.value.startsWith(dictionaryConflictPrefix);
+    let requestIsCurrent = isCurrentGlossaryRequest(request);
     if (conflict) {
-      await refreshDictionaryAfterConflict(saveError.value);
+      await refreshDictionaryAfterConflict(saveError.value, request);
+      requestIsCurrent = isCurrentGlossaryRequest(request);
+    } else if (!saved && !requestIsCurrent) {
+      rememberGlossaryRecovery(scopeId, value);
     }
+
+    if (requestIsCurrent) {
+      settingsError = saved ? "" : saveError.value;
+      if (saved) glossaryConflictScopeId = null;
+    }
+    if (saved) removeGlossaryRecovery(scopeId, value);
 
     // If our own save won the CAS race while the user kept typing in the
     // same edit lineage, advance only that lineage's baseline to our value.
@@ -533,16 +603,9 @@
 
     // A selector change while the invoke was pending owns the textarea now;
     // never overwrite its newer scope with this request's result.
-    if (
-      generation !== glossaryScopeGeneration
-      || scopeId !== glossaryScopeId
-      || draftGeneration !== glossaryDraftGeneration
-    ) return;
+    if (!requestIsCurrent) return;
     if (saved) {
       if (glossaryEditBaseline === editBaseline) glossaryEditBaseline = null;
-    } else if (!conflict && settings) {
-      glossaryDraft = glossarySourceForScope(scopeId, settings);
-      glossaryEditBaseline = null;
     }
   }
 
@@ -561,10 +624,22 @@
   function onGlossaryScopeChange(e: Event) {
     const nextScope = (e.target as HTMLSelectElement).value;
     if (!settings || !isValidGlossaryScope(nextScope)) return;
+    const previousScope = glossaryScopeId;
+    const previousConflict = glossaryConflictScopeId === previousScope
+      && settingsError.startsWith(dictionaryConflictPrefix);
+    if (
+      glossaryEditBaseline?.scopeId === previousScope
+      || previousConflict
+    ) {
+      rememberGlossaryRecovery(previousScope, glossaryDraft, previousConflict);
+    }
     glossaryScopeGeneration += 1;
     glossaryDraftGeneration += 1;
     glossaryEditBaseline = null;
-    if (settingsError.startsWith(dictionaryConflictPrefix)) settingsError = "";
+    if (previousConflict) {
+      settingsError = "";
+      glossaryConflictScopeId = null;
+    }
     glossaryScopeId = nextScope;
     glossaryDraft = glossarySourceForScope(nextScope, settings);
   }
@@ -1171,22 +1246,30 @@
               This explicit-language profile supplies deterministic aliases for its language. Leaving this field saves this profile only; switching scope never moves entries to another dictionary.
             </div>
           {/if}
-          {#if settingsError.startsWith(dictionaryConflictPrefix)}
+          {#if glossaryConflictScopeId === glossaryScopeId && settingsError.startsWith(dictionaryConflictPrefix)}
             <div class="hotkey-hint glossary-migration">
               This dictionary changed elsewhere. Your draft is preserved; copy it if needed, then switch scopes and reselect this scope to reload the saved value. If it still shows the old text, close and reopen Settings.
             </div>
           {/if}
-          {#if orphanGlossaryDraft}
+          {#if recoveredGlossaryDrafts.length > 0}
             <div class="hotkey-hint glossary-migration">
-              Unsaved draft for removed profile <code>{orphanGlossaryDraft.scopeId}</code> was preserved below. Copy it before re-creating or selecting a replacement profile; it is never saved automatically into Global hints.
+              Unsaved drafts are preserved below for manual recovery. They are never saved or copied automatically into another dictionary.
             </div>
-            <textarea
-              class="initial-prompt-input"
-              rows="3"
-              aria-label="Recovered dictionary draft"
-              value={orphanGlossaryDraft.draft}
-              readonly
-            ></textarea>
+            {#each recoveredGlossaryDrafts as recovery (recovery.scopeId + "\u0000" + recovery.draft)}
+              <div class="glossary-recovery">
+                <div class="hotkey-hint">
+                  <strong>Unsaved draft</strong> for <code>{glossaryScopeLabel(recovery.scopeId)}</code>
+                  {#if recovery.conflicted} — the saved dictionary changed elsewhere.{/if}
+                </div>
+                <textarea
+                  class="initial-prompt-input"
+                  rows="3"
+                  aria-label={`Unsaved draft for ${glossaryScopeLabel(recovery.scopeId)}`}
+                  value={recovery.draft}
+                  readonly
+                ></textarea>
+              </div>
+            {/each}
           {/if}
           <div class="hotkey-hint">
             One preferred spelling per line. Add exact mishearings after <code>=</code>, separated by <code>|</code>.

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -9,6 +9,7 @@
     setHotkeyProfiles,
     setAutoPaste,
     setInitialPrompt,
+    setProfileGlossary,
     setShowOverlay,
     setWhisperModel,
     setBeamSize,
@@ -146,6 +147,85 @@
   let dragOver: boolean = $state(false);
   let transcribePrompt: string = $state('');
   let transcribeDiarize: boolean = $state(false);
+  let transcribeProfileId: string | null = $state(null);
+
+  // The global dictionary is retained as a decoder hint source. Explicit
+  // language profiles are the only selectable sources for deterministic
+  // glossary replacements.
+  // Empty string is the UI-only global sentinel; profile IDs may legally be
+  // "global", so that name cannot identify the global scope.
+  let glossaryScopeId: string = $state("");
+  let glossaryDraft: string = $state("");
+  let glossaryDraftInitialized = false;
+  let glossaryScopeGeneration = 0;
+  let glossaryDraftGeneration = 0;
+  let lastStoredGlossarySources: Record<string, string> = {};
+  let glossaryEditBaseline: { scopeId: string; source: string; generation: number } | null = null;
+  let orphanGlossaryDraft: { scopeId: string; draft: string } | null = $state(null);
+
+  const dictionaryConflictPrefix = "Dictionary changed elsewhere:";
+
+  function explicitProfiles(source: Settings | null = settings): HotkeyProfile[] {
+    return source?.hotkey_profiles.filter((profile) => profile.language !== "auto") ?? [];
+  }
+
+  function profileForId(profileId: string | null, source: Settings | null = settings): HotkeyProfile | null {
+    if (!profileId) return null;
+    return explicitProfiles(source).find((profile) => profile.id === profileId) ?? null;
+  }
+
+  function glossarySourceForScope(scopeId: string, source: Settings | null = settings): string {
+    if (!source || scopeId === "") return source?.initial_prompt ?? "";
+    return source.profile_glossaries[scopeId] ?? "";
+  }
+
+  function isValidGlossaryScope(scopeId: string, source: Settings | null = settings): boolean {
+    return scopeId === "" || profileForId(scopeId, source) !== null;
+  }
+
+  function selectedTranscribeProfile(): HotkeyProfile | null {
+    return profileForId(transcribeProfileId);
+  }
+
+  function transcribeLanguage(): Language {
+    return selectedTranscribeProfile()?.language ?? settings?.language ?? "auto";
+  }
+
+  // Settings can be reloaded after hotkey/profile changes. Never leave a
+  // removed or newly-Auto profile selected, and never show another scope's
+  // text after that reconciliation.
+  $effect(() => {
+    const currentSettings = settings;
+    const currentScope = glossaryScopeId;
+    const currentTranscribeProfile = transcribeProfileId;
+    if (!currentSettings) return;
+
+    const currentStored = glossarySourceForScope(currentScope, currentSettings);
+    const previousStored = lastStoredGlossarySources[currentScope];
+    if (!glossaryDraftInitialized || glossaryDraft === previousStored) {
+      glossaryDraft = currentStored;
+      glossaryDraftInitialized = true;
+    }
+    lastStoredGlossarySources[currentScope] = currentStored;
+    if (!isValidGlossaryScope(currentScope, currentSettings)) {
+      const removedProfileHasDraft = currentScope !== ""
+        && (
+          glossaryEditBaseline?.scopeId === currentScope
+          || (glossaryDraftInitialized && glossaryDraft !== (previousStored ?? currentStored))
+        );
+      if (removedProfileHasDraft) {
+        orphanGlossaryDraft = { scopeId: currentScope, draft: glossaryDraft };
+      }
+      glossaryScopeGeneration += 1;
+      glossaryScopeId = "";
+      glossaryDraft = currentSettings.initial_prompt;
+      glossaryDraftGeneration += 1;
+      glossaryEditBaseline = null;
+    }
+    if (currentTranscribeProfile && !profileForId(currentTranscribeProfile, currentSettings)) {
+      transcribeProfileId = null;
+    }
+  });
 
   async function refreshProfileModels(profiles: HotkeyProfile[]) {
     const generation = ++profileModelRefresh;
@@ -291,7 +371,7 @@
    * bindings re-render from state, so a native control that already shows
    * the rejected value snaps back). Never re-throws.
    */
-  async function applySetting(mutate: () => Promise<void>): Promise<boolean> {
+  async function applySetting(mutate: () => Promise<void>, errorSink?: { value: string }): Promise<boolean> {
     settingsError = "";
     try {
       await mutate();
@@ -299,7 +379,9 @@
       await refreshProfileModels(settings.hotkey_profiles);
       return true;
     } catch (e: any) {
-      settingsError = typeof e === "string" ? e : e?.message || "Failed to save setting.";
+      const message = typeof e === "string" ? e : e?.message || "Failed to save setting.";
+      settingsError = message;
+      if (errorSink) errorSink.value = message;
       if (settings) settings = { ...settings };
       return false;
     }
@@ -399,10 +481,92 @@
     await applySetting(() => setShowOverlay(next));
   }
 
+  async function refreshDictionaryAfterConflict(primaryError: string) {
+    try {
+      settings = await getSettings();
+    } catch (error) {
+      console.warn("Could not refresh the dictionary after a concurrent change", error);
+    }
+    // The conflict belongs to this save request. Preserve it even if the
+    // fresh read or a concurrent settings operation changed shared UI state.
+    settingsError = primaryError;
+  }
+
   async function onInitialPromptBlur(e: Event) {
-    if (!settings) return;
+    const scopeId = glossaryScopeId;
+    const generation = glossaryScopeGeneration;
+    const draftGeneration = glossaryDraftGeneration;
     const value = (e.target as HTMLTextAreaElement).value;
-    await applySetting(() => setInitialPrompt(value));
+    const editBaseline = glossaryEditBaseline;
+    const expectedSource = editBaseline?.scopeId === scopeId
+      && editBaseline.generation <= draftGeneration
+      ? editBaseline.source
+      : lastStoredGlossarySources[scopeId] ?? glossarySourceForScope(scopeId);
+    glossaryDraft = value;
+    if (!settings || !isValidGlossaryScope(scopeId)) return;
+
+    const saveError = { value: "" };
+    const saved = await applySetting(() => scopeId === ""
+      ? setInitialPrompt(value, expectedSource)
+      : setProfileGlossary(scopeId, value, expectedSource), saveError);
+    const conflict = saveError.value.startsWith(dictionaryConflictPrefix);
+    if (conflict) {
+      await refreshDictionaryAfterConflict(saveError.value);
+    }
+
+    // If our own save won the CAS race while the user kept typing in the
+    // same edit lineage, advance only that lineage's baseline to our value.
+    // A reselected scope has a different baseline object and is never
+    // silently advanced from a fresh settings read.
+    if (
+      saved
+      && editBaseline
+      && glossaryEditBaseline === editBaseline
+      && editBaseline.scopeId === scopeId
+    ) {
+      if (draftGeneration === glossaryDraftGeneration) {
+        glossaryEditBaseline = null;
+      } else {
+        glossaryEditBaseline = { ...editBaseline, source: value };
+      }
+    }
+
+    // A selector change while the invoke was pending owns the textarea now;
+    // never overwrite its newer scope with this request's result.
+    if (
+      generation !== glossaryScopeGeneration
+      || scopeId !== glossaryScopeId
+      || draftGeneration !== glossaryDraftGeneration
+    ) return;
+    if (saved) {
+      if (glossaryEditBaseline === editBaseline) glossaryEditBaseline = null;
+    } else if (!conflict && settings) {
+      glossaryDraft = glossarySourceForScope(scopeId, settings);
+      glossaryEditBaseline = null;
+    }
+  }
+
+  function onGlossaryInput(e: Event) {
+    if (!glossaryEditBaseline || glossaryEditBaseline.scopeId !== glossaryScopeId) {
+      glossaryEditBaseline = {
+        scopeId: glossaryScopeId,
+        source: lastStoredGlossarySources[glossaryScopeId] ?? glossarySourceForScope(glossaryScopeId),
+        generation: glossaryDraftGeneration + 1,
+      };
+    }
+    glossaryDraftGeneration += 1;
+    glossaryDraft = (e.target as HTMLTextAreaElement).value;
+  }
+
+  function onGlossaryScopeChange(e: Event) {
+    const nextScope = (e.target as HTMLSelectElement).value;
+    if (!settings || !isValidGlossaryScope(nextScope)) return;
+    glossaryScopeGeneration += 1;
+    glossaryDraftGeneration += 1;
+    glossaryEditBaseline = null;
+    if (settingsError.startsWith(dictionaryConflictPrefix)) settingsError = "";
+    glossaryScopeId = nextScope;
+    glossaryDraft = glossarySourceForScope(nextScope, settings);
   }
 
   async function onBeamSizeChange(e: Event) {
@@ -506,6 +670,7 @@
 
   async function handleFileTranscription(filePath: string) {
     if (transcribing) return;
+    const profileId = selectedTranscribeProfile()?.id;
     transcribing = true;
     transcriptionProgress = 0;
     transcribeError = "";
@@ -514,6 +679,7 @@
       transcriptionResult = await transcribeFile(filePath, {
         prompt: transcribePrompt.trim() || undefined,
         diarize: transcribeDiarize,
+        profileId: profileId ?? undefined,
       });
     } catch (e: any) {
       transcribeError = typeof e === "string" ? e : e.message || "Transcription failed";
@@ -521,6 +687,11 @@
       transcribing = false;
       transcriptionProgress = 0;
     }
+  }
+
+  function onTranscribeProfileChange(e: Event) {
+    const nextProfileId = (e.target as HTMLSelectElement).value;
+    transcribeProfileId = profileForId(nextProfileId)?.id ?? null;
   }
 
   async function onPickFile() {
@@ -883,7 +1054,7 @@
         <button class="active-config-bar" onclick={() => (activeTab = "settings")}>
           <div class="active-config-row">
             <span class="active-config-label">Language</span>
-            <span class="active-config-value">{languageLabel(settings.language)}</span>
+            <span class="active-config-value">{languageLabel(transcribeLanguage())}</span>
           </div>
           <span class="active-config-link">Settings</span>
         </button>
@@ -913,6 +1084,20 @@
         </div>
 
         <div class="transcribe-options">
+          <div class="field">
+            <label for="transcribe-profile">Profile (optional)</label>
+            <select id="transcribe-profile" value={transcribeProfileId ?? ""} onchange={onTranscribeProfileChange}>
+              <option value="">No profile (use selected language)</option>
+              {#each explicitProfiles() as profile (profile.id)}
+                <option value={profile.id}>{profile.name} · {languageLabel(profile.language)}</option>
+              {/each}
+            </select>
+          </div>
+          {#if selectedTranscribeProfile()}
+            <div class="hotkey-hint">This profile fixes the file language and uses its personal dictionary.</div>
+          {:else}
+            <div class="hotkey-hint">No profile keeps the selected language and global hint context.</div>
+          {/if}
           <label class="diarize-option">
             <input type="checkbox" bind:checked={transcribeDiarize} />
             Speaker diarization
@@ -924,7 +1109,7 @@
             bind:value={transcribePrompt}
             rows="2"
           ></textarea>
-          <div class="hotkey-hint">Temporary context for this import. Your personal dictionary is managed in Settings.</div>
+          <div class="hotkey-hint">Temporary hint-only context for this import. A selected profile supplies its dictionary; no profile uses global hints.</div>
         </div>
 
         {#if transcribeError}
@@ -962,14 +1147,47 @@
 
         <div class="field">
           <label for="initial-prompt">Personal dictionary</label>
+          <select id="dictionary-scope" value={glossaryScopeId} onchange={onGlossaryScopeChange}>
+            <option value="">Global hints</option>
+            {#each explicitProfiles() as profile (profile.id)}
+              <option value={profile.id}>{profile.name} · {languageLabel(profile.language)}</option>
+            {/each}
+          </select>
           <textarea
             id="initial-prompt"
             class="initial-prompt-input"
             rows="5"
-            value={settings.initial_prompt}
+            value={glossaryDraft}
             onblur={onInitialPromptBlur}
+            oninput={onGlossaryInput}
             placeholder="OpenRouter = open router | open vrouter&#10;merge = merch&#10;Cloudflare = cloud flare"
           ></textarea>
+          {#if glossaryScopeId === ""}
+            <div class="hotkey-hint glossary-migration">
+              Global entries are hint-only and remain stored. To enable deterministic alias replacements, copy an entry into the explicit-language profile that should use it.
+            </div>
+          {:else}
+            <div class="hotkey-hint glossary-migration">
+              This explicit-language profile supplies deterministic aliases for its language. Leaving this field saves this profile only; switching scope never moves entries to another dictionary.
+            </div>
+          {/if}
+          {#if settingsError.startsWith(dictionaryConflictPrefix)}
+            <div class="hotkey-hint glossary-migration">
+              This dictionary changed elsewhere. Your draft is preserved; copy it if needed, then switch scopes and reselect this scope to reload the saved value. If it still shows the old text, close and reopen Settings.
+            </div>
+          {/if}
+          {#if orphanGlossaryDraft}
+            <div class="hotkey-hint glossary-migration">
+              Unsaved draft for removed profile <code>{orphanGlossaryDraft.scopeId}</code> was preserved below. Copy it before re-creating or selecting a replacement profile; it is never saved automatically into Global hints.
+            </div>
+            <textarea
+              class="initial-prompt-input"
+              rows="3"
+              aria-label="Recovered dictionary draft"
+              value={orphanGlossaryDraft.draft}
+              readonly
+            ></textarea>
+          {/if}
           <div class="hotkey-hint">
             One preferred spelling per line. Add exact mishearings after <code>=</code>, separated by <code>|</code>.
             Plain terms still guide Whisper. Saved automatically when you leave the field and used for live dictation and batch jobs.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,8 +130,12 @@ export async function setAutoPaste(enabled: boolean): Promise<void> {
   return invoke("set_auto_paste", { enabled });
 }
 
-export async function setInitialPrompt(prompt: string): Promise<void> {
-  return invoke("set_initial_prompt", { prompt });
+export async function setInitialPrompt(prompt: string, expectedSource?: string): Promise<void> {
+  return invoke("set_initial_prompt", { prompt, expectedSource });
+}
+
+export async function setProfileGlossary(profileId: string, source: string, expectedSource?: string): Promise<void> {
+  return invoke("set_profile_glossary", { profileId, source, expectedSource });
 }
 
 export async function setShowOverlay(enabled: boolean): Promise<void> {
@@ -180,12 +184,13 @@ export async function getBuildInfo(): Promise<BuildInfo> {
 
 export async function transcribeFile(
   filePath: string,
-  options?: { prompt?: string; diarize?: boolean }
+  options?: { prompt?: string; diarize?: boolean; profileId?: string }
 ): Promise<string> {
   return invoke("transcribe_file", {
     filePath,
     prompt: options?.prompt ?? null,
     diarize: options?.diarize ?? false,
+    profileId: options?.profileId ?? null,
   });
 }
 


### PR DESCRIPTION
## Outcome

Closes #150.

Adds explicit language-bound profile glossary aliases across live dictation, GUI file transcription, CLI record and batch/diarized transcription. A Swedish profile may correct `merch` to `merge`; the English profile preserves ordinary English `merch`.

## Behavior and migration

- Global glossary, legacy unscoped aliases and one-run hints remain Whisper hints only. Their stored source is preserved; no automatic destructive migration.
- Deterministic replacements require an explicitly selected existing profile with the same explicit, known non-Auto language. Unknown/Auto/mismatched scopes fail closed.
- Existing whole-term, Unicode case, longest-first, non-cascading and ambiguous-alias protections remain shared. Model/language/options/glossary are frozen before file decoding.
- GUI and CLI expose equivalent scoped functionality. GUI saves use compare-and-swap against fresh disk state; late saves cannot cross profile/language boundaries. Rejected drafts are retained in a labeled, read-only recovery collection rather than silently discarded or automatically applied.
- Dictionary-bearing profiles cannot silently change language; reset and implicit default-profile behavior are covered.
- No implicit model downloads, remote processing or shipped model-default changes.

Decision and examples: `docs/glossary-scoping-decision.md`, `docs/personal-glossary.md`, `docs/configuration.md`.

## Verification

- Integrated merged R1 base `b10a12e442962510d748e437484a24e57f185838` at head `17bf9ad808d3d3b6786c2026476b448ac3f22344`; source tree unchanged by the final topology-only integration.
- Full unfiltered Rust workspace: **786 passed** (190 app, 160 CLI unit, 36 CLI integration, 400 core), workspace check, all-target clippy with warnings denied, lean CLI build.
- **92 frontend tests passed**, one Windows-only local skip; Svelte check, build, metadata/license checks and actionlint passed.
- Synthetic browser visual verification covered recovered drafts and both late-await freshness boundaries; no user microphone, clipboard or settings involved.
- Actual independent reviewer **Claude Fable 5.1 (`claude-fable-5-1`) APPROVE** after grounded draft-loss, second-await freshness and disk CRLF normalization findings were fixed. Later R1 integration was independently reviewed and did not alter this feature diff.

Draft until exact-head platform CI is green. This is a scoped dictionary fix, not evidence of improved speech-recognition accuracy or completed physical latency acceptance.
