### PR TITLE
feat(presenter): guarded atomic Start and Finish workflow

### DIFF
--- a/docs/presenter-mode-design.md
+++ b/docs/presenter-mode-design.md
@@ -1,0 +1,160 @@
+# Presenter mode (#162): implementation contract
+
+Status: runtime integration implemented, verification/review in progress; not
+feature complete. Do not publish this as a completed feature until the runtime,
+CLI, UI, independent review and physical acceptance checks below pass.
+
+## Current implementation snapshot
+
+The desktop runtime now has the Presenter state flow: an existing language
+profile shortcut starts a session, the configured Finish shortcut stops and
+transcribes it, and the optional Cancel shortcut cancels it. If Start omits a
+profile ID, the default profile is selected when present, otherwise the first
+resolved profile is used. The action and target are frozen per session and
+generation checks reject stale callbacks.
+
+On macOS, verified insertion additionally requires Presenter mode and
+auto-paste to be enabled, a supported Accessibility target, released shortcut
+modifiers, and observed post-insertion field state. Held modifiers, unknown or
+unsupported targets, target changes, missing evidence, and expired observation
+deadlines retain any recognized text as a draft rather than submitting it.
+Empty or failed transcription never submits and creates no new recognized draft.
+Windows and Linux currently retain drafts for
+manual copy; they do not advertise automatic target-aware submission.
+
+Field contents and selections used for verification stay in bounded transient
+process memory only. They are not written to logs, settings, IPC, or status
+messages. A successful submit-key dispatch is not proof that the editor or an
+application/server accepted the prompt; the `Sent` status means only that the
+native key action reported success.
+
+## Activation and configuration
+
+Existing per-language profile shortcuts are the atomic **Start** actions in
+Presenter mode. A separate global Finish shortcut stops the active presenter
+recording and transcribes using its frozen profile. An optional Cancel shortcut
+aborts the presenter session. Key release never finishes Presenter mode, and a
+second Start while busy is a no-op. Push-to-talk and Toggle retain their current
+semantics. Training recordings are never controlled by Presenter shortcuts.
+
+The default finish action is Insert only. Return and Command+Return require an
+explicit rule for the captured application's stable native identity. Rules are
+not inferred from titles, websites, transcription text, or a process name.
+Command+Return means the macOS Command modifier; unsupported platform actions
+must fail closed, not silently turn into another keystroke.
+
+Profile, Finish and Cancel bindings belong to one validated registration
+transaction. Canonical aliases must not create duplicate bindings. A failed
+registration must retain/restore the previous effective bindings and expose an
+error; persistence must not falsely claim that new shortcuts are operational.
+Changing active configuration during a recording must not retarget that session.
+
+## Insertion and submission boundary
+
+At Start, capture the target application and focused field before showing any
+UI. Native handles stay on their required thread and are never serialized or
+logged. Text used to verify insertion stays only in bounded session memory;
+no field values, titles or clipboard contents enter diagnostics or IPC.
+Unknown, inaccessible, secure or unsupported targets cannot authorize Submit.
+
+The session freezes its action and target. Focus-change notifications invalidate
+submission eligibility irreversibly for that session, including a change away
+and back. Rechecking the current target is also required immediately before
+insertion and before Submit. Notification support or native verification failure
+must never degrade into unchecked Return injection.
+
+Successful transcription and a nonempty result are necessary but insufficient.
+The existing paste callback means the native paste call returned; it does **not**
+prove the editor received text. Submit requires observable target-field state
+matching the exact expected post-insertion value and selection. A deadline may
+bound waiting for this evidence; elapsed time is never evidence of completion.
+Do not alter the legacy paste path merely to accommodate Presenter mode.
+
+Cancellation, stale callbacks, timeout, insertion failure, target change or
+missing evidence must never submit. Consume a successful submission opportunity
+at most once. Preserve recognized text as a draft/copy fallback with a clear
+status, without moving focus while a pending native action could still execute.
+Cancellation during inference must invalidate pending insertion and Submit, not
+open a new recording while the old worker can still mutate controller state.
+
+macOS integration will use its existing Accessibility permission; it must not
+request or modify TCC approval in background. The platform adapter must verify
+notification support because [AXObserverAddNotification](https://developer.apple.com/documentation/applicationservices/1462089-axobserveraddnotification)
+can report unsupported notifications. The
+[focused-element notification](https://developer.apple.com/documentation/applicationservices/kaxfocuseduielementchangednotification)
+is an observation input, not authorization to synthesize a key.
+Windows/Linux require their own verified target/field adapters before equivalent
+automatic submission can be advertised. Unsupported paths retain drafts.
+
+## CLI parity and feedback
+
+The CLI exposes explicit presenter Start, Finish and Cancel. The supported
+request commands are:
+
+```text
+sagascript presenter start [PROFILE-ID]
+sagascript presenter finish
+sagascript presenter cancel
+```
+
+`PROFILE-ID` is optional and must use the bounded lowercase ASCII profile-ID
+grammar. These commands send a private request to the installed desktop app;
+the CLI process does not itself record, transcribe, insert text, or report
+completion. The desktop handles the requested action. The existing
+single-instance argv transport can carry fixed action markers but has no result
+acknowledgment today. A launcher success may therefore only mean a request was
+sent, never that recording or insertion succeeded. Keep the grammar bounded,
+reject mixed/unknown markers, ignore caller cwd, and carry no text or paths.
+Presenter dispatch must bypass Settings reveal and activation paths entirely.
+
+Presenter configuration is available through the existing CLI config command;
+these are the exact source-documented forms (not executed as part of this
+documentation update):
+
+```text
+sagascript config set hotkey_mode presenter
+sagascript config presenter show
+sagascript config presenter finish 'Control+Shift+Enter'
+sagascript config presenter cancel 'Control+Shift+Escape'
+sagascript config presenter cancel
+sagascript config presenter app com.example.editor command_return
+sagascript config presenter remove-app com.example.editor
+```
+
+Application actions are explicit opt-ins and default to `insert_only`. Verified
+native insertion in the runtime is gated by Presenter mode and auto-paste being
+enabled; the app-specific Return actions additionally require the supported
+macOS target path and Accessibility permission.
+
+Expose Listening, Transcribing, Inserted, Sent, Cancelled, draft-on-target-change
+and failure outcomes without transient messages falsely claiming delivery.
+Settings should explain that Logitech Spotlight maps its long-press actions to
+the two atomic shortcuts; Sagascript does not implement the remote's press
+timing. The physical Spotlight mapping is external to the app and remains
+unverified.
+
+## Required verification
+
+- Red/green tests for legacy settings compatibility, explicit opt-in rules,
+  canonical shortcut collisions and atomic rejected updates.
+- State tests for duplicate Start/Finish/Cancel, key releases, training isolation,
+  late callbacks and configuration changes; PTT/Toggle regressions remain green.
+- Injected insertion/target tests prove no Submit on empty/failed transcription,
+  unknown/changed focus, unsupported notifications, timeout, cancellation or
+  unmatched text; prove one Submit only after observed insertion.
+- Pure UTF-16 range tests cover emoji boundaries and overflow without normalizing
+  text, before using native selected-range coordinates.
+- CLI parsing/transport tests prove no focus-taking operation and no false
+  completion acknowledgment. Frontend tests and visual verification cover all
+  new controls/statuses; full Rust/frontend checks precede cross-model review.
+- Signed-device tests, not unsigned development or source inspection, must prove
+  real focus continuity, insertion observation, permission behavior and Logitech
+  Spotlight long-press mappings before the ticket's hardware acceptance is met.
+
+Current verification status: the pure routing, state-machine, generation,
+target-validation, UTF-16, observation-policy and CLI grammar tests are present;
+native Accessibility, clipboard, key dispatch, signed-device permission and
+physical Spotlight checks remain outstanding. Root's current UI check covered
+draft, sent and submit-uncertain statuses at narrow and wide widths, with no
+horizontal overflow and readable application-ID rows at 300 px. This does not
+replace signed-device or hardware acceptance.

--- a/docs/presenter-mode-design.md
+++ b/docs/presenter-mode-design.md
@@ -11,11 +11,16 @@ profile shortcut starts a session, the configured Finish shortcut stops and
 transcribes it, and the optional Cancel shortcut cancels it. If Start omits a
 profile ID, the default profile is selected when present, otherwise the first
 resolved profile is used. The action and target are frozen per session and
-generation checks reject stale callbacks.
+generation checks reject stale callbacks. Presenter ownership is explicit: a
+manual Dictate-button recording retains its normal completion/cancel pipeline
+even when the configured shortcut mode is Presenter. All Presenter transports,
+including hotkeys, dispatch their coordination onto the main thread.
 
 On macOS, verified insertion additionally requires Presenter mode and
 auto-paste to be enabled, a supported Accessibility target, released shortcut
-modifiers, and observed post-insertion field state. Held modifiers, unknown or
+modifiers, and observed post-insertion field state. A single two-second budget
+allows held Finish modifiers to be released before insertion and bounds the
+subsequent observation. Modifiers still held at expiry, unknown or
 unsupported targets, target changes, missing evidence, and expired observation
 deadlines retain any recognized text as a draft rather than submitting it.
 Empty or failed transcription never submits and creates no new recognized draft.
@@ -83,6 +88,15 @@ notification support because [AXObserverAddNotification](https://developer.apple
 can report unsupported notifications. The
 [focused-element notification](https://developer.apple.com/documentation/applicationservices/kaxfocuseduielementchangednotification)
 is an observation input, not authorization to synthesize a key.
+Apple declares [accessibilitySubrole](https://developer.apple.com/documentation/appkit/nsaccessibility-c.protocol/accessibilitysubrole)
+nullable. A subrole read reporting only the documented
+[no-value or unsupported-attribute result](https://developer.apple.com/documentation/applicationservices/1462085-axuielementcopyattributevalue)
+is treated as absent; transport/permission failures, malformed null successes,
+wrong value types and explicit secure-field subroles remain rejected. The
+required text role, field-value/selection, application identity and notification
+checks still apply. Start revalidation reuses the current-target traversal
+already performed by its snapshot check; native capture latency remains to be
+measured on supported editors.
 Windows/Linux require their own verified target/field adapters before equivalent
 automatic submission can be advertised. Unsupported paths retain drafts.
 

--- a/scripts/test-presenter-settings.mjs
+++ b/scripts/test-presenter-settings.mjs
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const api = readFileSync(new URL("../src/lib/api.ts", import.meta.url), "utf8");
+const settings = readFileSync(new URL("../src/lib/Settings.svelte", import.meta.url), "utf8");
+const presenter = readFileSync(new URL("../src/lib/PresenterSettings.svelte", import.meta.url), "utf8");
+
+test("API exposes the presenter settings contract and command", () => {
+  assert.match(api, /export type HotkeyMode = "push" \| "toggle" \| "presenter";/);
+  assert.match(api, /export interface PresenterConfig/);
+  assert.match(api, /finish_shortcut: string;/);
+  assert.match(api, /cancel_shortcut: string \| null;/);
+  assert.match(api, /app_actions: Record<string, PresenterFinishAction>;/);
+  assert.match(api, /invoke\("set_presenter_config", \{ config \}\)/);
+});
+
+test("Settings exposes presenter mode as an explicit conditional editor", () => {
+  assert.match(settings, /<option value="presenter">Presenter<\/option>/);
+  assert.match(settings, /settings\.hotkey_mode === "presenter"/);
+  assert.match(settings, /<PresenterSettings/);
+  assert.match(settings, /setPresenterConfig\(config\)/);
+  assert.match(settings, /Presenter start shortcuts/);
+});
+
+test("Presenter editor keeps actions explicit and platform-bounded", () => {
+  for (const action of ["insert_only", "return", "command_return"]) {
+    assert.match(presenter, new RegExp(`value="${action}"`));
+  }
+  assert.match(presenter, /const supportsAutoSubmit = \(\) => platform === "macos"/);
+  assert.match(presenter, /disabled=\{!supportsAutoSubmit\(\)\}/);
+  assert.match(presenter, /stable IDs/);
+  assert.match(presenter, /does not detect titles,?\s*sites/);
+  assert.match(presenter, /at most 32 app actions/);
+});
+
+test("Presenter editor includes local canonical collision checks and preserves save errors", () => {
+  assert.match(presenter, /canonicalShortcut/);
+  assert.match(presenter, /Finish shortcut conflicts with a presenter start shortcut/);
+  assert.match(presenter, /Cancel shortcut conflicts with a presenter start shortcut/);
+  assert.match(presenter, /saveError/);
+  assert.match(presenter, /onSave\(cloneConfig\(draft\)\)/);
+});
+
+test("Presenter editor uses dark-theme controls and states focused-field requirements", () => {
+  assert.match(presenter, /<input\s+type="text"/);
+  assert.match(presenter, /class="link-btn secondary presenter-disable-cancel"/);
+  assert.match(presenter, /class="link-btn secondary" onclick=\{addAppAction\}/);
+  assert.match(presenter, /requires Accessibility permission and a verifiable focused text field/);
+  assert.match(presenter, /min-width: max-content/);
+  assert.match(presenter, /flex-shrink: 0/);
+  assert.match(presenter, /white-space: nowrap/);
+});
+
+test("Presenter application IDs stay readable in narrow action rows", () => {
+  assert.match(presenter, /<code title=\{appId\}>\{appId\}<\/code>/);
+  assert.match(presenter, /@media \(max-width: 520px\)/);
+  assert.match(presenter, /grid-template-columns: minmax\(0, 1fr\) auto/);
+  assert.match(presenter, /grid-column: 1 \/ -1/);
+  assert.match(presenter, /overflow-wrap: anywhere/);
+});

--- a/scripts/test-presenter-status.mjs
+++ b/scripts/test-presenter-status.mjs
@@ -14,6 +14,14 @@ test("Dictate renders fixed presenter status feedback", () => {
   assert.match(settings, /No speech detected/);
 });
 
+test("Presenter status does not hijack the selected tab", () => {
+  const listener = settings.match(/const presenterStatusListener = listen\([\s\S]*?\n    \}\)\.then\(remember\);/);
+  assert.ok(listener, "presenter-status listener should remain registered");
+  assert.doesNotMatch(listener[0], /activeTab\s*=/);
+  assert.match(listener[0], /typeof event\.payload !== "string"/);
+  assert.match(listener[0], /!isPresenterStatus\(event\.payload\)/);
+});
+
 test("Presenter UI uses manual-copy wording off macOS", () => {
   assert.match(presenterSettings, /Manual copy on this platform/);
   assert.doesNotMatch(presenterSettings, /Insert-only on this platform/);

--- a/scripts/test-presenter-status.mjs
+++ b/scripts/test-presenter-status.mjs
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const settings = readFileSync(new URL("../src/lib/Settings.svelte", import.meta.url), "utf8");
+const presenterSettings = readFileSync(new URL("../src/lib/PresenterSettings.svelte", import.meta.url), "utf8");
+
+test("Dictate renders fixed presenter status feedback", () => {
+  assert.match(settings, /listen\("presenter-status"/);
+  assert.match(settings, /let presenterStatus: PresenterStatus \| null = \$state\(null\)/);
+  assert.match(settings, /Submit key sent; delivery not confirmed/);
+  assert.match(settings, /Not sent — copy recognized text from Dictate/);
+  assert.match(settings, /Submit may have been sent — check destination before retrying/);
+  assert.match(settings, /No speech detected/);
+});
+
+test("Presenter UI uses manual-copy wording off macOS", () => {
+  assert.match(presenterSettings, /Manual copy on this platform/);
+  assert.doesNotMatch(presenterSettings, /Insert-only on this platform/);
+});

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -2,7 +2,8 @@ use clap::{Args, Subcommand};
 
 use sagascript_core::error::DictationError;
 use sagascript_core::settings::{
-    self, validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
+    self, validate_hotkey, HotkeyMode, HotkeyProfile, Language, PresenterConfig,
+    PresenterFinishAction, Settings, WhisperModel,
 };
 
 #[derive(Args)]
@@ -17,9 +18,10 @@ pub enum ConfigAction {
     #[command(long_about = "\
 Show all settings in a table with their current values and defaults.
 
-Valid keys: language, whisper_model, hotkey_mode, show_overlay, \
+Valid keys: language, whisper_model, hotkey_mode (push, toggle, presenter), show_overlay, \
 auto_paste, auto_select_model, hotkey, initial_prompt, \
-beam_size, temperature_fallback, vad_enabled")]
+beam_size, temperature_fallback, vad_enabled. Use `sagascript config presenter` \
+for presenter finish/cancel/app actions.")]
     List,
 
     /// Get a single setting value
@@ -27,7 +29,7 @@ beam_size, temperature_fallback, vad_enabled")]
         long_about = "\
 Print the current value of a single setting to stdout.
 
-Valid keys: language, whisper_model, hotkey_mode, show_overlay, \
+Valid keys: language, whisper_model, hotkey_mode (push, toggle, presenter), show_overlay, \
 auto_paste, auto_select_model, hotkey, initial_prompt, \
 beam_size, temperature_fallback, vad_enabled",
         after_long_help = "\
@@ -52,7 +54,7 @@ Valid values per key:
   whisper_model        tiny.en, tiny, base.en, base, kb-whisper-tiny,
                        kb-whisper-base, kb-whisper-small, nb-whisper-tiny,
                        nb-whisper-base, nb-whisper-small
-  hotkey_mode          push, toggle
+  hotkey_mode          push, toggle, presenter
   show_overlay         true, false
   auto_paste           true, false (enabling requires Accessibility approval for the installed GUI)
   auto_select_model    true, false
@@ -105,6 +107,25 @@ Print the absolute path to the settings JSON file. Use `sagascript glossary \
 path` for the separate personal dictionary.")]
     Path,
 
+    /// Configure the opt-in presenter hotkey mode
+    #[command(
+        long_about = "\
+Configure presenter mode. Existing profile shortcuts start dictation; the \
+finish shortcut ends it. App actions are opt-in and default to insert-only.",
+        after_long_help = "\
+EXAMPLES:
+  sagascript config presenter show
+  sagascript config presenter finish 'Control+Shift+Enter'
+  sagascript config presenter cancel 'Control+Shift+Escape'
+  sagascript config presenter cancel
+  sagascript config presenter app com.example.editor command_return
+  sagascript config presenter remove-app com.example.editor"
+    )]
+    Presenter {
+        #[command(subcommand)]
+        action: PresenterAction,
+    },
+
     /// Manage per-shortcut dictation language profiles
     Profiles {
         #[command(subcommand)]
@@ -140,6 +161,24 @@ pub enum ProfileAction {
     Remove { id: String },
 }
 
+#[derive(Subcommand)]
+pub enum PresenterAction {
+    /// Print the presenter configuration as JSON
+    Show,
+    /// Set the global presenter finish shortcut
+    Finish { shortcut: String },
+    /// Set the presenter cancel shortcut, or omit it to disable cancel
+    Cancel { shortcut: Option<String> },
+    /// Set an explicit action for an application identifier
+    App {
+        app_id: String,
+        #[arg(value_parser = ["insert_only", "return", "command_return"])]
+        action: String,
+    },
+    /// Remove an application-specific presenter action
+    RemoveApp { app_id: String },
+}
+
 const VALID_KEYS: &[&str] = &[
     "language",
     "whisper_model",
@@ -161,8 +200,85 @@ pub fn run(args: ConfigArgs) -> Result<(), DictationError> {
         ConfigAction::Set { key, value } => cmd_set(&key, &value),
         ConfigAction::Reset { key } => cmd_reset(key.as_deref()),
         ConfigAction::Path => cmd_path(),
+        ConfigAction::Presenter { action } => cmd_presenter(action),
         ConfigAction::Profiles { action } => cmd_profiles(action),
     }
+}
+
+fn cmd_presenter(action: PresenterAction) -> Result<(), DictationError> {
+    if matches!(&action, PresenterAction::Show) {
+        let presenter = settings::store::load().presenter;
+        let json = serde_json::to_string_pretty(&presenter)
+            .map_err(|error| DictationError::SettingsError(error.to_string()))?;
+        println!("{json}");
+        return Ok(());
+    }
+
+    let summary = match &action {
+        PresenterAction::Finish { shortcut } => format!("Presenter finish shortcut = {shortcut}"),
+        PresenterAction::Cancel {
+            shortcut: Some(shortcut),
+        } => {
+            format!("Presenter cancel shortcut = {shortcut}")
+        }
+        PresenterAction::Cancel { shortcut: None } => {
+            "Presenter cancel shortcut disabled".to_string()
+        }
+        PresenterAction::App { app_id, action } => {
+            format!("Presenter action for {app_id} = {action}")
+        }
+        PresenterAction::RemoveApp { app_id } => format!("Removed presenter action for {app_id}"),
+        PresenterAction::Show => unreachable!(),
+    };
+    update_presenter_config(|presenter| apply_presenter_action(presenter, action))?;
+    eprintln!("{summary}");
+    Ok(())
+}
+
+fn apply_presenter_action(
+    presenter: &mut PresenterConfig,
+    action: PresenterAction,
+) -> Result<(), String> {
+    match action {
+        PresenterAction::Show => Err("Presenter show does not mutate settings".to_string()),
+        PresenterAction::Finish { shortcut } => {
+            validate_hotkey(&shortcut)?;
+            presenter.finish_shortcut = shortcut;
+            Ok(())
+        }
+        PresenterAction::Cancel { shortcut } => {
+            if let Some(shortcut) = &shortcut {
+                validate_hotkey(shortcut)?;
+            }
+            presenter.cancel_shortcut = shortcut;
+            Ok(())
+        }
+        PresenterAction::App { app_id, action } => {
+            let action = parse_enum_value::<PresenterFinishAction>(&action, "presenter action")
+                .map_err(|error| error.to_string())?;
+            presenter.app_actions.insert(app_id, action);
+            Ok(())
+        }
+        PresenterAction::RemoveApp { app_id } => {
+            if presenter.app_actions.remove(&app_id).is_none() {
+                return Err(format!("No presenter action configured for app '{app_id}'"));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn update_presenter_config<F>(mutate: F) -> Result<PresenterConfig, DictationError>
+where
+    F: FnOnce(&mut PresenterConfig) -> Result<(), String>,
+{
+    let updated = settings::store::try_update(|settings| {
+        let mut presenter = settings.presenter.clone();
+        mutate(&mut presenter)?;
+        settings.replace_presenter_config(presenter)
+    })
+    .map_err(DictationError::SettingsError)?;
+    Ok(updated.presenter)
 }
 
 fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
@@ -170,18 +286,36 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
         ProfileAction::List => {
             println!("{:<16} {:<20} {:<28} LANGUAGE", "ID", "NAME", "HOTKEY");
             for profile in settings::store::load().resolved_hotkey_profiles() {
-                println!("{:<16} {:<20} {:<28} {}", profile.id, profile.name, profile.shortcut, format_language(profile.language));
+                println!(
+                    "{:<16} {:<20} {:<28} {}",
+                    profile.id,
+                    profile.name,
+                    profile.shortcut,
+                    format_language(profile.language)
+                );
             }
             Ok(())
         }
-        ProfileAction::Create { id, name, hotkey, language } => {
+        ProfileAction::Create {
+            id,
+            name,
+            hotkey,
+            language,
+        } => {
             let language = parse_enum_value::<Language>(&language, "language")?;
             let hotkey_warning = bare_extended_hotkey_warning(&hotkey);
             let mut profiles = settings::store::load().resolved_hotkey_profiles();
             if profiles.iter().any(|profile| profile.id == id) {
-                return Err(DictationError::SettingsError(format!("Profile '{id}' already exists")));
+                return Err(DictationError::SettingsError(format!(
+                    "Profile '{id}' already exists"
+                )));
             }
-            profiles.push(HotkeyProfile { id: id.clone(), name, shortcut: hotkey, language });
+            profiles.push(HotkeyProfile {
+                id: id.clone(),
+                name,
+                shortcut: hotkey,
+                language,
+            });
             persist_profiles(profiles)?;
             eprintln!("Created profile {id}");
             if let Some(warning) = hotkey_warning {
@@ -189,19 +323,36 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             }
             Ok(())
         }
-        ProfileAction::Update { id, name, hotkey, language } => {
+        ProfileAction::Update {
+            id,
+            name,
+            hotkey,
+            language,
+        } => {
             if name.is_none() && hotkey.is_none() && language.is_none() {
-                return Err(DictationError::SettingsError("Specify at least one of --name, --hotkey, or --language".to_string()));
+                return Err(DictationError::SettingsError(
+                    "Specify at least one of --name, --hotkey, or --language".to_string(),
+                ));
             }
-            let hotkey_warning = hotkey
+            let hotkey_warning = hotkey.as_deref().and_then(bare_extended_hotkey_warning);
+            let language = language
                 .as_deref()
-                .and_then(bare_extended_hotkey_warning);
-            let language = language.as_deref().map(|value| parse_enum_value::<Language>(value, "language")).transpose()?;
+                .map(|value| parse_enum_value::<Language>(value, "language"))
+                .transpose()?;
             let mut profiles = settings::store::load().resolved_hotkey_profiles();
-            let profile = profiles.iter_mut().find(|profile| profile.id == id).ok_or_else(|| DictationError::SettingsError(format!("Unknown profile '{id}'")))?;
-            if let Some(name) = name { profile.name = name; }
-            if let Some(hotkey) = hotkey { profile.shortcut = hotkey; }
-            if let Some(language) = language { profile.language = language; }
+            let profile = profiles
+                .iter_mut()
+                .find(|profile| profile.id == id)
+                .ok_or_else(|| DictationError::SettingsError(format!("Unknown profile '{id}'")))?;
+            if let Some(name) = name {
+                profile.name = name;
+            }
+            if let Some(hotkey) = hotkey {
+                profile.shortcut = hotkey;
+            }
+            if let Some(language) = language {
+                profile.language = language;
+            }
             persist_profiles(profiles)?;
             eprintln!("Updated profile {id}");
             if let Some(warning) = hotkey_warning {
@@ -219,7 +370,9 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             let original_len = profiles.len();
             profiles.retain(|profile| profile.id != id);
             if profiles.len() == original_len {
-                return Err(DictationError::SettingsError(format!("Unknown profile '{id}'")));
+                return Err(DictationError::SettingsError(format!(
+                    "Unknown profile '{id}'"
+                )));
             }
             persist_profiles(profiles)?;
             eprintln!("Removed profile {id}");
@@ -269,21 +422,15 @@ fn cmd_list() -> Result<(), DictationError> {
     );
     println!(
         "{:<20} {:<24} {}",
-        "show_overlay",
-        current.show_overlay,
-        defaults.show_overlay
+        "show_overlay", current.show_overlay, defaults.show_overlay
     );
     println!(
         "{:<20} {:<24} {}",
-        "auto_paste",
-        current.auto_paste,
-        defaults.auto_paste
+        "auto_paste", current.auto_paste, defaults.auto_paste
     );
     println!(
         "{:<20} {:<24} {}",
-        "auto_select_model",
-        current.auto_select_model,
-        defaults.auto_select_model
+        "auto_select_model", current.auto_select_model, defaults.auto_select_model
     );
     println!(
         "{:<20} {:<24} {}",
@@ -321,14 +468,15 @@ fn cmd_set(key: &str, value: &str) -> Result<(), DictationError> {
     // Parse before acquiring the settings lock so invalid input never writes.
     let mut validation_target = settings::store::load();
     apply_setting_value(&mut validation_target, key, value)?;
-    if key == "hotkey" {
-        Settings::validate_hotkey_profiles(&validation_target.resolved_hotkey_profiles())
+    if matches!(key, "hotkey" | "hotkey_mode") {
+        validation_target
+            .validate_shortcut_configuration()
             .map_err(DictationError::SettingsError)?;
     }
     let settings = settings::store::try_update(|settings| {
         apply_setting_value(settings, key, value).map_err(|error| error.to_string())?;
-        if key == "hotkey" {
-            Settings::validate_hotkey_profiles(&settings.resolved_hotkey_profiles())?;
+        if matches!(key, "hotkey" | "hotkey_mode") {
+            settings.validate_shortcut_configuration()?;
         }
         Ok(())
     })
@@ -365,9 +513,8 @@ fn bare_extended_hotkey_warning(shortcut: &str) -> Option<&'static str> {
         && digits
             .parse::<u8>()
             .is_ok_and(|number| (13..=24).contains(&number));
-    (cfg!(target_os = "macos") && is_bare_extended).then_some(
-        "bare F13-F24 requires Accessibility approval for the installed Sagascript app",
-    )
+    (cfg!(target_os = "macos") && is_bare_extended)
+        .then_some("bare F13-F24 requires Accessibility approval for the installed Sagascript app")
 }
 
 fn apply_setting_value(
@@ -385,7 +532,9 @@ fn apply_setting_value(
             settings.whisper_model = parse_enum_value::<WhisperModel>(value, "whisper_model")?;
         }
         "hotkey_mode" => {
-            settings.hotkey_mode = parse_enum_value::<HotkeyMode>(value, "hotkey_mode")?;
+            settings
+                .replace_hotkey_mode(parse_enum_value::<HotkeyMode>(value, "hotkey_mode")?)
+                .map_err(DictationError::SettingsError)?;
         }
         "show_overlay" => {
             settings.show_overlay = parse_bool(value, "show_overlay")?;
@@ -398,7 +547,9 @@ fn apply_setting_value(
         }
         "hotkey" => {
             validate_hotkey(value).map_err(DictationError::SettingsError)?;
-            settings.set_legacy_hotkey(value.to_string());
+            settings
+                .try_set_legacy_hotkey(value.to_string())
+                .map_err(DictationError::SettingsError)?;
         }
         "initial_prompt" => settings.initial_prompt = value.to_string(),
         "beam_size" => {
@@ -425,7 +576,10 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
         let defaults = Settings::default();
         if key == "hotkey" {
             let mut profiles = settings::store::load().resolved_hotkey_profiles();
-            let index = profiles.iter().position(|profile| profile.id == "default").unwrap_or(0);
+            let index = profiles
+                .iter()
+                .position(|profile| profile.id == "default")
+                .unwrap_or(0);
             profiles[index].shortcut = defaults.hotkey;
             persist_profiles(profiles)?;
             eprintln!("Reset hotkey to {}", settings::store::load().hotkey);
@@ -437,10 +591,7 @@ fn cmd_reset(key: Option<&str>) -> Result<(), DictationError> {
                 settings.whisper_model = defaults.whisper_model;
                 Ok(())
             }
-            "hotkey_mode" => {
-                settings.hotkey_mode = defaults.hotkey_mode;
-                Ok(())
-            }
+            "hotkey_mode" => settings.replace_hotkey_mode(defaults.hotkey_mode),
             "show_overlay" => {
                 settings.show_overlay = defaults.show_overlay;
                 Ok(())
@@ -722,7 +873,10 @@ mod tests {
         let err = validate_key("bogus").unwrap_err();
         let msg = err.to_string();
         for key in VALID_KEYS {
-            assert!(msg.contains(key), "error should list valid key '{key}': {msg}");
+            assert!(
+                msg.contains(key),
+                "error should list valid key '{key}': {msg}"
+            );
         }
     }
 
@@ -749,6 +903,7 @@ mod tests {
             "has_completed_onboarding",
             "hotkey_profiles",
             "profile_glossaries",
+            "presenter",
         ];
 
         let settings = Settings::default();
@@ -842,7 +997,10 @@ mod tests {
         assert!(settings.hotkey_profiles.is_empty());
         assert_eq!(settings.language, Language::English);
         assert_eq!(
-            settings.profile_glossaries.get("default").map(String::as_str),
+            settings
+                .profile_glossaries
+                .get("default")
+                .map(String::as_str),
             Some("merge = merch")
         );
     }
@@ -906,7 +1064,10 @@ mod tests {
 
         assert!(settings.hotkey_profiles.is_empty());
         assert_eq!(
-            settings.profile_glossaries.get("removed").map(String::as_str),
+            settings
+                .profile_glossaries
+                .get("removed")
+                .map(String::as_str),
             Some("merge = merch")
         );
         assert_eq!(settings.effective_glossary_source(Some("removed")), "");
@@ -940,9 +1101,16 @@ mod tests {
     #[test]
     fn parse_enum_value_all_valid_models() {
         let valid = [
-            "tiny.en", "tiny", "base.en", "base",
-            "kb-whisper-tiny", "kb-whisper-base", "kb-whisper-small",
-            "nb-whisper-tiny", "nb-whisper-base", "nb-whisper-small",
+            "tiny.en",
+            "tiny",
+            "base.en",
+            "base",
+            "kb-whisper-tiny",
+            "kb-whisper-base",
+            "kb-whisper-small",
+            "nb-whisper-tiny",
+            "nb-whisper-base",
+            "nb-whisper-small",
         ];
         for v in valid {
             let result = parse_enum_value::<WhisperModel>(v, "whisper_model");
@@ -958,7 +1126,7 @@ mod tests {
 
     #[test]
     fn parse_enum_value_all_valid_hotkey_modes() {
-        let valid = ["push", "toggle"];
+        let valid = ["push", "toggle", "presenter"];
         for v in valid {
             let result = parse_enum_value::<HotkeyMode>(v, "hotkey_mode");
             assert!(result.is_ok(), "should parse hotkey_mode '{v}'");
@@ -969,6 +1137,113 @@ mod tests {
     fn parse_enum_value_invalid_hotkey_mode() {
         let result = parse_enum_value::<HotkeyMode>("hold", "hotkey_mode");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn presenter_action_values_are_strict_and_snake_case() {
+        assert_eq!(
+            parse_enum_value::<PresenterFinishAction>("insert_only", "presenter action").unwrap(),
+            PresenterFinishAction::InsertOnly
+        );
+        assert_eq!(
+            parse_enum_value::<PresenterFinishAction>("return", "presenter action").unwrap(),
+            PresenterFinishAction::Return
+        );
+        assert_eq!(
+            parse_enum_value::<PresenterFinishAction>("command_return", "presenter action")
+                .unwrap(),
+            PresenterFinishAction::CommandReturn
+        );
+        assert!(
+            parse_enum_value::<PresenterFinishAction>("commandReturn", "presenter action").is_err()
+        );
+        assert!(parse_enum_value::<PresenterFinishAction>("submit", "presenter action").is_err());
+    }
+
+    #[test]
+    fn presenter_hotkey_mode_mutation_is_atomic_through_cli_helper() {
+        let mut settings = Settings::default();
+        settings
+            .replace_hotkey_profiles(vec![HotkeyProfile::legacy_default(
+                "Control+Shift+Enter".to_string(),
+                Language::English,
+            )])
+            .unwrap();
+        let before = settings.hotkey_mode;
+        let error = apply_setting_value(&mut settings, "hotkey_mode", "presenter").unwrap_err();
+        assert!(error.to_string().contains("profile shortcut"));
+        assert_eq!(settings.hotkey_mode, before);
+    }
+
+    #[test]
+    fn presenter_legacy_hotkey_mutation_is_checked_and_atomic() {
+        let mut settings = Settings::default();
+        settings.replace_hotkey_mode(HotkeyMode::Presenter).unwrap();
+        let before = settings.hotkey.clone();
+        let error = apply_setting_value(&mut settings, "hotkey", "Ctrl+Shift+Enter").unwrap_err();
+        assert!(error.to_string().contains("profile shortcut"));
+        assert_eq!(settings.hotkey, before);
+        assert_eq!(settings.resolved_hotkey_profiles()[0].shortcut, before);
+    }
+
+    #[test]
+    fn presenter_command_help_inventory_has_all_mutations() {
+        let command = <PresenterAction as clap::Subcommand>::augment_subcommands(
+            clap::Command::new("presenter"),
+        );
+        let names: Vec<_> = command
+            .get_subcommands()
+            .map(|command| command.get_name())
+            .collect();
+        assert_eq!(names, ["show", "finish", "cancel", "app", "remove-app"]);
+    }
+
+    #[test]
+    fn apply_presenter_action_rejects_invalid_input_without_partial_mutation() {
+        let mut presenter = PresenterConfig::default();
+        let before = presenter.clone();
+        let error = apply_presenter_action(
+            &mut presenter,
+            PresenterAction::App {
+                app_id: "com.example.editor".to_string(),
+                action: "submit".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("Invalid value"));
+        assert_eq!(presenter, before);
+
+        let error = apply_presenter_action(
+            &mut presenter,
+            PresenterAction::Finish {
+                shortcut: "NotAHotkey".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert!(!error.is_empty());
+        assert_eq!(presenter, before);
+    }
+
+    #[test]
+    fn presenter_candidate_uses_fresh_state_and_core_validation_before_commit() {
+        let mut settings = Settings::default();
+        let mut candidate = settings.presenter.clone();
+        for index in 0..PresenterConfig::MAX_APP_ACTIONS {
+            candidate.app_actions.insert(
+                format!("com.example.editor{index}"),
+                PresenterFinishAction::InsertOnly,
+            );
+        }
+        apply_presenter_action(
+            &mut candidate,
+            PresenterAction::App {
+                app_id: "com.example.editor32".to_string(),
+                action: "return".to_string(),
+            },
+        )
+        .unwrap();
+        assert!(settings.replace_presenter_config(candidate).is_err());
+        assert!(settings.presenter.app_actions.is_empty());
     }
 
     // -- parse_bool --
@@ -995,7 +1270,10 @@ mod tests {
         let err = parse_bool("yes", "auto_paste").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("yes"), "error should mention input: {msg}");
-        assert!(msg.contains("auto_paste"), "error should mention key: {msg}");
+        assert!(
+            msg.contains("auto_paste"),
+            "error should mention key: {msg}"
+        );
     }
 
     // -- get_setting_value / format helpers --
@@ -1008,7 +1286,10 @@ mod tests {
         assert_eq!(get_setting_value(&settings, "show_overlay"), "true");
         assert_eq!(get_setting_value(&settings, "auto_paste"), "true");
         assert_eq!(get_setting_value(&settings, "auto_select_model"), "true");
-        assert_eq!(get_setting_value(&settings, "hotkey"), "Control+Shift+Space");
+        assert_eq!(
+            get_setting_value(&settings, "hotkey"),
+            "Control+Shift+Space"
+        );
         assert_eq!(get_setting_value(&settings, "initial_prompt"), "");
         assert_eq!(get_setting_value(&settings, "beam_size"), "0");
         assert_eq!(get_setting_value(&settings, "temperature_fallback"), "true");

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod glossary;
 pub mod latency;
 pub mod models;
 pub mod open;
+pub mod presenter;
 // Live recording is optional (`record` feature, on by default) so a pure
 // batch-transcribe build (`--no-default-features`) carries no audio-capture
 // stack — on Linux, no cpal/ALSA.
@@ -351,6 +352,13 @@ This is a recovery path when the menu-bar status item is unavailable. On macOS, 
     )]
     Open,
 
+    /// Send a presenter start, finish, or cancel request to the installed desktop app
+    #[command(
+        long_about = "Send one private presenter request to the installed Sagascript desktop app. The command does not record audio, transcribe, insert text, or report completion; check the desktop status for the result.",
+        after_long_help = "EXAMPLES:\n  sagascript presenter start\n  sagascript presenter start swedish\n  sagascript presenter finish\n  sagascript presenter cancel"
+    )]
+    Presenter(presenter::PresenterArgs),
+
     /// Reset first-launch onboarding (re-run setup wizard on next launch)
     #[command(
         long_about = "\
@@ -494,6 +502,7 @@ pub fn run(cli: Cli) {
         Command::DownloadModel(args) => rt.block_on(models::download(args)),
         Command::DeleteModel(args) => models::delete(args),
         Command::Open => open::run(),
+        Command::Presenter(args) => presenter::run(args),
         Command::ResetOnboarding => {
             sagascript_core::settings::store::update(|settings| {
                 settings.has_completed_onboarding = false;
@@ -693,6 +702,30 @@ mod tests {
         assert!(benchmark.get_arguments().any(|arg| arg.get_id() == "iterations"));
         assert!(benchmark.get_arguments().any(|arg| arg.get_id() == "max_warm_ms"));
         assert!(benchmark.get_arguments().any(|arg| arg.get_id() == "expect_word"));
+    }
+
+    #[test]
+    fn presenter_commands_are_discoverable_and_parse_without_launching() {
+        let command = Cli::command();
+        let presenter = command
+            .find_subcommand("presenter")
+            .expect("presenter should be a root subcommand");
+        let names: Vec<_> = presenter
+            .get_subcommands()
+            .map(|subcommand| subcommand.get_name())
+            .collect();
+        assert_eq!(names, ["start", "finish", "cancel"]);
+
+        let parsed = Cli::try_parse_from(["sagascript", "presenter", "start", "swedish"])
+            .expect("presenter start should parse");
+        assert!(matches!(
+            parsed.command,
+            Some(Command::Presenter(presenter::PresenterArgs {
+                action: presenter::PresenterAction::Start {
+                    profile_id: Some(_)
+                }
+            }))
+        ));
     }
 
     // -- Completions generation --

--- a/src-tauri/crates/sagascript-cli/src/presenter.rs
+++ b/src-tauri/crates/sagascript-cli/src/presenter.rs
@@ -1,6 +1,6 @@
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::process::Command;
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", all(test, unix)))]
 use std::process::ExitStatus;
 
 use clap::{Args, Subcommand};
@@ -193,11 +193,12 @@ fn command_for(request: &PresenterRequest) -> Result<LaunchCommand, DictationErr
     }
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
 fn spawn_failure(error: std::io::Error) -> DictationError {
     DictationError::ApplicationLaunchError(format!("failed to launch presenter request: {error}"))
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", all(test, unix)))]
 fn status_failure(status: ExitStatus) -> DictationError {
     DictationError::ApplicationLaunchError(format!(
         "presenter request launcher exited unsuccessfully: {status}"

--- a/src-tauri/crates/sagascript-cli/src/presenter.rs
+++ b/src-tauri/crates/sagascript-cli/src/presenter.rs
@@ -1,0 +1,333 @@
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::process::Command;
+#[cfg(any(target_os = "macos", test))]
+use std::process::ExitStatus;
+
+use clap::{Args, Subcommand};
+use sagascript_core::error::DictationError;
+
+#[cfg(target_os = "windows")]
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "macos")]
+const APP_BUNDLE_PATH: &str = "/Applications/Sagascript.app";
+
+pub const SUCCESS_MESSAGE: &str = "Presenter request sent; check Sagascript status for completion";
+
+/// A private request understood by the desktop binary's startup/single-instance
+/// callback. It intentionally carries no recording data, paths, or text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PresenterRequest {
+    Start { profile_id: Option<String> },
+    Finish,
+    Cancel,
+}
+
+/// Build the one private argv marker accepted by the desktop presenter bridge.
+pub fn build_marker(request: &PresenterRequest) -> Result<String, String> {
+    match request {
+        PresenterRequest::Start { profile_id: None } => Ok("--presenter-start".to_string()),
+        PresenterRequest::Start {
+            profile_id: Some(profile_id),
+        } => {
+            if !valid_profile_id(profile_id) {
+                return Err("invalid presenter profile id".to_string());
+            }
+            Ok(format!("--presenter-start={profile_id}"))
+        }
+        PresenterRequest::Finish => Ok("--presenter-finish".to_string()),
+        PresenterRequest::Cancel => Ok("--presenter-cancel".to_string()),
+    }
+}
+
+/// Parse exactly one private argv marker. The caller must pass argv after the
+/// executable name; all ordinary arguments and mixed/unknown markers fail.
+pub fn parse_marker(args: &[String]) -> Result<PresenterRequest, String> {
+    if args.len() != 1 {
+        return Err("presenter request requires exactly one private marker".to_string());
+    }
+
+    match args[0].as_str() {
+        "--presenter-start" => Ok(PresenterRequest::Start { profile_id: None }),
+        "--presenter-finish" => Ok(PresenterRequest::Finish),
+        "--presenter-cancel" => Ok(PresenterRequest::Cancel),
+        marker => match marker.strip_prefix("--presenter-start=") {
+            Some(profile_id) if valid_profile_id(profile_id) => Ok(PresenterRequest::Start {
+                profile_id: Some(profile_id.to_string()),
+            }),
+            Some(_) => Err("invalid presenter profile id".to_string()),
+            None => Err("unknown presenter marker".to_string()),
+        },
+    }
+}
+
+fn valid_profile_id(profile_id: &str) -> bool {
+    let bytes = profile_id.as_bytes();
+    if bytes.is_empty() || bytes.len() > 32 {
+        return false;
+    }
+    (bytes[0].is_ascii_lowercase() || bytes[0].is_ascii_digit())
+        && bytes[1..].iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-' || *byte == b'_'
+        })
+}
+
+#[derive(Args)]
+pub struct PresenterArgs {
+    #[command(subcommand)]
+    pub action: PresenterAction,
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum PresenterAction {
+    /// Start presenter dictation with the named profile, or the default/first profile when omitted
+    Start {
+        /// Optional explicit profile id (lowercase ASCII letters, digits, '-' or '_')
+        #[arg(value_name = "PROFILE-ID")]
+        profile_id: Option<String>,
+    },
+    /// Finish the active presenter dictation
+    Finish,
+    /// Cancel the active presenter dictation
+    Cancel,
+}
+
+impl PresenterAction {
+    fn into_request(self) -> PresenterRequest {
+        match self {
+            Self::Start { profile_id } => PresenterRequest::Start { profile_id },
+            Self::Finish => PresenterRequest::Finish,
+            Self::Cancel => PresenterRequest::Cancel,
+        }
+    }
+}
+
+pub fn run(args: PresenterArgs) -> Result<(), DictationError> {
+    send_request(args.action.into_request())?;
+    println!("{SUCCESS_MESSAGE}");
+    Ok(())
+}
+
+fn send_request(request: PresenterRequest) -> Result<(), DictationError> {
+    let command = command_for(&request)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut process = Command::new(&command.program);
+        process.args(&command.args);
+        let status = process.status().map_err(spawn_failure)?;
+        if status.success() {
+            return Ok(());
+        }
+        Err(status_failure(status))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let mut process = Command::new(&command.program);
+        process.args(&command.args);
+        if command.create_no_window {
+            process.creation_flags(0x0800_0000);
+        }
+        process.spawn().map(|_| ()).map_err(spawn_failure)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = command;
+        Err(DictationError::ApplicationLaunchError(
+            "presenter requests are currently supported only on macOS and Windows".to_string(),
+        ))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct LaunchCommand {
+    program: String,
+    args: Vec<String>,
+    create_no_window: bool,
+}
+
+fn command_for(request: &PresenterRequest) -> Result<LaunchCommand, DictationError> {
+    let marker = build_marker(request).map_err(DictationError::SettingsError)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(LaunchCommand {
+            program: "/usr/bin/open".to_string(),
+            args: vec![
+                "-g".to_string(),
+                "-n".to_string(),
+                APP_BUNDLE_PATH.to_string(),
+                "--args".to_string(),
+                marker,
+            ],
+            create_no_window: false,
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let executable = installed_windows_app_path().ok_or_else(|| {
+            DictationError::ApplicationLaunchError(
+                "LOCALAPPDATA is unavailable; cannot locate the installed Sagascript app"
+                    .to_string(),
+            )
+        })?;
+        if !executable.is_file() {
+            return Err(DictationError::ApplicationLaunchError(
+                "Sagascript desktop app is not installed".to_string(),
+            ));
+        }
+        Ok(windows_command_for_path(&executable, marker))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = marker;
+        Err(DictationError::ApplicationLaunchError(
+            "presenter requests are currently supported only on macOS and Windows".to_string(),
+        ))
+    }
+}
+
+fn spawn_failure(error: std::io::Error) -> DictationError {
+    DictationError::ApplicationLaunchError(format!("failed to launch presenter request: {error}"))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn status_failure(status: ExitStatus) -> DictationError {
+    DictationError::ApplicationLaunchError(format!(
+        "presenter request launcher exited unsuccessfully: {status}"
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn installed_windows_app_path() -> Option<PathBuf> {
+    std::env::var_os("LOCALAPPDATA").map(|base| windows_app_path(Path::new(&base)))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_app_path(local_app_data: &Path) -> PathBuf {
+    local_app_data.join("Sagascript").join("sagascript.exe")
+}
+
+#[cfg(target_os = "windows")]
+fn windows_command_for_path(path: &Path, marker: String) -> LaunchCommand {
+    LaunchCommand {
+        program: path.to_string_lossy().into_owned(),
+        args: vec![marker],
+        create_no_window: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_marker, parse_marker, PresenterRequest};
+
+    #[test]
+    fn marker_builder_and_parser_round_trip_all_requests() {
+        for (request, marker) in [
+            (
+                PresenterRequest::Start { profile_id: None },
+                "--presenter-start",
+            ),
+            (
+                PresenterRequest::Start {
+                    profile_id: Some("swedish_1".to_string()),
+                },
+                "--presenter-start=swedish_1",
+            ),
+            (PresenterRequest::Finish, "--presenter-finish"),
+            (PresenterRequest::Cancel, "--presenter-cancel"),
+        ] {
+            assert_eq!(build_marker(&request).unwrap(), marker);
+            assert_eq!(parse_marker(&[marker.to_string()]).unwrap(), request);
+        }
+    }
+
+    #[test]
+    fn parser_rejects_extra_mixed_unknown_and_malformed_arguments() {
+        for args in [
+            vec![],
+            vec!["--presenter-start".to_string(), "extra".to_string()],
+            vec![
+                "--presenter-start".to_string(),
+                "--presenter-cancel".to_string(),
+            ],
+            vec!["--presenter-start=Bad_ID".to_string()],
+            vec!["--presenter-start=".to_string()],
+            vec!["--presenter-start=abc/../x".to_string()],
+            vec!["--presenter-start=abc\u{0000}x".to_string()],
+            vec!["--unknown".to_string()],
+            vec!["/tmp/recording.wav".to_string()],
+        ] {
+            assert!(parse_marker(&args).is_err(), "accepted {args:?}");
+        }
+    }
+
+    #[test]
+    fn builder_rejects_invalid_profile_ids() {
+        for profile_id in ["", "Bad", "-bad", "bad.id", "bad/id", "bad profile"] {
+            assert!(build_marker(&PresenterRequest::Start {
+                profile_id: Some(profile_id.to_string()),
+            })
+            .is_err());
+        }
+        assert!(build_marker(&PresenterRequest::Start {
+            profile_id: Some("a".repeat(33)),
+        })
+        .is_err());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_command_is_background_new_app_with_only_marker_args() {
+        let command = super::command_for(&PresenterRequest::Finish).unwrap();
+        assert_eq!(command.program, "/usr/bin/open");
+        assert_eq!(
+            command.args,
+            [
+                "-g",
+                "-n",
+                "/Applications/Sagascript.app",
+                "--args",
+                "--presenter-finish",
+            ]
+        );
+    }
+
+    #[test]
+    fn launch_failures_are_returned_without_claiming_success() {
+        let error = super::spawn_failure(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "blocked",
+        ));
+        assert!(error.to_string().contains("failed to launch"));
+        assert!(!error.to_string().contains("request sent"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nonzero_launcher_status_is_returned_as_failure() {
+        let status = std::process::Command::new("/usr/bin/false")
+            .status()
+            .expect("false should be available on the test host");
+        assert!(!status.success());
+        assert!(super::status_failure(status)
+            .to_string()
+            .contains("unsuccessfully"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_command_uses_the_per_user_install_and_hidden_console_flag() {
+        let path = std::path::Path::new(r"C:\Users\test\AppData\Local\Sagascript\sagascript.exe");
+        let command = super::windows_command_for_path(path, "--presenter-cancel".to_string());
+        assert_eq!(command.program, path.to_string_lossy());
+        assert_eq!(command.args, ["--presenter-cancel"]);
+        assert!(command.create_no_window);
+    }
+}

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use super::{canonical_hotkey, validate_hotkey};
+use super::{canonical_hotkey, validate_hotkey, PresenterConfig};
 
 use crate::{download::DownloadIntegrity, transcription::Glossary};
 
@@ -463,6 +463,8 @@ pub enum HotkeyMode {
     PushToTalk,
     #[serde(rename = "toggle")]
     Toggle,
+    #[serde(rename = "presenter")]
+    Presenter,
 }
 
 impl HotkeyMode {
@@ -471,6 +473,7 @@ impl HotkeyMode {
         match self {
             HotkeyMode::PushToTalk => "Push-to-talk",
             HotkeyMode::Toggle => "Toggle",
+            HotkeyMode::Presenter => "Presenter",
         }
     }
 }
@@ -502,6 +505,7 @@ pub struct Settings {
     pub language: Language,
     pub whisper_model: WhisperModel,
     pub hotkey_mode: HotkeyMode,
+    pub presenter: PresenterConfig,
     pub show_overlay: bool,
     pub auto_paste: bool,
     pub auto_select_model: bool,
@@ -536,6 +540,7 @@ impl Default for Settings {
             language: Language::default(),
             whisper_model: WhisperModel::default(),
             hotkey_mode: HotkeyMode::default(),
+            presenter: PresenterConfig::default(),
             show_overlay: true,
             auto_paste: true,
             auto_select_model: true,
@@ -615,6 +620,24 @@ impl Settings {
         }
     }
 
+    /// Return all shortcuts that the active hotkey mode may register.
+    /// Presenter finish/cancel shortcuts are intentionally omitted from the
+    /// ordinary modes so opting into presenter behavior is explicit.
+    pub fn resolved_shortcuts(&self) -> Vec<String> {
+        let mut shortcuts = self
+            .resolved_hotkey_profiles()
+            .into_iter()
+            .map(|profile| profile.shortcut)
+            .collect::<Vec<_>>();
+        if self.hotkey_mode == HotkeyMode::Presenter {
+            shortcuts.push(self.presenter.finish_shortcut.clone());
+            if let Some(cancel) = &self.presenter.cancel_shortcut {
+                shortcuts.push(cancel.clone());
+            }
+        }
+        shortcuts
+    }
+
     pub fn validate_hotkey_profiles(profiles: &[HotkeyProfile]) -> Result<(), String> {
         if profiles.is_empty() {
             return Err("At least one hotkey profile is required".to_string());
@@ -644,6 +667,48 @@ impl Settings {
                 return Err(format!("Duplicate hotkey '{}'", profile.shortcut));
             }
         }
+        Ok(())
+    }
+
+    /// Validate the complete shortcut configuration. Presenter shortcuts are
+    /// checked syntactically in every mode, while collisions with profile
+    /// shortcuts matter only after presenter mode is explicitly enabled.
+    pub fn validate_shortcut_configuration(&self) -> Result<(), String> {
+        let profiles = self.resolved_hotkey_profiles();
+        Self::validate_hotkey_profiles(&profiles)?;
+        self.presenter.validate()?;
+        if self.hotkey_mode == HotkeyMode::Presenter {
+            let mut shortcuts = profiles
+                .iter()
+                .map(|profile| canonical_hotkey(&profile.shortcut))
+                .collect::<Result<HashSet<_>, _>>()?;
+            let finish = canonical_hotkey(&self.presenter.finish_shortcut)?;
+            if !shortcuts.insert(finish) {
+                return Err("Presenter finish shortcut conflicts with a profile shortcut".to_string());
+            }
+            if let Some(cancel) = &self.presenter.cancel_shortcut {
+                if !shortcuts.insert(canonical_hotkey(cancel)?) {
+                    return Err("Presenter cancel shortcut conflicts with a profile shortcut".to_string());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn replace_presenter_config(&mut self, presenter: PresenterConfig) -> Result<(), String> {
+        presenter.validate()?;
+        let mut candidate = self.clone();
+        candidate.presenter = presenter.clone();
+        candidate.validate_shortcut_configuration()?;
+        self.presenter = presenter;
+        Ok(())
+    }
+
+    pub fn replace_hotkey_mode(&mut self, hotkey_mode: HotkeyMode) -> Result<(), String> {
+        let mut candidate = self.clone();
+        candidate.hotkey_mode = hotkey_mode;
+        candidate.validate_shortcut_configuration()?;
+        self.hotkey_mode = hotkey_mode;
         Ok(())
     }
 
@@ -682,9 +747,14 @@ impl Settings {
             ));
         }
         let legacy = profiles.iter().find(|profile| profile.id == "default").unwrap_or(&profiles[0]);
-        self.hotkey = legacy.shortcut.clone();
-        self.language = legacy.language;
-        self.hotkey_profiles = profiles;
+        let mut candidate = self.clone();
+        candidate.hotkey = legacy.shortcut.clone();
+        candidate.language = legacy.language;
+        candidate.hotkey_profiles = profiles;
+        candidate.validate_shortcut_configuration()?;
+        self.hotkey = candidate.hotkey;
+        self.language = candidate.language;
+        self.hotkey_profiles = candidate.hotkey_profiles;
         Ok(())
     }
 
@@ -722,11 +792,23 @@ impl Settings {
         Ok(())
     }
 
-    pub fn set_legacy_hotkey(&mut self, shortcut: String) {
-        self.hotkey = shortcut.clone();
-        if let Some(profile) = self.hotkey_profiles.iter_mut().find(|profile| profile.id == "default") {
+    /// Try to update the legacy/default profile shortcut atomically.
+    pub fn try_set_legacy_hotkey(&mut self, shortcut: String) -> Result<(), String> {
+        let mut candidate = self.clone();
+        candidate.hotkey = shortcut.clone();
+        if let Some(profile) = candidate.hotkey_profiles.iter_mut().find(|profile| profile.id == "default") {
             profile.shortcut = shortcut;
         }
+        candidate.validate_shortcut_configuration()?;
+        self.hotkey = candidate.hotkey;
+        self.hotkey_profiles = candidate.hotkey_profiles;
+        Ok(())
+    }
+
+    /// Checked legacy/default profile shortcut update. Invalid or colliding
+    /// updates leave the complete settings value unchanged.
+    pub fn set_legacy_hotkey(&mut self, shortcut: String) -> Result<(), String> {
+        self.try_set_legacy_hotkey(shortcut)
     }
 
     /// Build the ordered set of profile models worth loading during GUI
@@ -1139,6 +1221,7 @@ mod tests {
     fn hotkey_mode_display_names() {
         assert_eq!(HotkeyMode::PushToTalk.display_name(), "Push-to-talk");
         assert_eq!(HotkeyMode::Toggle.display_name(), "Toggle");
+        assert_eq!(HotkeyMode::Presenter.display_name(), "Presenter");
     }
 
     #[test]
@@ -1147,6 +1230,8 @@ mod tests {
         assert_eq!(json, "\"push\"");
         let json = serde_json::to_string(&HotkeyMode::Toggle).unwrap();
         assert_eq!(json, "\"toggle\"");
+        let json = serde_json::to_string(&HotkeyMode::Presenter).unwrap();
+        assert_eq!(json, "\"presenter\"");
     }
 
     // -- Settings --
@@ -1161,11 +1246,134 @@ mod tests {
         assert!(s.auto_paste);
         assert!(s.auto_select_model);
         assert_eq!(s.hotkey, "Control+Shift+Space");
+        assert_eq!(s.presenter, PresenterConfig::default());
         assert_eq!(s.initial_prompt, "");
         assert!(s.profile_glossaries.is_empty());
         assert_eq!(s.beam_size, 0);
         assert!(s.temperature_fallback);
         assert!(!s.vad_enabled);
+    }
+
+    #[test]
+    fn legacy_settings_default_presenter_without_changing_old_hotkey_fields() {
+        let settings: Settings = serde_json::from_str(
+            r#"{"hotkey_mode":"toggle","hotkey":"Option+Space"}"#,
+        )
+        .unwrap();
+        assert_eq!(settings.hotkey_mode, HotkeyMode::Toggle);
+        assert_eq!(settings.hotkey, "Option+Space");
+        assert_eq!(settings.presenter, PresenterConfig::default());
+    }
+
+    #[test]
+    fn presenter_config_serializes_actions_with_strict_names() {
+        let mut presenter = PresenterConfig {
+            cancel_shortcut: Some("Option+Escape".to_string()),
+            ..PresenterConfig::default()
+        };
+        presenter.app_actions.insert(
+            "com.example.editor".to_string(),
+            crate::settings::PresenterFinishAction::CommandReturn,
+        );
+        let json = serde_json::to_string(&presenter).unwrap();
+        assert!(json.contains("command_return"));
+        let roundtrip: PresenterConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip, presenter);
+        assert!(serde_json::from_str::<PresenterConfig>(
+            r#"{"finish_shortcut":"Control+Shift+Enter","app_actions":{"com.example.editor":"unknown"}}"#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn presenter_config_validates_bounded_app_identifiers() {
+        let mut presenter = PresenterConfig::default();
+        presenter.app_actions.insert("bad\napp".to_string(), Default::default());
+        assert!(presenter.validate().is_err());
+        presenter.app_actions.clear();
+        presenter.app_actions.insert("x".repeat(513), Default::default());
+        assert!(presenter.validate().is_err());
+        presenter.app_actions.clear();
+        presenter.app_actions.insert(String::new(), Default::default());
+        assert!(presenter.validate().is_err());
+        presenter.app_actions.clear();
+        for index in 0..=PresenterConfig::MAX_APP_ACTIONS {
+            presenter
+                .app_actions
+                .insert(format!("com.example.app{index}"), Default::default());
+        }
+        assert!(presenter.validate().is_err());
+    }
+
+    #[test]
+    fn presenter_mode_transition_rejects_canonical_profile_collision_atomically() {
+        let mut settings = Settings::default();
+        settings
+            .replace_hotkey_profiles(vec![profile(
+                "default",
+                "Control+Shift+Enter",
+                Language::English,
+            )])
+            .unwrap();
+        let before_mode = settings.hotkey_mode;
+        let error = settings.replace_hotkey_mode(HotkeyMode::Presenter).unwrap_err();
+        assert!(error.contains("profile shortcut"));
+        assert_eq!(settings.hotkey_mode, before_mode);
+        assert_eq!(settings.hotkey_profiles[0].shortcut, "Control+Shift+Enter");
+    }
+
+    #[test]
+    fn presenter_config_replacement_and_profile_edit_are_atomic_when_active() {
+        let mut settings = Settings::default();
+        settings.replace_hotkey_mode(HotkeyMode::Presenter).unwrap();
+        let old_presenter = settings.presenter.clone();
+        let mut colliding = old_presenter.clone();
+        colliding.finish_shortcut = "Control+Shift+Space".to_string();
+        assert!(settings.replace_presenter_config(colliding).is_err());
+        assert_eq!(settings.presenter, old_presenter);
+
+        let old_profiles = settings.hotkey_profiles.clone();
+        let error = settings.replace_hotkey_profiles(vec![profile(
+            "default",
+            "Ctrl+Shift+Enter",
+            Language::English,
+        )]);
+        assert!(error.is_err());
+        assert_eq!(settings.hotkey_profiles, old_profiles);
+    }
+
+    #[test]
+    fn presenter_shortcuts_are_resolved_only_when_mode_is_active() {
+        let mut settings = Settings::default();
+        settings.presenter.cancel_shortcut = Some("Option+Escape".to_string());
+        assert_eq!(
+            settings.resolved_shortcuts(),
+            vec!["Control+Shift+Space".to_string()]
+        );
+        settings.replace_hotkey_mode(HotkeyMode::Presenter).unwrap();
+        assert_eq!(
+            settings.resolved_shortcuts(),
+            vec![
+                "Control+Shift+Space".to_string(),
+                "Control+Shift+Enter".to_string(),
+                "Option+Escape".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn legacy_hotkey_collision_is_rejected_without_mutation() {
+        let mut settings = Settings::default();
+        settings.replace_hotkey_mode(HotkeyMode::Presenter).unwrap();
+        let before = settings.hotkey.clone();
+        assert!(settings
+            .set_legacy_hotkey("Ctrl+Shift+Enter".to_string())
+            .is_err());
+        assert_eq!(settings.hotkey, before);
+        assert_eq!(settings.resolved_hotkey_profiles()[0].shortcut, before);
+        assert!(settings
+            .try_set_legacy_hotkey("Ctrl+Shift+Enter".to_string())
+            .is_err());
     }
 
     #[test]

--- a/src-tauri/crates/sagascript-core/src/settings/mod.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/mod.rs
@@ -1,6 +1,8 @@
 mod hotkey;
+mod presenter;
 pub mod manager;
 pub mod store;
 
 pub use hotkey::{canonical_hotkey, validate_hotkey};
 pub use manager::*;
+pub use presenter::{PresenterConfig, PresenterFinishAction};

--- a/src-tauri/crates/sagascript-core/src/settings/presenter.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/presenter.rs
@@ -1,0 +1,85 @@
+use std::collections::{BTreeMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::{canonical_hotkey, validate_hotkey};
+
+/// Action to take when a presenter dictation is finished for a known app.
+///
+/// The app-specific mapping is deliberately opt-in.  An empty mapping keeps
+/// the safe default of inserting text without synthesizing an Enter key.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresenterFinishAction {
+    #[default]
+    InsertOnly,
+    Return,
+    CommandReturn,
+}
+
+/// Settings for the opt-in presenter hotkey mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PresenterConfig {
+    pub finish_shortcut: String,
+    pub cancel_shortcut: Option<String>,
+    pub app_actions: BTreeMap<String, PresenterFinishAction>,
+}
+
+impl Default for PresenterConfig {
+    fn default() -> Self {
+        Self {
+            finish_shortcut: "Control+Shift+Enter".to_string(),
+            cancel_shortcut: None,
+            app_actions: BTreeMap::new(),
+        }
+    }
+}
+
+impl PresenterConfig {
+    pub const MAX_APP_ACTIONS: usize = 32;
+
+    /// Validate the presenter settings without considering profile shortcuts.
+    /// Cross-role collisions are checked by `Settings` only when presenter
+    /// mode is active, so an inactive configuration can be prepared safely.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_hotkey(&self.finish_shortcut)
+            .map_err(|error| format!("Invalid presenter finish shortcut: {error}"))?;
+        let finish = canonical_hotkey(&self.finish_shortcut)
+            .map_err(|error| format!("Invalid presenter finish shortcut: {error}"))?;
+        let mut shortcuts = HashSet::from([finish]);
+
+        if let Some(cancel) = &self.cancel_shortcut {
+            validate_hotkey(cancel)
+                .map_err(|error| format!("Invalid presenter cancel shortcut: {error}"))?;
+            let canonical = canonical_hotkey(cancel)
+                .map_err(|error| format!("Invalid presenter cancel shortcut: {error}"))?;
+            if !shortcuts.insert(canonical) {
+                return Err("Presenter finish and cancel shortcuts must differ".to_string());
+            }
+        }
+
+        for app_id in self.app_actions.keys() {
+            if app_id.is_empty() {
+                return Err("Presenter app identifiers must not be empty".to_string());
+            }
+            if app_id.len() > 512 {
+                return Err("Presenter app identifiers must be 512 bytes or fewer".to_string());
+            }
+            if app_id.chars().any(char::is_control) {
+                return Err(
+                    "Presenter app identifiers must not contain control characters".to_string(),
+                );
+            }
+        }
+
+        if self.app_actions.len() > Self::MAX_APP_ACTIONS {
+            return Err(format!(
+                "Presenter app actions must contain {} entries or fewer",
+                Self::MAX_APP_ACTIONS
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -75,6 +75,9 @@ pub struct AppController {
     last_error: Option<String>,
     model_ready: bool,
     active_hotkey_profile: Option<HotkeyProfile>,
+    active_hotkey_mode: Option<HotkeyMode>,
+    recording_generation: u64,
+    hotkey_configuration_changing: bool,
     training_recording: bool,
     session_data: Option<serde_json::Value>,
     release_started: Option<Instant>,
@@ -104,6 +107,9 @@ impl AppController {
             last_error: None,
             model_ready: false,
             active_hotkey_profile: None,
+            active_hotkey_mode: None,
+            recording_generation: 0,
+            hotkey_configuration_changing: false,
             training_recording: false,
             session_data: None,
             release_started: None,
@@ -168,7 +174,7 @@ impl AppController {
     ) -> Result<HotkeyDownResult, DictationError> {
         info!("Hotkey DOWN");
 
-        match self.settings.hotkey_mode {
+        match self.session_hotkey_mode() {
             HotkeyMode::PushToTalk => {
                 // Only report StartedRecording if we actually started. Holding
                 // PTT while a prior utterance is still Transcribing must be a
@@ -191,7 +197,19 @@ impl AppController {
                 {
                     Ok(HotkeyDownResult::StopRecording)
                 } else if self.state == AppState::Idle {
-                    self.start_recording_for_profile(profile)?;
+                    if self.start_recording_for_profile(profile)? {
+                        Ok(HotkeyDownResult::StartedRecording)
+                    } else {
+                        Ok(HotkeyDownResult::NoOp)
+                    }
+                } else {
+                    Ok(HotkeyDownResult::NoOp)
+                }
+            }
+            HotkeyMode::Presenter => {
+                // Atomic Start is never a toggle. Finish has its own action;
+                // repeated Start, training and in-flight transcription are no-ops.
+                if self.start_recording_for_profile(profile)? {
                     Ok(HotkeyDownResult::StartedRecording)
                 } else {
                     Ok(HotkeyDownResult::NoOp)
@@ -200,9 +218,67 @@ impl AppController {
         }
     }
 
+    fn session_hotkey_mode(&self) -> HotkeyMode {
+        if self.state.is_busy() {
+            self.active_hotkey_mode.unwrap_or(self.settings.hotkey_mode)
+        } else {
+            self.settings.hotkey_mode
+        }
+    }
+
+    pub fn should_finish_presenter(&self) -> bool {
+        self.session_hotkey_mode() == HotkeyMode::Presenter
+            && self.state.is_recording()
+            && !self.training_recording
+    }
+
+    pub fn recording_generation(&self) -> u64 {
+        self.recording_generation
+    }
+
+    pub fn is_presenter_session(&self) -> bool {
+        self.state.is_busy()
+            && self.active_hotkey_mode == Some(HotkeyMode::Presenter)
+            && !self.training_recording
+    }
+
+    /// Only the validated registration-failure fallback caller may use this.
+    /// Keep the invalid saved configuration visible, but make this one capture
+    /// releasable by the exact fallback key that actually started it.
+    pub fn use_safe_fallback_lifecycle(&mut self) {
+        if self.state.is_recording() && !self.training_recording {
+            self.active_hotkey_mode = Some(HotkeyMode::PushToTalk);
+            if let Some(profile) = &mut self.active_hotkey_profile {
+                profile.shortcut = crate::SAFE_FALLBACK_HOTKEY.to_string();
+            }
+        }
+    }
+
+    pub fn stop_recording_generation(&mut self, generation: u64) -> StopRecordingOutcome {
+        if self.recording_generation != generation {
+            StopRecordingOutcome::NotRecording
+        } else {
+            self.stop_recording_guarded()
+        }
+    }
+
+    /// Prevent a recording from starting halfway through an OS registration
+    /// transaction, without holding the controller mutex across native calls.
+    pub fn begin_hotkey_configuration_change(&mut self) -> bool {
+        if self.state != AppState::Idle || self.hotkey_configuration_changing {
+            return false;
+        }
+        self.hotkey_configuration_changing = true;
+        true
+    }
+
+    pub fn end_hotkey_configuration_change(&mut self) {
+        self.hotkey_configuration_changing = false;
+    }
+
     /// Handle hotkey up event
     pub fn should_stop_on_key_up(&self) -> bool {
-        self.settings.hotkey_mode == HotkeyMode::PushToTalk
+        self.session_hotkey_mode() == HotkeyMode::PushToTalk
             && self.state.is_recording()
             && !self.training_recording
     }
@@ -256,10 +332,14 @@ impl AppController {
     where
         F: FnOnce(&mut AudioCaptureService) -> Result<(), DictationError>,
     {
-        if self.state != AppState::Idle {
+        if self.state != AppState::Idle || self.hotkey_configuration_changing {
             warn!("Cannot start recording: state is {:?}", self.state);
             return Ok(false);
         }
+
+        let next_generation = self.recording_generation.checked_add(1).ok_or_else(|| {
+            DictationError::TranscriptionFailed("Recording generation exhausted; restart Sagascript.".into())
+        })?;
 
         let session_id = self.logging.start_dictation_session();
         self.logging.log(
@@ -292,6 +372,8 @@ impl AppController {
             "Recording profile selected"
         );
         self.active_hotkey_profile = Some(profile);
+        self.recording_generation = next_generation;
+        self.active_hotkey_mode = Some(self.settings.hotkey_mode);
         self.training_recording = false;
         self.state = AppState::Recording;
         self.recording_start = Some(Instant::now());
@@ -473,14 +555,21 @@ impl AppController {
     }
 
     /// Cancel recording without transcribing
+    pub fn complete_cancelled_recording(&mut self) {
+        self.end_session("cancelled");
+        self.audio.clear_last_captured();
+        self.state = AppState::Idle;
+        self.active_hotkey_profile = None;
+        self.active_hotkey_mode = None;
+        self.training_recording = false;
+        self.logging.end_dictation_session();
+    }
+
+    /// Cancel recording without transcribing
     pub fn cancel_recording(&mut self) {
         if self.state.is_recording() {
             let _ = self.audio.stop_capture();
-            self.end_session("cancelled");
-            self.state = AppState::Idle;
-            self.active_hotkey_profile = None;
-            self.training_recording = false;
-            self.logging.end_dictation_session();
+            self.complete_cancelled_recording();
             info!("Recording cancelled");
         }
     }
@@ -535,6 +624,7 @@ impl AppController {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     fn default_controller() -> AppController {
         AppController::new(Settings::default())
@@ -573,6 +663,120 @@ mod tests {
     fn initial_state_is_idle() {
         let ctrl = default_controller();
         assert_eq!(ctrl.state(), AppState::Idle);
+    }
+
+    #[test]
+    fn a_deferred_stop_cannot_stop_a_new_recording() {
+        let mut ctrl = default_controller();
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        ctrl.start_recording_for_profile_with_capture(profile.clone(), |_| Ok(())).unwrap();
+        let old_generation = ctrl.recording_generation();
+        ctrl.cancel_recording();
+        ctrl.start_recording_for_profile_with_capture(profile, |_| Ok(())).unwrap();
+        assert_ne!(old_generation, ctrl.recording_generation());
+        assert!(matches!(ctrl.stop_recording_generation(old_generation), StopRecordingOutcome::NotRecording));
+        assert_eq!(ctrl.state(), AppState::Recording);
+        ctrl.cancel_recording();
+    }
+
+    #[test]
+    fn cancellation_during_transcription_requires_explicit_completion() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Transcribing;
+        ctrl.last_transcription = Some("Previous useful result".to_string());
+
+        ctrl.cancel_recording();
+        assert_eq!(ctrl.state(), AppState::Transcribing);
+        assert_eq!(ctrl.last_transcription(), Some("Previous useful result"));
+
+        ctrl.complete_cancelled_recording();
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert_eq!(ctrl.last_transcription(), Some("Previous useful result"));
+    }
+
+    #[test]
+    fn failed_capture_keeps_generation_available_for_next_start() {
+        let mut ctrl = default_controller();
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        assert!(ctrl
+            .start_recording_for_profile_with_capture(profile.clone(), |_| Ok(()))
+            .unwrap());
+        let first_generation = ctrl.recording_generation();
+        ctrl.cancel_recording();
+
+        let failed = ctrl.start_recording_for_profile_with_capture(profile.clone(), |_| {
+            Err(DictationError::MicrophonePermissionDenied)
+        });
+        assert!(matches!(failed, Err(DictationError::MicrophonePermissionDenied)));
+        assert_eq!(ctrl.recording_generation(), first_generation);
+        assert_eq!(ctrl.state(), AppState::Idle);
+
+        assert!(ctrl
+            .start_recording_for_profile_with_capture(profile, |_| Ok(()))
+            .unwrap());
+        assert_eq!(ctrl.recording_generation(), first_generation + 1);
+        ctrl.cancel_recording();
+    }
+
+    #[test]
+    fn generation_exhaustion_fails_before_capture() {
+        let mut ctrl = default_controller();
+        ctrl.recording_generation = u64::MAX;
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        let capture_called = Cell::new(false);
+
+        let result = ctrl.start_recording_for_profile_with_capture(profile, |_| {
+            capture_called.set(true);
+            Ok(())
+        });
+
+        assert!(matches!(
+            result,
+            Err(DictationError::TranscriptionFailed(message))
+                if message.contains("generation exhausted")
+        ));
+        assert!(!capture_called.get());
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert_eq!(ctrl.recording_generation(), u64::MAX);
+    }
+
+    #[test]
+    fn training_recording_is_not_a_presenter_session() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_mode = Some(HotkeyMode::Presenter);
+        ctrl.training_recording = true;
+        assert!(!ctrl.is_presenter_session());
+        assert!(!ctrl.should_finish_presenter());
+        ctrl.complete_cancelled_recording();
+    }
+
+    #[test]
+    fn pending_toggle_configuration_does_not_report_started_recording() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Toggle;
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        assert!(ctrl.begin_hotkey_configuration_change());
+
+        let result = ctrl.handle_hotkey_down_for_profile(profile);
+
+        assert_eq!(result.unwrap(), HotkeyDownResult::NoOp);
+        assert_eq!(ctrl.state(), AppState::Idle);
+        ctrl.end_hotkey_configuration_change();
+    }
+
+    #[test]
+    fn fallback_start_freezes_push_to_talk_without_rewriting_preferences() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        ctrl.start_recording_for_profile_with_capture(profile, |_| Ok(())).unwrap();
+        ctrl.use_safe_fallback_lifecycle();
+        assert!(ctrl.should_stop_profile_on_key_up(crate::SAFE_FALLBACK_HOTKEY));
+        assert!(!ctrl.should_finish_presenter());
+        assert_eq!(ctrl.settings().hotkey_mode, HotkeyMode::Presenter);
+        ctrl.cancel_recording();
     }
 
     #[test]
@@ -778,6 +982,55 @@ mod tests {
         ctrl.settings_mut().hotkey_mode = HotkeyMode::Toggle;
         ctrl.state = AppState::Recording;
         assert!(!ctrl.should_stop_on_key_up());
+    }
+
+    #[test]
+    fn presenter_start_and_release_never_implicitly_finish() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        for state in [AppState::Recording, AppState::Transcribing] {
+            ctrl.state = state;
+            assert_eq!(ctrl.handle_hotkey_down().unwrap(), HotkeyDownResult::NoOp);
+            assert!(!ctrl.should_stop_on_key_up());
+            assert_eq!(ctrl.should_finish_presenter(), state == AppState::Recording);
+        }
+        ctrl.state = AppState::Recording;
+        ctrl.training_recording = true;
+        assert!(!ctrl.should_finish_presenter());
+    }
+
+    #[test]
+    fn mode_changes_do_not_reinterpret_active_recording() {
+        let mut ctrl = default_controller();
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_mode = Some(HotkeyMode::Presenter);
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
+        assert!(!ctrl.should_stop_on_key_up());
+        assert!(ctrl.should_finish_presenter());
+        assert_eq!(ctrl.handle_hotkey_down().unwrap(), HotkeyDownResult::NoOp);
+
+        ctrl.active_hotkey_mode = Some(HotkeyMode::PushToTalk);
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        assert!(ctrl.should_stop_on_key_up());
+        assert!(!ctrl.should_finish_presenter());
+    }
+
+    #[test]
+    fn shortcut_transaction_blocks_capture_without_holding_controller_lock() {
+        let mut ctrl = default_controller();
+        assert!(ctrl.begin_hotkey_configuration_change());
+        assert!(!ctrl.begin_hotkey_configuration_change());
+        let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+        assert!(!ctrl.start_recording_for_profile_with_capture(profile, |_| {
+            panic!("capture must not start while bindings are changing");
+        }).unwrap());
+        ctrl.end_hotkey_configuration_change();
+        assert!(ctrl.begin_hotkey_configuration_change());
+        ctrl.end_hotkey_configuration_change();
+        for state in [AppState::Recording, AppState::Transcribing, AppState::Error] {
+            ctrl.state = state;
+            assert!(!ctrl.begin_hotkey_configuration_change());
+        }
     }
 
     #[test]

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -76,6 +76,7 @@ pub struct AppController {
     model_ready: bool,
     active_hotkey_profile: Option<HotkeyProfile>,
     active_hotkey_mode: Option<HotkeyMode>,
+    presenter_owned: bool,
     recording_generation: u64,
     hotkey_configuration_changing: bool,
     training_recording: bool,
@@ -108,6 +109,7 @@ impl AppController {
             model_ready: false,
             active_hotkey_profile: None,
             active_hotkey_mode: None,
+            presenter_owned: false,
             recording_generation: 0,
             hotkey_configuration_changing: false,
             training_recording: false,
@@ -227,9 +229,7 @@ impl AppController {
     }
 
     pub fn should_finish_presenter(&self) -> bool {
-        self.session_hotkey_mode() == HotkeyMode::Presenter
-            && self.state.is_recording()
-            && !self.training_recording
+        self.is_presenter_session() && self.state.is_recording()
     }
 
     pub fn recording_generation(&self) -> u64 {
@@ -238,6 +238,7 @@ impl AppController {
 
     pub fn is_presenter_session(&self) -> bool {
         self.state.is_busy()
+            && self.presenter_owned
             && self.active_hotkey_mode == Some(HotkeyMode::Presenter)
             && !self.training_recording
     }
@@ -374,6 +375,7 @@ impl AppController {
         self.active_hotkey_profile = Some(profile);
         self.recording_generation = next_generation;
         self.active_hotkey_mode = Some(self.settings.hotkey_mode);
+        self.presenter_owned = false;
         self.training_recording = false;
         self.state = AppState::Recording;
         self.recording_start = Some(Instant::now());
@@ -381,6 +383,34 @@ impl AppController {
 
         info!("Recording started");
         Ok(true)
+    }
+
+    /// Only the native Presenter coordinator owns this completion pipeline.
+    /// A GUI/manual recording must keep its normal lifecycle even when the
+    /// configured global-hotkey mode happens to be Presenter.
+    pub fn start_presenter_recording_for_profile(
+        &mut self,
+        profile: HotkeyProfile,
+    ) -> Result<bool, DictationError> {
+        self.start_presenter_recording_with_capture(profile, |audio| audio.start_capture())
+    }
+
+    fn start_presenter_recording_with_capture<F>(
+        &mut self,
+        profile: HotkeyProfile,
+        start_capture: F,
+    ) -> Result<bool, DictationError>
+    where
+        F: FnOnce(&mut AudioCaptureService) -> Result<(), DictationError>,
+    {
+        if self.settings.hotkey_mode != HotkeyMode::Presenter {
+            return Ok(false);
+        }
+        let started = self.start_recording_for_profile_with_capture(profile, start_capture)?;
+        if started {
+            self.presenter_owned = true;
+        }
+        Ok(started)
     }
 
     /// Start a Teach Sagascript recording that only the Teach UI may stop.
@@ -474,6 +504,7 @@ impl AppController {
 
     /// Called after transcription succeeds
     pub fn on_transcription_success(&mut self, text: &str) {
+        self.presenter_owned = false;
         self.end_session("success");
         self.last_error = None;
         self.last_transcription = Some(text.to_string());
@@ -487,6 +518,7 @@ impl AppController {
     /// Complete a quiet push-to-talk cancellation without replacing the last
     /// useful transcript, surfacing an error, or leaving retry audio behind.
     pub fn on_no_speech_detected(&mut self) {
+        self.presenter_owned = false;
         self.end_session("no_speech");
         self.audio.clear_last_captured();
         self.state = AppState::Idle;
@@ -512,6 +544,7 @@ impl AppController {
 
     /// Called after transcription fails
     pub fn on_transcription_error(&mut self, error: &str) {
+        self.presenter_owned = false;
         self.end_session("error");
         self.last_error = Some(error.to_string());
         self.state = AppState::Idle;
@@ -556,6 +589,7 @@ impl AppController {
 
     /// Cancel recording without transcribing
     pub fn complete_cancelled_recording(&mut self) {
+        self.presenter_owned = false;
         self.end_session("cancelled");
         self.audio.clear_last_captured();
         self.state = AppState::Idle;
@@ -738,6 +772,123 @@ mod tests {
         assert!(!capture_called.get());
         assert_eq!(ctrl.state(), AppState::Idle);
         assert_eq!(ctrl.recording_generation(), u64::MAX);
+    }
+
+    #[test]
+    fn manual_recording_in_presenter_mode_does_not_own_presenter_pipeline() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+        ctrl.start_recording_for_profile_with_capture(profile, |_| Ok(())).unwrap();
+        assert!(!ctrl.is_presenter_session());
+        assert!(!ctrl.should_finish_presenter());
+        ctrl.state = AppState::Transcribing;
+        assert!(!ctrl.is_presenter_session());
+        ctrl.finish_transcription(Ok("manual result".into())).unwrap();
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert_eq!(ctrl.last_transcription(), Some("manual result"));
+    }
+
+    #[test]
+    fn dedicated_presenter_start_owns_successful_capture_and_repeated_start_is_noop() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+
+        assert!(ctrl
+            .start_presenter_recording_with_capture(profile.clone(), |_| Ok(()))
+            .unwrap());
+        let generation = ctrl.recording_generation();
+        assert!(ctrl.presenter_owned);
+        assert!(ctrl.is_presenter_session());
+
+        assert!(!ctrl
+            .start_presenter_recording_with_capture(profile, |_| {
+                panic!("a repeated presenter start must not invoke capture")
+            })
+            .unwrap());
+        assert_eq!(ctrl.recording_generation(), generation);
+        assert!(ctrl.presenter_owned);
+        assert!(ctrl.is_presenter_session());
+        ctrl.complete_cancelled_recording();
+    }
+
+    #[test]
+    fn presenter_start_failure_block_and_wrong_mode_never_take_ownership() {
+        let mut ctrl = default_controller();
+        let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+
+        assert!(!ctrl
+            .start_presenter_recording_with_capture(profile.clone(), |_| {
+                panic!("wrong-mode presenter start must not invoke capture")
+            })
+            .unwrap());
+        assert!(!ctrl.presenter_owned);
+        assert_eq!(ctrl.state(), AppState::Idle);
+
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        ctrl.state = AppState::Transcribing;
+        assert!(!ctrl
+            .start_presenter_recording_with_capture(profile.clone(), |_| {
+                panic!("blocked presenter start must not invoke capture")
+            })
+            .unwrap());
+        assert!(!ctrl.presenter_owned);
+        assert_eq!(ctrl.state(), AppState::Transcribing);
+
+        ctrl.state = AppState::Idle;
+        let failed = ctrl.start_presenter_recording_with_capture(profile, |_| {
+            Err(DictationError::MicrophonePermissionDenied)
+        });
+        assert!(matches!(failed, Err(DictationError::MicrophonePermissionDenied)));
+        assert!(!ctrl.presenter_owned);
+        assert_eq!(ctrl.state(), AppState::Idle);
+        assert!(ctrl.active_hotkey_profile().is_none());
+    }
+
+    #[test]
+    fn presenter_ownership_clears_on_every_terminal_path_and_manual_restart_stays_normal() {
+        for terminal in ["success", "error", "no_speech", "cancelled"] {
+            let mut ctrl = default_controller();
+            ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+            let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+            assert!(ctrl
+                .start_presenter_recording_with_capture(profile, |_| Ok(()))
+                .unwrap());
+            assert!(ctrl.presenter_owned);
+
+            match terminal {
+                "success" => ctrl.on_transcription_success("presenter result"),
+                "error" => ctrl.on_transcription_error("presenter failed"),
+                "no_speech" => ctrl.on_no_speech_detected(),
+                "cancelled" => ctrl.complete_cancelled_recording(),
+                _ => unreachable!(),
+            }
+            assert!(!ctrl.presenter_owned, "terminal path: {terminal}");
+            assert_eq!(ctrl.state(), AppState::Idle);
+
+            let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+            assert!(ctrl
+                .start_recording_for_profile_with_capture(profile, |_| Ok(()))
+                .unwrap());
+            assert!(!ctrl.presenter_owned, "manual restart: {terminal}");
+            assert!(!ctrl.is_presenter_session(), "manual restart: {terminal}");
+            ctrl.complete_cancelled_recording();
+        }
+    }
+
+    #[test]
+    fn training_capture_is_never_presenter_owned() {
+        let mut ctrl = default_controller();
+        ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        let profile = ctrl.settings.resolved_hotkey_profiles()[0].clone();
+        assert!(ctrl
+            .start_recording_for_profile_with_capture(profile, |_| Ok(()))
+            .unwrap());
+        ctrl.training_recording = true;
+        assert!(!ctrl.presenter_owned);
+        assert!(!ctrl.is_presenter_session());
+        ctrl.complete_cancelled_recording();
     }
 
     #[test]
@@ -988,6 +1139,8 @@ mod tests {
     fn presenter_start_and_release_never_implicitly_finish() {
         let mut ctrl = default_controller();
         ctrl.settings_mut().hotkey_mode = HotkeyMode::Presenter;
+        ctrl.active_hotkey_mode = Some(HotkeyMode::Presenter);
+        ctrl.presenter_owned = true;
         for state in [AppState::Recording, AppState::Transcribing] {
             ctrl.state = state;
             assert_eq!(ctrl.handle_hotkey_down().unwrap(), HotkeyDownResult::NoOp);
@@ -1005,6 +1158,7 @@ mod tests {
         ctrl.state = AppState::Recording;
         ctrl.active_hotkey_mode = Some(HotkeyMode::Presenter);
         ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
+        ctrl.presenter_owned = true;
         assert!(!ctrl.should_stop_on_key_up());
         assert!(ctrl.should_finish_presenter());
         assert_eq!(ctrl.handle_hotkey_down().unwrap(), HotkeyDownResult::NoOp);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,9 +15,10 @@ const ABORT_GRACE_SECS: u64 = 5;
 
 use crate::app_controller::{AppController, AppState, StopRecordingOutcome};
 use crate::hotkey::{HotkeyHealth, HotkeyStatus, OperationalHotkey};
+use crate::hotkey::configuration::HotkeyChange;
 use sagascript_core::audio::decoder;
 use sagascript_core::settings::{
-    validate_hotkey, HotkeyMode, HotkeyProfile, Language, Settings, WhisperModel,
+    validate_hotkey, HotkeyMode, HotkeyProfile, Language, PresenterConfig, Settings, WhisperModel,
 };
 use sagascript_core::transcription::{
     model, recommended_parallel_chunks, ContextProfile, TranscribeOptions, WhisperBackend,
@@ -486,16 +487,22 @@ pub async fn set_auto_select_model(
 
 #[tauri::command]
 pub async fn set_hotkey_mode(
+    app: tauri::AppHandle,
     controller: State<'_, SharedController>,
+    health: State<'_, HotkeyHealth>,
     mode: HotkeyMode,
 ) -> Result<(), String> {
-    let persisted = sagascript_core::settings::store::update(|settings| {
-        settings.hotkey_mode = mode;
-    })?;
-    let mut ctrl = controller.lock().unwrap();
-    ctrl.settings_mut().hotkey_mode = persisted.hotkey_mode;
-    info!("Hotkey mode set to {:?}", mode);
-    Ok(())
+    apply_hotkey_change(app, controller, health, HotkeyChange::Mode(mode))
+}
+
+#[tauri::command]
+pub async fn set_presenter_config(
+    app: tauri::AppHandle,
+    controller: State<'_, SharedController>,
+    health: State<'_, HotkeyHealth>,
+    config: PresenterConfig,
+) -> Result<(), String> {
+    apply_hotkey_change(app, controller, health, HotkeyChange::Presenter(config))
 }
 
 #[tauri::command]
@@ -526,21 +533,39 @@ pub async fn set_hotkey_profiles(
     health: State<'_, HotkeyHealth>,
     profiles: Vec<HotkeyProfile>,
 ) -> Result<(), String> {
-    use tauri::Emitter;
-    Settings::validate_hotkey_profiles(&profiles)?;
-    let new_shortcuts: Vec<String> = profiles
-        .iter()
-        .map(|profile| profile.shortcut.clone())
-        .collect();
-    let new_primary = profiles
-        .iter()
-        .find(|profile| profile.id == "default")
-        .unwrap_or(&profiles[0])
-        .shortcut
-        .clone();
+    apply_hotkey_change(app, controller, health, HotkeyChange::Profiles(profiles))
+}
 
+pub(crate) struct HotkeyConfigurationLease<'a>(&'a SharedController);
+
+impl Drop for HotkeyConfigurationLease<'_> {
+    fn drop(&mut self) {
+        self.0.lock().unwrap().end_hotkey_configuration_change();
+    }
+}
+
+pub(crate) fn acquire_hotkey_configuration(
+    controller: &SharedController,
+) -> Result<HotkeyConfigurationLease<'_>, String> {
+    if !controller.lock().unwrap().begin_hotkey_configuration_change() {
+        return Err("Finish or cancel the active dictation before changing shortcuts".into());
+    }
+    Ok(HotkeyConfigurationLease(controller))
+}
+
+fn apply_hotkey_change(
+    app: tauri::AppHandle,
+    controller: State<'_, SharedController>,
+    health: State<'_, HotkeyHealth>,
+    update: HotkeyChange,
+) -> Result<(), String> {
+    use tauri::Emitter;
     let _transition = health.transition_guard();
+    let _recording_lease = acquire_hotkey_configuration(&controller)?;
     let old_settings = controller.lock().unwrap().settings().clone();
+    let candidate = update.prepare(&sagascript_core::settings::store::load())?;
+    let new_shortcuts = candidate.resolved_shortcuts();
+    let new_primary = candidate.hotkey.clone();
     let old_shortcut = old_settings.hotkey.clone();
     let old_operational = health.operational_hotkey();
     if old_operational == OperationalHotkey::Unknown {
@@ -550,18 +575,13 @@ pub async fn set_hotkey_profiles(
         );
     }
 
-    let old_shortcuts: Vec<String> = old_settings
-        .resolved_hotkey_profiles()
-        .into_iter()
-        .map(|profile| profile.shortcut)
-        .collect();
+    let old_shortcuts = old_settings.resolved_shortcuts();
     if new_shortcuts == old_shortcuts
         && old_operational.matches(&new_shortcuts)
         && !health.is_failed()
     {
         let persisted = sagascript_core::settings::store::try_update(|settings| {
-            settings.replace_hotkey_profiles(profiles.clone())?;
-            Ok(())
+            update.apply_registered(settings, &new_shortcuts)
         })?;
         controller
             .lock()
@@ -649,8 +669,7 @@ pub async fn set_hotkey_profiles(
     );
 
     let persisted = match sagascript_core::settings::store::try_update(|settings| {
-        settings.replace_hotkey_profiles(profiles.clone())?;
-        Ok(())
+        update.apply_registered(settings, &new_shortcuts)
     }) {
         Ok(settings) => settings,
         Err(save_error) => {
@@ -1077,6 +1096,12 @@ pub async fn cancel_recording(
     app: tauri::AppHandle,
     controller: State<'_, SharedController>,
 ) -> Result<(), String> {
+    if controller.lock().unwrap().is_presenter_session() {
+        let handle = app.clone();
+        app.run_on_main_thread(move || crate::presenter::cancel(&handle))
+            .map_err(|error| error.to_string())?;
+        return Ok(());
+    }
     let mut ctrl = controller.lock().unwrap();
     ctrl.cancel_recording();
     drop(ctrl);

--- a/src-tauri/src/hotkey/configuration.rs
+++ b/src-tauri/src/hotkey/configuration.rs
@@ -1,0 +1,81 @@
+use sagascript_core::settings::{HotkeyMode, HotkeyProfile, PresenterConfig, Settings};
+
+/// One explicit user change. Apply it to fresh settings without replacing
+/// unrelated preferences, then bind persistence to the registered shortcuts.
+pub enum HotkeyChange {
+    Profiles(Vec<HotkeyProfile>),
+    Mode(HotkeyMode),
+    Presenter(PresenterConfig),
+}
+
+impl HotkeyChange {
+    pub fn prepare(&self, settings: &Settings) -> Result<Settings, String> {
+        let mut candidate = settings.clone();
+        match self {
+            Self::Profiles(profiles) => candidate.replace_hotkey_profiles(profiles.clone())?,
+            Self::Mode(mode) => candidate.replace_hotkey_mode(*mode)?,
+            Self::Presenter(config) => candidate.replace_presenter_config(config.clone())?,
+        }
+        candidate.validate_shortcut_configuration()?;
+        Ok(candidate)
+    }
+
+    pub fn apply_registered(
+        &self,
+        fresh: &mut Settings,
+        registered: &[String],
+    ) -> Result<(), String> {
+        let candidate = self.prepare(fresh)?;
+        if candidate.resolved_shortcuts() != registered {
+            return Err("Shortcut configuration changed concurrently; retry after settings refresh".into());
+        }
+        *fresh = candidate;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HotkeyChange;
+    use sagascript_core::settings::{HotkeyMode, PresenterConfig, Settings};
+
+    #[test]
+    fn presenter_change_registers_complete_active_binding_set() {
+        let settings = Settings::default();
+        let changed = HotkeyChange::Mode(HotkeyMode::Presenter).prepare(&settings).unwrap();
+        assert_eq!(changed.resolved_shortcuts(), vec!["Control+Shift+Space", "Control+Shift+Enter"]);
+        assert_eq!(settings.hotkey_mode, HotkeyMode::PushToTalk);
+    }
+
+    #[test]
+    fn concurrent_binding_change_rejects_persistence_without_mutation() {
+        let settings = Settings::default();
+        let change = HotkeyChange::Mode(HotkeyMode::Presenter);
+        let registered = change.prepare(&settings).unwrap().resolved_shortcuts();
+        let mut fresh = settings;
+        fresh.set_legacy_hotkey("Control+Shift+E".into()).unwrap();
+        let original = serde_json::to_value(&fresh).unwrap();
+        assert!(change.apply_registered(&mut fresh, &registered).is_err());
+        assert_eq!(serde_json::to_value(&fresh).unwrap(), original);
+    }
+
+    #[test]
+    fn unrelated_fresh_settings_are_preserved() {
+        let settings = Settings::default();
+        let change = HotkeyChange::Mode(HotkeyMode::Presenter);
+        let registered = change.prepare(&settings).unwrap().resolved_shortcuts();
+        let mut fresh = settings;
+        fresh.show_overlay = false;
+        change.apply_registered(&mut fresh, &registered).unwrap();
+        assert!(!fresh.show_overlay);
+        assert_eq!(fresh.hotkey_mode, HotkeyMode::Presenter);
+    }
+
+    #[test]
+    fn invalid_configuration_never_produces_registration_candidate() {
+        let settings = Settings { hotkey_mode: HotkeyMode::Presenter, ..Settings::default() };
+        let config = PresenterConfig { finish_shortcut: settings.hotkey.clone(), ..PresenterConfig::default() };
+        assert!(HotkeyChange::Presenter(config).prepare(&settings).is_err());
+        assert!(HotkeyChange::Profiles(Vec::new()).prepare(&settings).is_err());
+    }
+}

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -1,4 +1,6 @@
 pub mod health;
+pub mod configuration;
+pub mod presenter_routing;
 mod registration;
 pub mod service;
 

--- a/src-tauri/src/hotkey/presenter_routing.rs
+++ b/src-tauri/src/hotkey/presenter_routing.rs
@@ -1,0 +1,171 @@
+use sagascript_core::settings::{canonical_hotkey, HotkeyMode, HotkeyProfile, Settings};
+
+/// Semantic result of one global-shortcut press. Recording lifecycle and
+/// release handling stay with the controller; this helper only resolves the
+/// configured binding without touching application state.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PressAction {
+    Start(HotkeyProfile),
+    Finish,
+    Cancel,
+    NoOp,
+}
+
+/// Resolve a pressed shortcut against one complete, validated settings value.
+/// Profile shortcuts remain starts in every mode. Presenter finish/cancel
+/// bindings are active only in Presenter mode and never become implicit starts.
+pub fn pressed_action(settings: &Settings, shortcut: &str) -> PressAction {
+    if settings.validate_shortcut_configuration().is_err() {
+        return PressAction::NoOp;
+    }
+    let Ok(target) = canonical_hotkey(shortcut) else {
+        return PressAction::NoOp;
+    };
+
+    if let Some(profile) = settings
+        .resolved_hotkey_profiles()
+        .into_iter()
+        .find(|profile| {
+            canonical_hotkey(&profile.shortcut).ok().as_deref() == Some(target.as_str())
+        })
+    {
+        return PressAction::Start(profile);
+    }
+
+    if settings.hotkey_mode != HotkeyMode::Presenter {
+        return PressAction::NoOp;
+    }
+    if canonical_hotkey(&settings.presenter.finish_shortcut)
+        .ok()
+        .as_deref()
+        == Some(target.as_str())
+    {
+        return PressAction::Finish;
+    }
+    if settings
+        .presenter
+        .cancel_shortcut
+        .as_deref()
+        .and_then(|cancel| canonical_hotkey(cancel).ok())
+        .as_deref()
+        == Some(target.as_str())
+    {
+        return PressAction::Cancel;
+    }
+    PressAction::NoOp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{pressed_action, PressAction};
+    use sagascript_core::settings::{HotkeyMode, HotkeyProfile, Language, Settings};
+
+    fn profile(id: &str, shortcut: &str, language: Language) -> HotkeyProfile {
+        HotkeyProfile {
+            id: id.to_string(),
+            name: id.to_string(),
+            shortcut: shortcut.to_string(),
+            language,
+        }
+    }
+
+    fn presenter_settings() -> Settings {
+        let mut settings = Settings::default();
+        settings
+            .replace_hotkey_profiles(vec![
+                profile("default", "Control+Shift+Space", Language::English),
+                profile("swedish", "Control+Option+S", Language::Swedish),
+            ])
+            .unwrap();
+        settings.presenter.cancel_shortcut = Some("Option+Escape".to_string());
+        settings.replace_hotkey_mode(HotkeyMode::Presenter).unwrap();
+        settings
+    }
+
+    #[test]
+    fn push_and_toggle_keep_profile_shortcuts_as_starts() {
+        for mode in [HotkeyMode::PushToTalk, HotkeyMode::Toggle] {
+            let mut settings = Settings::default();
+            settings
+                .replace_hotkey_profiles(vec![profile(
+                    "default",
+                    "Control+Shift+Space",
+                    Language::English,
+                )])
+                .unwrap();
+            settings.replace_hotkey_mode(mode).unwrap();
+            assert!(matches!(
+                pressed_action(&settings, "Ctrl+Shift+Space"),
+                PressAction::Start(ref profile) if profile.id == "default"
+            ));
+        }
+    }
+
+    #[test]
+    fn presenter_routes_start_finish_and_cancel_aliases() {
+        let settings = presenter_settings();
+        assert!(matches!(
+            pressed_action(&settings, "Ctrl+Shift+Space"),
+            PressAction::Start(ref profile) if profile.id == "default"
+        ));
+        assert!(matches!(
+            pressed_action(&settings, "Ctrl+Option+S"),
+            PressAction::Start(ref profile) if profile.id == "swedish"
+        ));
+        assert_eq!(
+            pressed_action(&settings, "Ctrl+Shift+Enter"),
+            PressAction::Finish
+        );
+        assert_eq!(pressed_action(&settings, "Alt+Esc"), PressAction::Cancel);
+    }
+
+    #[test]
+    fn inactive_presenter_bindings_are_noops_unless_profile_owns_binding() {
+        let mut settings = Settings::default();
+        settings.presenter.cancel_shortcut = Some("Option+Escape".to_string());
+        assert_eq!(
+            pressed_action(&settings, "Ctrl+Shift+Enter"),
+            PressAction::NoOp
+        );
+        assert_eq!(pressed_action(&settings, "Alt+Escape"), PressAction::NoOp);
+
+        settings
+            .replace_hotkey_profiles(vec![profile(
+                "default",
+                "Control+Shift+Enter",
+                Language::English,
+            )])
+            .unwrap();
+        assert!(matches!(
+            pressed_action(&settings, "Ctrl+Shift+Enter"),
+            PressAction::Start(ref profile) if profile.id == "default"
+        ));
+    }
+
+    #[test]
+    fn invalid_or_unknown_shortcuts_are_noops_without_implicit_start() {
+        let settings = presenter_settings();
+        assert_eq!(
+            pressed_action(&settings, "Control+NotAKey"),
+            PressAction::NoOp
+        );
+        assert_eq!(
+            pressed_action(&settings, "Control+Shift+Q"),
+            PressAction::NoOp
+        );
+    }
+
+    #[test]
+    fn invalid_whole_configuration_disables_every_route() {
+        let mut settings = presenter_settings();
+        settings.presenter.finish_shortcut = settings.hotkey.clone();
+        assert_eq!(
+            pressed_action(&settings, "Ctrl+Shift+Space"),
+            PressAction::NoOp
+        );
+        assert_eq!(
+            pressed_action(&settings, "Ctrl+Shift+Enter"),
+            PressAction::NoOp
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -416,28 +416,20 @@ fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::Ba
                 })
             };
             if let Some(action) = presenter_action {
-                match action {
-                    hotkey::presenter_routing::PressAction::Start(profile) => {
-                        presenter::handle_request(
-                            app,
-                            sagascript_cli::presenter::PresenterRequest::Start {
-                                profile_id: Some(profile.id),
-                            },
-                        );
-                    }
-                    hotkey::presenter_routing::PressAction::Finish => {
-                        presenter::handle_request(
-                            app,
-                            sagascript_cli::presenter::PresenterRequest::Finish,
-                        );
-                    }
-                    hotkey::presenter_routing::PressAction::Cancel => {
-                        presenter::handle_request(
-                            app,
-                            sagascript_cli::presenter::PresenterRequest::Cancel,
-                        );
-                    }
-                    hotkey::presenter_routing::PressAction::NoOp => {}
+                let request = match action {
+                    hotkey::presenter_routing::PressAction::Start(profile) => Some(
+                        sagascript_cli::presenter::PresenterRequest::Start {
+                            profile_id: Some(profile.id),
+                        },
+                    ),
+                    hotkey::presenter_routing::PressAction::Finish =>
+                        Some(sagascript_cli::presenter::PresenterRequest::Finish),
+                    hotkey::presenter_routing::PressAction::Cancel =>
+                        Some(sagascript_cli::presenter::PresenterRequest::Cancel),
+                    hotkey::presenter_routing::PressAction::NoOp => None,
+                };
+                if let Some(request) = request {
+                    dispatch_to_main(app, move |app| presenter::handle_request(app, request));
                 }
                 return;
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,6 +20,7 @@ mod events;
 mod hotkey;
 mod overlay;
 mod paste;
+mod presenter;
 #[path = "paste/completion.rs"]
 mod paste_completion;
 mod platform;
@@ -54,6 +55,7 @@ use app_controller::AppState;
 use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
 use sagascript_core::settings::HotkeyProfile;
+use sagascript_core::settings::HotkeyMode;
 #[cfg(test)]
 use sagascript_core::settings::{validate_hotkey, Language};
 use sagascript_core::transcription::{
@@ -400,18 +402,62 @@ fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::Ba
     match state {
         hotkey::BareHotkeyState::Pressed => {
             info!("Hotkey pressed: {shortcut}");
+            let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
+            let safe_fallback = {
+                let c = ctrl.lock().unwrap();
+                shortcut == SAFE_FALLBACK_HOTKEY
+                    && c.settings().validate_shortcut_configuration().is_err()
+                    && health.operational_hotkey().matches(&[SAFE_FALLBACK_HOTKEY.to_string()])
+            };
+            let presenter_action = {
+                let c = ctrl.lock().unwrap();
+                (!safe_fallback && c.settings().hotkey_mode == HotkeyMode::Presenter).then(|| {
+                    hotkey::presenter_routing::pressed_action(c.settings(), shortcut)
+                })
+            };
+            if let Some(action) = presenter_action {
+                match action {
+                    hotkey::presenter_routing::PressAction::Start(profile) => {
+                        presenter::handle_request(
+                            app,
+                            sagascript_cli::presenter::PresenterRequest::Start {
+                                profile_id: Some(profile.id),
+                            },
+                        );
+                    }
+                    hotkey::presenter_routing::PressAction::Finish => {
+                        presenter::handle_request(
+                            app,
+                            sagascript_cli::presenter::PresenterRequest::Finish,
+                        );
+                    }
+                    hotkey::presenter_routing::PressAction::Cancel => {
+                        presenter::handle_request(
+                            app,
+                            sagascript_cli::presenter::PresenterRequest::Cancel,
+                        );
+                    }
+                    hotkey::presenter_routing::PressAction::NoOp => {}
+                }
+                return;
+            }
             let (result, active_profile) = {
                 let mut c = ctrl.lock().unwrap();
                 let profile = c
                     .settings()
                     .hotkey_profile_for_shortcut(shortcut)
                     .or_else(|| {
-                        (shortcut == SAFE_FALLBACK_HOTKEY)
+                        safe_fallback
                             .then(|| c.settings().resolved_hotkey_profiles()[0].clone())
                     });
                 let result = match profile {
                     Some(profile) => match c.handle_hotkey_down_for_profile(profile) {
-                        Ok(result) => result,
+                        Ok(result) => {
+                            if safe_fallback && result == HotkeyDownResult::StartedRecording {
+                                c.use_safe_fallback_lifecycle();
+                            }
+                            result
+                        },
                         Err(error) => {
                             error!("Hotkey down error: {error}");
                             let _ = app.emit(events::event::ERROR, error.to_string());
@@ -454,7 +500,20 @@ fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::Ba
     }
 }
 fn main() {
-    let gui_launch_mode = gui_launch_mode(std::env::args_os());
+    let startup_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    let presenter_args = startup_args.get(1..).unwrap_or_default();
+    let presenter_request = presenter_request_from_os_args(presenter_args);
+    let gui_launch_mode = match &presenter_request {
+        Ok(Some(_)) => GuiLaunchMode::Presenter,
+        Err(_) => GuiLaunchMode::InvalidPresenter,
+        Ok(None) => gui_launch_mode(startup_args),
+    };
+
+    if gui_launch_mode == GuiLaunchMode::InvalidPresenter {
+        eprintln!("Invalid presenter request");
+        std::process::exit(2);
+    }
+    let startup_presenter_request = presenter_request.ok().flatten();
 
     // CLI mode: if a subcommand is given, run CLI and exit. The desktop
     // binary is a full CLI (CLI-first design) — the GUI only launches on a
@@ -489,6 +548,18 @@ fn main() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            match presenter_request_from_second_instance_args(&args) {
+                Ok(Some(request)) => {
+                    let app = app.clone();
+                    dispatch_to_main(&app, move |app| presenter::handle_request(app, request));
+                    return;
+                }
+                Err(_) => {
+                    info!("Ignoring malformed second-instance presenter request");
+                    return;
+                }
+                Ok(None) => {}
+            }
             if !second_instance_requests_settings(&args) {
                 info!("Background second-instance launch ignored");
                 return;
@@ -567,11 +638,12 @@ fn main() {
             }
 
             // Read every configured dictation profile and register its shortcut.
-            let profiles = {
+            let requested_settings = {
                 let ctrl: tauri::State<'_, SharedController> = app.state();
                 let c = ctrl.lock().unwrap();
-                c.settings().resolved_hotkey_profiles()
+                c.settings().clone()
             };
+            let profiles = requested_settings.resolved_hotkey_profiles();
             let requested_primary = profiles
                 .iter()
                 .find(|profile| profile.id == "default")
@@ -585,11 +657,11 @@ fn main() {
             // dictate. Recorded in the process-wide health flag so the tray
             // and Settings UI can surface it.
             let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
-            let validation_error = sagascript_core::settings::Settings::validate_hotkey_profiles(&profiles).err();
+            let validation_error = requested_settings.validate_shortcut_configuration().err();
             let registration_shortcuts: Vec<String> = if validation_error.is_some() {
                 vec![SAFE_FALLBACK_HOTKEY.to_string()]
             } else {
-                profiles.iter().map(|profile| profile.shortcut.clone()).collect()
+                requested_settings.resolved_shortcuts()
             };
             if let Some(error) = &validation_error {
                 warn!(
@@ -823,6 +895,10 @@ fn main() {
                 }
             }
 
+            if let Some(request) = startup_presenter_request {
+                presenter::handle_request(app.handle(), request);
+            }
+
             // Preload + warm the bounded set of models selected by the hotkey
             // profiles. The primary profile is restored as active after warmup,
             // while one distinct secondary stays resident for instant bilingual
@@ -932,6 +1008,7 @@ fn main() {
             commands::set_whisper_model,
             commands::set_auto_select_model,
             commands::set_hotkey_mode,
+            commands::set_presenter_config,
             commands::set_hotkey,
             commands::set_hotkey_profiles,
             commands::retry_hotkey_registration,
@@ -1189,12 +1266,18 @@ enum GuiLaunchMode {
     Standard,
     ShowSettings,
     Background,
+    Presenter,
+    InvalidPresenter,
 }
 
 fn gui_launch_mode(args: impl IntoIterator<Item = std::ffi::OsString>) -> GuiLaunchMode {
     let mut args = args.into_iter();
     let _program = args.next();
-    match (args.next(), args.next()) {
+    let remaining: Vec<_> = args.collect();
+    match presenter_request_from_os_args(&remaining) {
+        Ok(Some(_)) => GuiLaunchMode::Presenter,
+        Err(_) => GuiLaunchMode::InvalidPresenter,
+        Ok(None) => match (remaining.first().cloned(), remaining.get(1).cloned()) {
         (Some(argument), None)
             if argument == std::ffi::OsStr::new(sagascript_cli::open::GUI_OPEN_ARG) =>
         {
@@ -1206,10 +1289,74 @@ fn gui_launch_mode(args: impl IntoIterator<Item = std::ffi::OsString>) -> GuiLau
             GuiLaunchMode::Background
         }
         _ => GuiLaunchMode::Standard,
+        },
     }
 }
 
+fn presenter_request_from_strings(
+    args: &[String],
+) -> Result<Option<sagascript_cli::presenter::PresenterRequest>, String> {
+    let has_private_marker = args
+        .iter()
+        .any(|argument| argument.starts_with("--presenter-"));
+    if !has_private_marker {
+        return Ok(None);
+    }
+    sagascript_cli::presenter::parse_marker(args).map(Some)
+}
+
+fn presenter_request_from_os_args(
+    args: &[std::ffi::OsString],
+) -> Result<Option<sagascript_cli::presenter::PresenterRequest>, String> {
+    // Ordinary CLI commands may legitimately carry non-UTF-8 paths on Unix.
+    // Only enter the private presenter parser when a marker is actually
+    // present; otherwise preserve the normal clap/CLI path unchanged.
+    if !args
+        .iter()
+        .any(|argument| argument.to_string_lossy().starts_with("--presenter-"))
+    {
+        return Ok(None);
+    }
+
+    let mut strings = Vec::with_capacity(args.len());
+    for argument in args {
+        let Some(argument) = argument.to_str() else {
+            return Err("presenter request contains a non-text argument".to_string());
+        };
+        strings.push(argument.to_string());
+    }
+    presenter_request_from_strings(&strings)
+}
+
+fn is_sagascript_program(argument: &str) -> bool {
+    let basename = argument
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(argument);
+    basename.eq_ignore_ascii_case("sagascript")
+        || basename.eq_ignore_ascii_case("sagascript.exe")
+}
+
+fn presenter_request_from_second_instance_args(
+    args: &[String],
+) -> Result<Option<sagascript_cli::presenter::PresenterRequest>, String> {
+    if args.len() == 2
+        && !args[0].starts_with("--presenter-")
+        && args[1].starts_with("--presenter-")
+    {
+        if !is_sagascript_program(&args[0]) {
+            return Err("presenter request has an unexpected program name".to_string());
+        }
+        return presenter_request_from_strings(&args[1..]);
+    }
+    presenter_request_from_strings(args)
+}
+
 fn second_instance_requests_settings(args: &[String]) -> bool {
+    match presenter_request_from_strings(args) {
+        Ok(Some(_)) | Err(_) => return false,
+        Ok(None) => {}
+    }
     // `tauri-plugin-single-instance` forwards the complete argv on Windows,
     // including argv[0], but transports differ across platforms and versions.
     // Treat the private background marker as a capability to stay hidden and
@@ -1225,7 +1372,9 @@ fn initial_window_request(
     has_completed_onboarding: bool,
     launch_mode: GuiLaunchMode,
 ) -> InitialWindowRequest {
-    if !has_completed_onboarding {
+    if launch_mode == GuiLaunchMode::Presenter {
+        InitialWindowRequest::Hidden
+    } else if !has_completed_onboarding {
         InitialWindowRequest::Onboarding
     } else if launch_mode == GuiLaunchMode::Background {
         InitialWindowRequest::Hidden
@@ -1399,10 +1548,10 @@ fn stop_recording_and_transcribe(
     // duration — but do NOT block the global-shortcut (UI) thread waiting for it
     // (finding 2): a std::thread::sleep here freezes UI redraw and stalls
     // subsequent hotkey events. The delay is offloaded to an async task below.
-    let elapsed = {
+    let (elapsed, generation, presenter_session) = {
         let mut c = ctrl.lock().unwrap();
         c.mark_release();
-        c.recording_elapsed()
+        (c.recording_elapsed(), c.recording_generation(), c.is_presenter_session())
     };
     let min = Duration::from_millis(MIN_RECORDING_MS);
     let remaining = if elapsed < min {
@@ -1431,11 +1580,15 @@ fn stop_recording_and_transcribe(
         let outcome = {
             let ctrl: tauri::State<'_, SharedController> = app_handle.state();
             let mut c = ctrl.lock().unwrap();
-            c.stop_recording_guarded()
+            c.stop_recording_generation(generation)
         };
         let audio = match outcome {
             StopRecordingOutcome::NotRecording => return,
             StopRecordingOutcome::Failed(msg) => {
+                if presenter_session {
+                    dispatch_to_main(&app_handle, move |app| presenter::complete(app, generation, Err(msg)));
+                    return;
+                }
                 error!("Recording stop failed: {msg}");
                 dispatch_to_main(&app_handle, |app| {
                     overlay::hide(app);
@@ -1459,6 +1612,10 @@ fn stop_recording_and_transcribe(
         let _ = app_handle.emit(events::event::STATE_CHANGED, "transcribing");
 
         if audio.is_empty() {
+            if presenter_session {
+                dispatch_to_main(&app_handle, move |app| presenter::complete(app, generation, Ok(String::new())));
+                return;
+            }
             {
                 let ctrl: tauri::State<'_, SharedController> = app_handle.state();
                 let mut c = ctrl.lock().unwrap();
@@ -1583,6 +1740,11 @@ fn stop_recording_and_transcribe(
         let postprocess_started = std::time::Instant::now();
         let result = result.map(|text| commands::apply_glossary(text, &glossary));
         ctrl.lock().unwrap().record_phase("postprocessing", postprocess_started.elapsed());
+        if presenter_session {
+            let result = result.map_err(|error| error.to_string());
+            dispatch_to_main(&app_handle, move |app| presenter::complete(app, generation, result));
+            return;
+        }
         match result {
             Ok(text) => {
                 info!("Transcription complete: {} chars", text.len());
@@ -1858,23 +2020,29 @@ fn start_settings_watcher(app: tauri::AppHandle) {
             std::thread::sleep(Duration::from_millis(50));
 
             let health: tauri::State<'_, hotkey::HotkeyHealth> = app.state();
+            let ctrl: tauri::State<'_, SharedController> = app.state();
+            // Keep a live recording's bindings/configuration intact. This is
+            // the dedicated settings-watcher thread, never the native UI or
+            // audio thread. Re-read disk after idle so queued writes coalesce.
+            let _recording_lease = loop {
+                match commands::acquire_hotkey_configuration(&ctrl) {
+                    Ok(lease) => break lease,
+                    Err(_) => std::thread::sleep(Duration::from_millis(50)),
+                }
+            };
             let _transition = health.transition_guard();
             let mut new_settings = load_settings_with_permission_gate();
-            let ctrl: tauri::State<'_, SharedController> = app.state();
             let old_settings = {
                 let c = ctrl.lock().unwrap();
                 c.settings().clone()
             };
 
-            let old_profiles = old_settings.resolved_hotkey_profiles();
-            let new_profiles = new_settings.resolved_hotkey_profiles();
-            let old_profile_shortcuts: Vec<&str> = old_profiles.iter().map(|profile| profile.shortcut.as_str()).collect();
-            let new_profile_shortcuts: Vec<&str> = new_profiles.iter().map(|profile| profile.shortcut.as_str()).collect();
-            if new_profile_shortcuts != old_profile_shortcuts {
+            let old_shortcuts = old_settings.resolved_shortcuts();
+            let new_shortcuts = new_settings.resolved_shortcuts();
+            let validation_error = new_settings.validate_shortcut_configuration().err();
+            if new_shortcuts != old_shortcuts || validation_error.is_some() {
                 info!("Settings watcher: hotkey profiles changed");
                 let old_operational = health.operational_hotkey();
-                let new_shortcuts: Vec<String> = new_profiles.iter().map(|profile| profile.shortcut.clone()).collect();
-                let validation_error = sagascript_core::settings::Settings::validate_hotkey_profiles(&new_profiles).err();
                 let unregister_error = if validation_error.is_none() {
                     match &old_operational {
                         hotkey::OperationalHotkey::Registered(shortcuts) => hotkey::unregister_shortcuts(
@@ -1896,11 +2064,15 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                     new_settings.hotkey = old_settings.hotkey.clone();
                     new_settings.language = old_settings.language;
                     new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
+                    new_settings.hotkey_mode = old_settings.hotkey_mode;
+                    new_settings.presenter = old_settings.presenter.clone();
                     health.record(&old_settings.hotkey, Some(format!("{error}; previous hotkey profiles remain active")), old_operational)
                 } else if let Some(error) = unregister_error {
                     new_settings.hotkey = old_settings.hotkey.clone();
                     new_settings.language = old_settings.language;
                     new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
+                    new_settings.hotkey_mode = old_settings.hotkey_mode;
+                    new_settings.presenter = old_settings.presenter.clone();
                     health.record(&old_settings.hotkey, Some(format!("failed to unregister previous hotkeys: {error}")), hotkey::OperationalHotkey::Unknown)
                 } else {
                     match hotkey::register_shortcuts(&app, &new_shortcuts) {
@@ -1909,6 +2081,8 @@ fn start_settings_watcher(app: tauri::AppHandle) {
                             new_settings.hotkey = old_settings.hotkey.clone();
                             new_settings.language = old_settings.language;
                             new_settings.hotkey_profiles = old_settings.hotkey_profiles.clone();
+                            new_settings.hotkey_mode = old_settings.hotkey_mode;
+                            new_settings.presenter = old_settings.presenter.clone();
                             match hotkey::unregister_shortcuts(&app, &new_shortcuts) {
                                 Err(cleanup_error) => health.record(
                                     &old_settings.hotkey,
@@ -2135,6 +2309,18 @@ mod tests {
     }
 
     #[test]
+    fn presenter_launch_stays_hidden_even_before_onboarding_is_complete() {
+        assert_eq!(
+            initial_window_request(true, GuiLaunchMode::Presenter),
+            InitialWindowRequest::Hidden
+        );
+        assert_eq!(
+            initial_window_request(false, GuiLaunchMode::Presenter),
+            InitialWindowRequest::Hidden
+        );
+    }
+
+    #[test]
     fn incomplete_onboarding_starts_on_the_onboarding_view_even_when_headless() {
         assert_eq!(
             initial_window_request(false, GuiLaunchMode::Background),
@@ -2163,6 +2349,93 @@ mod tests {
             mode(&["sagascript", "config", sagascript_cli::open::GUI_OPEN_ARG]),
             GuiLaunchMode::Standard
         );
+        assert_eq!(
+            mode(&["sagascript", "presenter", "start"]),
+            GuiLaunchMode::Standard
+        );
+    }
+
+    #[test]
+    fn presenter_second_instance_markers_never_reveal_settings() {
+        assert!(!second_instance_requests_settings(&[
+            "sagascript".to_string(),
+            "--presenter-finish".to_string(),
+        ]));
+        assert!(!second_instance_requests_settings(&[
+            "sagascript".to_string(),
+            "--presenter-finish".to_string(),
+            "unexpected".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn second_instance_accepts_complete_argv_shape_without_using_cwd() {
+        let request = presenter_request_from_second_instance_args(&[
+            "/Applications/Sagascript.app/Contents/MacOS/sagascript".to_string(),
+            "--presenter-cancel".to_string(),
+        ])
+        .expect("complete argv marker should parse")
+        .expect("complete argv marker should produce a request");
+        assert_eq!(
+            request,
+            sagascript_cli::presenter::PresenterRequest::Cancel
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ordinary_non_text_cli_argument_stays_on_standard_cli_path() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let args = vec![
+            std::ffi::OsString::from("sagascript"),
+            std::ffi::OsString::from_vec(vec![b'/', b't', b'm', b'p', 0x80]),
+        ];
+        assert_eq!(
+            presenter_request_from_os_args(&args[1..]).expect("ordinary CLI args must be preserved"),
+            None
+        );
+        assert_eq!(gui_launch_mode(args), GuiLaunchMode::Standard);
+    }
+
+    #[test]
+    fn second_instance_rejects_unknown_program_name_before_private_marker() {
+        let args = vec!["other-tool".to_string(), "--presenter-start".to_string()];
+        assert!(presenter_request_from_second_instance_args(&args).is_err());
+        assert!(!second_instance_requests_settings(&args));
+    }
+
+    #[test]
+    fn presenter_marker_receipt_requires_one_valid_private_marker() {
+        use sagascript_cli::presenter::PresenterRequest;
+
+        let request = presenter_request_from_strings(&["--presenter-start".to_string()])
+            .expect("valid presenter marker should parse")
+            .expect("presenter marker should produce a request");
+        assert_eq!(request, PresenterRequest::Start { profile_id: None });
+        assert_eq!(
+            gui_launch_mode(["sagascript".into(), "--presenter-start".into()]),
+            GuiLaunchMode::Presenter
+        );
+    }
+
+    #[test]
+    fn malformed_or_mixed_presenter_markers_fail_closed_without_settings_reveal() {
+        for args in [
+            vec!["--presenter-finish".to_string(), "extra".to_string()],
+            vec!["--presenter-start=Bad_ID".to_string()],
+            vec!["--presenter-unknown".to_string()],
+            vec!["ordinary-cli".to_string(), "--presenter-cancel".to_string()],
+        ] {
+            assert!(presenter_request_from_strings(&args).is_err());
+            assert_eq!(
+                gui_launch_mode(
+                    std::iter::once(std::ffi::OsString::from("sagascript"))
+                        .chain(args.into_iter().map(std::ffi::OsString::from))
+                ),
+                GuiLaunchMode::InvalidPresenter
+            );
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/paste/service.rs
+++ b/src-tauri/src/paste/service.rs
@@ -22,12 +22,39 @@ use sagascript_core::error::DictationError;
 /// Uses clipboard + simulated Cmd+V (macOS) or Ctrl+V (Windows/Linux)
 pub struct PasteService;
 
-fn paste_payload(text: &str) -> Cow<'_, str> {
+pub(crate) fn paste_payload(text: &str) -> Cow<'_, str> {
     if text.is_empty() || text.chars().last().is_some_and(char::is_whitespace) {
         Cow::Borrowed(text)
     } else {
         Cow::Owned(format!("{text} "))
     }
+}
+
+const PASTE_GUARD_REJECTED: &str =
+    "Paste target changed before keystroke dispatch; paste was cancelled.";
+
+#[derive(Debug)]
+enum CheckedDispatchError {
+    GuardRejected,
+    Dispatch(DictationError),
+}
+
+fn run_checked_dispatch<Before, Dispatch>(
+    text: &str,
+    before_key: Before,
+    dispatch: Dispatch,
+) -> Result<(), CheckedDispatchError>
+where
+    Before: FnOnce() -> bool,
+    Dispatch: FnOnce() -> Result<(), DictationError>,
+{
+    if text.is_empty() {
+        return Ok(());
+    }
+    if !before_key() {
+        return Err(CheckedDispatchError::GuardRejected);
+    }
+    dispatch().map_err(CheckedDispatchError::Dispatch)
 }
 
 impl PasteService {
@@ -38,6 +65,17 @@ impl PasteService {
     /// Paste text into the currently active application
     /// Saves and restores previous clipboard contents
     pub fn paste(&self, text: &str) -> Result<(), DictationError> {
+        self.paste_checked(text, || true)
+    }
+
+    /// Paste text only if the caller's target guard is still valid immediately
+    /// before the synthetic keystroke. Clipboard setup and focus delays happen
+    /// before this final check; a rejected guard never dispatches a key.
+    pub(crate) fn paste_checked(
+        &self,
+        text: &str,
+        before_key: impl FnOnce() -> bool,
+    ) -> Result<(), DictationError> {
         if text.is_empty() {
             return Ok(());
         }
@@ -112,9 +150,26 @@ impl PasteService {
         #[cfg(target_os = "windows")]
         wait_for_windows_modifiers()?;
 
-        // Simulate paste keystroke
+        // Simulate paste keystroke. This is intentionally the first operation
+        // after the final target check: a rejected guard cannot emit a key.
         info!("Simulating paste keystroke...");
-        simulate_paste()?;
+        match run_checked_dispatch(text.as_ref(), before_key, simulate_paste) {
+            Ok(()) => {}
+            Err(CheckedDispatchError::GuardRejected) => {
+                // macOS and Windows retain generation/ownership checks for
+                // restoration. Linux has no equivalent generation primitive,
+                // so leave its temporary clipboard untouched rather than
+                // risking a concurrent-copy overwrite.
+                #[cfg(target_os = "macos")]
+                if let Some(snapshot) = saved_pasteboard {
+                    let _ = macos_clipboard::restore_if_unchanged(snapshot, owned_change_count);
+                }
+                #[cfg(target_os = "windows")]
+                saved_windows.schedule_restore();
+                return Err(DictationError::PasteError(PASTE_GUARD_REJECTED.to_owned()));
+            }
+            Err(CheckedDispatchError::Dispatch(error)) => return Err(error),
+        }
 
         // Windows owns the native clipboard session on its worker thread. A
         // dropped pending handle deliberately leaves the temporary copy in
@@ -157,6 +212,61 @@ fn validate_accessibility(trusted: bool) -> Result<(), DictationError> {
         Ok(())
     } else {
         Err(DictationError::AccessibilityPermissionDenied)
+    }
+}
+
+#[cfg(test)]
+mod checked_paste_tests {
+    use super::{run_checked_dispatch, CheckedDispatchError};
+
+    #[test]
+    fn rejected_guard_skips_key_dispatch() {
+        let mut key_calls = 0;
+        let result = run_checked_dispatch(
+            "recognized text",
+            || false,
+            || {
+                key_calls += 1;
+                Ok(())
+            },
+        );
+        assert!(matches!(result, Err(CheckedDispatchError::GuardRejected)));
+        assert_eq!(key_calls, 0);
+    }
+
+    #[test]
+    fn accepted_guard_dispatches_once() {
+        let mut key_calls = 0;
+        run_checked_dispatch(
+            "recognized text",
+            || true,
+            || {
+                key_calls += 1;
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(key_calls, 1);
+    }
+
+    #[test]
+    fn empty_text_does_not_check_guard_or_dispatch() {
+        let mut guard_checks = 0;
+        let mut key_calls = 0;
+        run_checked_dispatch(
+            "",
+            || {
+                guard_checks += 1;
+                true
+            },
+            || {
+                key_calls += 1;
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(guard_checks, 0);
+        assert_eq!(key_calls, 0);
     }
 }
 

--- a/src-tauri/src/presenter/gate.rs
+++ b/src-tauri/src/presenter/gate.rs
@@ -1,0 +1,284 @@
+//! Pure sequencing policy. Native target/field observations must be supplied
+//! by the platform adapter, never by IPC or frontend claims. This gate alone
+//! does not prove insertion or prevent a queued OS action after dispatch.
+
+// Non-macOS builds deliberately retain drafts until they have a verified
+// native field adapter. Keep the shared policy testable on every platform.
+#![cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    #[default]
+    InsertOnly,
+    Return,
+    CommandReturn,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Listening,
+    Transcribing,
+    AwaitingInsertion,
+    Inserted,
+    Submitting,
+    Sent,
+    Cancelled,
+    Draft,
+    Failed,
+    NoSpeech,
+    SubmitUncertain,
+}
+
+pub struct Gate {
+    action: Action,
+    target_valid: bool,
+    phase: Phase,
+    insertion_dispatched: bool,
+}
+
+impl Gate {
+    pub fn new(action: Action, target_known: bool) -> Self {
+        Self {
+            action,
+            target_valid: target_known,
+            phase: Phase::Listening,
+            insertion_dispatched: false,
+        }
+    }
+
+    pub fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    pub fn action(&self) -> Action {
+        self.action
+    }
+
+    pub fn finish(&mut self) -> bool {
+        if self.phase != Phase::Listening {
+            return false;
+        }
+        self.phase = Phase::Transcribing;
+        true
+    }
+
+    pub fn target_changed(&mut self) {
+        self.target_valid = false;
+    }
+
+    pub fn transcribed(&mut self, success: bool, nonempty: bool) {
+        if self.phase != Phase::Transcribing {
+            return;
+        }
+        self.phase = if !success {
+            Phase::Failed
+        } else if !nonempty {
+            Phase::NoSpeech
+        } else if !self.target_valid {
+            Phase::Draft
+        } else {
+            Phase::AwaitingInsertion
+        };
+    }
+
+    pub fn may_insert(&mut self, current_target_matches: bool) -> bool {
+        if self.phase != Phase::AwaitingInsertion || self.insertion_dispatched {
+            return false;
+        }
+        if !self.target_valid || !current_target_matches {
+            self.target_valid = false;
+            self.phase = Phase::Draft;
+            return false;
+        }
+        self.insertion_dispatched = true;
+        true
+    }
+
+    /// Consume the one possible submit opportunity after native field-state
+    /// verification. The caller must keep this decision and key dispatch in
+    /// the same serialized native action and recheck target immediately there.
+    pub fn authorize_submit(
+        &mut self,
+        insertion_proven: bool,
+        current_target_matches: bool,
+        app_rule_still_allows_action: bool,
+    ) -> Option<Action> {
+        if self.phase != Phase::AwaitingInsertion || !self.insertion_dispatched {
+            return None;
+        }
+        if !self.target_valid || !current_target_matches || !insertion_proven {
+            self.phase = Phase::Draft;
+            return None;
+        }
+        if self.action == Action::InsertOnly || !app_rule_still_allows_action {
+            self.phase = Phase::Inserted;
+            return None;
+        }
+        self.phase = Phase::Submitting;
+        Some(self.action)
+    }
+
+    pub fn submit_completed(&mut self, success: bool) {
+        if self.phase == Phase::Submitting {
+            // A failed native call may already have injected part of a key
+            // sequence. Do not retry or claim the prompt was definitely unsent.
+            self.phase = if success {
+                Phase::Sent
+            } else {
+                Phase::SubmitUncertain
+            };
+        }
+    }
+
+    pub fn insertion_timed_out(&mut self) {
+        if self.phase == Phase::AwaitingInsertion {
+            self.phase = Phase::Draft;
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        if matches!(
+            self.phase,
+            Phase::Listening | Phase::Transcribing | Phase::AwaitingInsertion
+        ) {
+            self.phase = Phase::Cancelled;
+            self.target_valid = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Action, Gate, Phase};
+
+    #[test]
+    fn insertion_dispatch_is_consumed_once_and_required_before_submit() {
+        let mut gate = Gate::new(Action::Return, true);
+        gate.finish();
+        gate.transcribed(true, true);
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        assert!(gate.may_insert(true));
+        assert!(!gate.may_insert(true));
+        assert_eq!(gate.authorize_submit(true, true, true), Some(Action::Return));
+    }
+
+    #[test]
+    fn submit_requires_each_observation_in_order_and_is_consumed_once() {
+        let mut gate = Gate::new(Action::Return, true);
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        assert!(gate.finish());
+        assert!(!gate.finish());
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        gate.transcribed(true, true);
+        assert!(gate.may_insert(true));
+        assert_eq!(
+            gate.authorize_submit(true, true, true),
+            Some(Action::Return)
+        );
+        assert_eq!(gate.phase(), Phase::Submitting);
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        gate.submit_completed(true);
+        assert_eq!(gate.phase(), Phase::Sent);
+        gate.submit_completed(false);
+        assert_eq!(gate.phase(), Phase::Sent);
+    }
+
+    #[test]
+    fn default_inserts_without_submit() {
+        let mut gate = Gate::new(Action::InsertOnly, true);
+        gate.finish();
+        gate.transcribed(true, true);
+        assert!(gate.may_insert(true));
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        assert_eq!(gate.phase(), Phase::Inserted);
+    }
+
+    #[test]
+    fn missing_or_changed_target_never_inserts_or_submits() {
+        for initially_known in [false, true] {
+            let mut gate = Gate::new(Action::CommandReturn, initially_known);
+            gate.target_changed(); // Changing away and back must stay invalid.
+            gate.finish();
+            gate.transcribed(true, true);
+            assert!(!gate.may_insert(true));
+            assert_eq!(gate.authorize_submit(true, true, true), None);
+            assert_eq!(gate.phase(), Phase::Draft);
+        }
+    }
+
+    #[test]
+    fn empty_failed_or_unproven_insertion_cannot_submit() {
+        for (success, nonempty) in [(false, false), (false, true), (true, false)] {
+            let mut gate = Gate::new(Action::Return, true);
+            gate.finish();
+            gate.transcribed(success, nonempty);
+            assert!(!gate.may_insert(true));
+            assert_eq!(gate.authorize_submit(true, true, true), None);
+        }
+        for (proven, same, still_allowed) in [
+            (false, true, true),
+            (true, false, true),
+            (true, true, false),
+        ] {
+            let mut gate = Gate::new(Action::Return, true);
+            gate.finish();
+            gate.transcribed(true, true);
+            assert!(gate.may_insert(true));
+            assert_eq!(gate.authorize_submit(proven, same, still_allowed), None);
+            assert_ne!(gate.phase(), Phase::Sent);
+            assert_eq!(gate.authorize_submit(true, true, true), None);
+        }
+    }
+
+    #[test]
+    fn cancellation_and_timeout_are_terminal_for_late_callbacks() {
+        for steps in 0..3 {
+            let mut gate = Gate::new(Action::Return, true);
+            if steps >= 1 {
+                gate.finish();
+            }
+            if steps >= 2 {
+                gate.transcribed(true, true);
+            }
+            gate.cancel();
+            gate.transcribed(true, true);
+            assert!(!gate.finish());
+            assert!(!gate.may_insert(true));
+            assert_eq!(gate.authorize_submit(true, true, true), None);
+            gate.submit_completed(true);
+            assert_eq!(gate.phase(), Phase::Cancelled);
+        }
+        let mut gate = Gate::new(Action::Return, true);
+        gate.finish();
+        gate.transcribed(true, true);
+        gate.insertion_timed_out();
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        assert_eq!(gate.phase(), Phase::Draft);
+    }
+
+    #[test]
+    fn failed_submit_is_not_retried_and_cancellation_cannot_claim_recall() {
+        for succeeded in [false, true] {
+            let mut gate = Gate::new(Action::Return, true);
+            gate.finish();
+            gate.transcribed(true, true);
+            assert!(gate.may_insert(true));
+            assert_eq!(
+                gate.authorize_submit(true, true, true),
+                Some(Action::Return)
+            );
+            gate.cancel(); // Native key dispatch may already be in flight.
+            assert_eq!(gate.phase(), Phase::Submitting);
+            gate.submit_completed(succeeded);
+            assert_eq!(
+                gate.phase(),
+                if succeeded {
+                    Phase::Sent
+                } else {
+                    Phase::SubmitUncertain
+                }
+            );
+            assert_eq!(gate.authorize_submit(true, true, true), None);
+        }
+    }
+}

--- a/src-tauri/src/presenter/gate.rs
+++ b/src-tauri/src/presenter/gate.rs
@@ -150,6 +150,7 @@ impl Gate {
 #[cfg(test)]
 mod tests {
     use super::{Action, Gate, Phase};
+    use crate::presenter::observation::{decide, Decision};
 
     #[test]
     fn insertion_dispatch_is_consumed_once_and_required_before_submit() {
@@ -280,5 +281,66 @@ mod tests {
             );
             assert_eq!(gate.authorize_submit(true, true, true), None);
         }
+    }
+
+    #[test]
+    fn held_modifiers_wait_then_release_proves_one_insert_and_one_submit() {
+        let mut gate = Gate::new(Action::Return, true);
+        assert!(gate.finish());
+        gate.transcribed(true, true);
+
+        assert_eq!(decide(true, false, true, false), Decision::Wait);
+        assert_eq!(gate.phase(), Phase::AwaitingInsertion);
+        assert_eq!(decide(true, true, true, false), Decision::Wait);
+
+        assert_eq!(decide(true, true, true, true), Decision::Proven);
+        assert!(gate.may_insert(true));
+        assert!(!gate.may_insert(true));
+        assert_eq!(
+            gate.authorize_submit(true, true, true),
+            Some(Action::Return)
+        );
+        assert_eq!(gate.phase(), Phase::Submitting);
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+    }
+
+    #[test]
+    fn timeout_while_modifiers_are_held_never_inserts_or_submits() {
+        let mut gate = Gate::new(Action::Return, true);
+        gate.finish();
+        gate.transcribed(true, true);
+        assert_eq!(decide(true, true, true, false), Decision::Wait);
+        gate.insertion_timed_out();
+
+        assert_eq!(gate.phase(), Phase::Draft);
+        assert!(!gate.may_insert(true));
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+    }
+
+    #[test]
+    fn cancel_while_waiting_never_inserts_or_submits() {
+        let mut gate = Gate::new(Action::Return, true);
+        gate.finish();
+        gate.transcribed(true, true);
+        assert_eq!(decide(true, true, true, false), Decision::Wait);
+        gate.cancel();
+
+        assert_eq!(gate.phase(), Phase::Cancelled);
+        assert!(!gate.may_insert(true));
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+    }
+
+    #[test]
+    fn target_change_away_and_back_stays_uninsertable() {
+        let mut gate = Gate::new(Action::Return, true);
+        gate.finish();
+        gate.transcribed(true, true);
+        gate.target_changed();
+
+        assert_eq!(decide(false, false, true, true), Decision::Draft);
+        assert_eq!(decide(true, true, true, true), Decision::Proven);
+        assert!(!gate.may_insert(true));
+        assert_eq!(gate.authorize_submit(true, true, true), None);
+        assert_eq!(gate.phase(), Phase::Draft);
     }
 }

--- a/src-tauri/src/presenter/macos_target.rs
+++ b/src-tauri/src/presenter/macos_target.rs
@@ -185,8 +185,8 @@ fn validate_bundle_id(value: &str) -> Result<(), TargetError> {
     }
 }
 
-fn capture_revalidation_succeeds(snapshot_matches: bool, unchanged: bool) -> bool {
-    snapshot_matches && unchanged
+fn capture_revalidation_succeeds(snapshot_matches: bool, token_valid: bool) -> bool {
+    snapshot_matches && token_valid
 }
 
 fn decode_utf16_bounded(units: &[u16], max_utf8_bytes: usize) -> Result<String, TargetError> {
@@ -259,6 +259,33 @@ fn copy_attribute(element: AXUIElementRef, attribute: &CFString) -> Result<Owned
         return Err(map_ax_error(error));
     }
     OwnedCf::new(value)
+}
+
+// Only the optional subrole may be absent; a successful call with a null
+// value or a transport/permission failure is not proof of absence.
+fn optional_subrole_present(error: AXError, has_value: bool) -> Result<bool, TargetError> {
+    if matches!(error, AX_ERROR_ATTRIBUTE_UNSUPPORTED | AX_ERROR_NO_VALUE) && !has_value {
+        return Ok(false);
+    }
+    if error != AX_SUCCESS {
+        return Err(map_ax_error(error));
+    }
+    if !has_value { return Err(TargetError::InvalidValue); }
+    Ok(true)
+}
+
+fn copy_subrole(element: AXUIElementRef) -> Result<String, TargetError> {
+    let mut value: CFTypeRef = ptr::null();
+    let error = unsafe {
+        AXUIElementCopyAttributeValue(element, attribute_subrole().as_concrete_TypeRef(), &mut value)
+    };
+    // Retain ownership even for an unexpected non-null error result.
+    let owned = if value.is_null() { None } else { Some(OwnedCf(value)) };
+    if !optional_subrole_present(error, owned.is_some())? {
+        return Ok(String::new());
+    }
+    let value = owned.ok_or(TargetError::InvalidValue)?;
+    read_cf_string(value.as_ptr(), MAX_BUNDLE_ID_BYTES).map(|(text, _)| text)
 }
 
 fn require_ax_element(value: CFTypeRef) -> Result<(), TargetError> {
@@ -423,14 +450,7 @@ fn current_target() -> Result<CurrentTarget, TargetError> {
         copy_attribute(focused_field.as_ptr() as AXUIElementRef, &attribute_role())?.as_ptr(),
         MAX_BUNDLE_ID_BYTES,
     )?;
-    let (subrole, _) = read_cf_string(
-        copy_attribute(
-            focused_field.as_ptr() as AXUIElementRef,
-            &attribute_subrole(),
-        )?
-        .as_ptr(),
-        MAX_BUNDLE_ID_BYTES,
-    )?;
+    let subrole = copy_subrole(focused_field.as_ptr() as AXUIElementRef)?;
     validate_editable_role(&role, &subrole)?;
     let (frontmost_pid, app_id) = frontmost_application_identity()?;
     if frontmost_pid != pid {
@@ -596,8 +616,10 @@ impl TargetGuard {
                 _main_thread_only: PhantomData,
             };
             let snapshot_matches = candidate.snapshot_matches()?;
-            let unchanged = candidate.unchanged()?;
-            if !capture_revalidation_succeeds(snapshot_matches, unchanged) {
+            // snapshot_matches already traverses and verifies the current
+            // app/field identity. Avoid a third full AX traversal here, but
+            // reject any observer invalidation during the snapshot read.
+            if !capture_revalidation_succeeds(snapshot_matches, candidate.valid_token().is_ok()) {
                 return Err(TargetError::TargetChanged);
             }
             Ok(candidate)
@@ -653,7 +675,9 @@ impl TargetGuard {
         if !self.matches_current(&current) {
             return Err(TargetError::TargetChanged);
         }
-        read_value_and_selection(current.field.as_ptr() as AXUIElementRef)
+        let observation = read_value_and_selection(current.field.as_ptr() as AXUIElementRef)?;
+        self.valid_token()?;
+        Ok(observation)
     }
 }
 
@@ -670,6 +694,19 @@ mod tests {
         capture_revalidation_succeeds, decode_utf16_bounded, main_thread_and_runloop_are_valid,
         validate_bundle_id, validate_editable_role, validate_selection_range, TargetError,
     };
+
+    #[test]
+    fn optional_subrole_absence_is_not_a_transport_or_type_failure() {
+        assert_eq!(super::optional_subrole_present(super::AX_ERROR_NO_VALUE, false), Ok(false));
+        assert_eq!(super::optional_subrole_present(super::AX_ERROR_ATTRIBUTE_UNSUPPORTED, false), Ok(false));
+        assert_eq!(super::optional_subrole_present(super::AX_SUCCESS, true), Ok(true));
+        assert_eq!(super::optional_subrole_present(super::AX_SUCCESS, false), Err(TargetError::InvalidValue));
+        assert!(super::optional_subrole_present(super::AX_ERROR_API_DISABLED, false).is_err());
+        assert!(super::optional_subrole_present(-25204, false).is_err());
+        assert!(super::optional_subrole_present(-25202, false).is_err());
+        assert!(validate_editable_role("AXTextArea", "").is_ok());
+        assert_eq!(validate_editable_role("AXTextField", "AXSecureTextField"), Err(TargetError::SecureField));
+    }
 
     #[test]
     fn native_calls_require_both_main_run_loop_and_main_thread() {

--- a/src-tauri/src/presenter/macos_target.rs
+++ b/src-tauri/src/presenter/macos_target.rs
@@ -1,0 +1,758 @@
+//! Read-only macOS Accessibility target observation for Presenter Mode.
+//!
+//! This adapter deliberately contains no AX setter, key event, clipboard, or
+//! permission-prompt path. All native entry points are main-thread-only and
+//! every native failure is reduced to a content-free `TargetError`.
+
+use core_foundation::base::{CFEqual, CFGetTypeID, CFRelease, CFTypeRef, TCFType};
+use core_foundation::runloop::{
+    kCFRunLoopDefaultMode, CFRunLoopAddSource, CFRunLoopGetCurrent, CFRunLoopGetMain, CFRunLoopRef,
+    CFRunLoopRemoveSource, CFRunLoopSourceRef,
+};
+use core_foundation::string::{CFString, CFStringGetCharacters, CFStringGetLength, CFStringRef};
+use objc::runtime::{Class, Object};
+use objc::{class, msg_send, sel, sel_impl};
+use std::ffi::{c_char, c_void, CStr};
+use std::marker::PhantomData;
+use std::ptr;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+type AXUIElementRef = *const c_void;
+type AXObserverRef = *const c_void;
+type AXValueRef = *const c_void;
+type AXValueType = u32;
+type AXError = i32;
+type Pid = i32;
+
+const AX_SUCCESS: AXError = 0;
+const AX_ERROR_ATTRIBUTE_UNSUPPORTED: AXError = -25205;
+const AX_ERROR_API_DISABLED: AXError = -25211;
+const AX_ERROR_NO_VALUE: AXError = -25212;
+const AX_VALUE_CF_RANGE_TYPE: AXValueType = 4;
+const MAX_VALUE_UTF8_BYTES: usize = 32_768;
+const MAX_BUNDLE_ID_BYTES: usize = 512;
+const MESSAGING_TIMEOUT_SECONDS: f32 = 0.1;
+
+static NEXT_SESSION_TOKEN: AtomicUsize = AtomicUsize::new(1);
+static LAST_INVALIDATED_TOKEN: AtomicUsize = AtomicUsize::new(0);
+
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn AXUIElementCreateSystemWide() -> AXUIElementRef;
+    fn AXUIElementCopyAttributeValue(
+        element: AXUIElementRef,
+        attribute: CFStringRef,
+        value: *mut CFTypeRef,
+    ) -> AXError;
+    fn AXUIElementGetPid(element: AXUIElementRef, pid: *mut Pid) -> AXError;
+    fn AXUIElementGetTypeID() -> usize;
+    fn AXUIElementSetMessagingTimeout(element: AXUIElementRef, timeout: f32) -> AXError;
+    fn AXObserverCreate(
+        application: Pid,
+        callback: extern "C" fn(AXObserverRef, AXUIElementRef, CFStringRef, *mut c_void),
+        observer: *mut AXObserverRef,
+    ) -> AXError;
+    fn AXObserverAddNotification(
+        observer: AXObserverRef,
+        element: AXUIElementRef,
+        notification: CFStringRef,
+        refcon: *mut c_void,
+    ) -> AXError;
+    fn AXObserverRemoveNotification(
+        observer: AXObserverRef,
+        element: AXUIElementRef,
+        notification: CFStringRef,
+    ) -> AXError;
+    fn AXObserverGetRunLoopSource(observer: AXObserverRef) -> CFRunLoopSourceRef;
+    fn AXValueGetTypeID() -> usize;
+    fn AXValueGetType(value: AXValueRef) -> AXValueType;
+    fn AXValueGetValue(value: AXValueRef, value_type: AXValueType, value_out: *mut CFRange)
+        -> bool;
+}
+
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CFRange {
+    location: isize,
+    length: isize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetError {
+    MainThreadRequired,
+    AccessibilityUnavailable,
+    NativeFailure,
+    MessagingTimeout,
+    AttributeUnavailable,
+    AttributeTypeMismatch,
+    InvalidRole,
+    SecureField,
+    InvalidValue,
+    ValueTooLarge,
+    InvalidSelection,
+    AppIdentityUnavailable,
+    AppIdentityMismatch,
+    ObserverUnavailable,
+    ObserverRegistrationFailed,
+    ObserverRunLoopUnavailable,
+    SessionTokenExhausted,
+    TargetChanged,
+}
+
+fn map_ax_error(error: AXError) -> TargetError {
+    match error {
+        AX_ERROR_API_DISABLED => TargetError::AccessibilityUnavailable,
+        AX_ERROR_ATTRIBUTE_UNSUPPORTED | AX_ERROR_NO_VALUE => TargetError::AttributeUnavailable,
+        _ => TargetError::NativeFailure,
+    }
+}
+
+fn require_main_thread() -> Result<(), TargetError> {
+    unsafe {
+        let current = CFRunLoopGetCurrent();
+        let main = CFRunLoopGetMain();
+        let thread_class: *const Class = class!(NSThread);
+        let main_thread: bool = msg_send![thread_class, isMainThread];
+        let current_is_main = !current.is_null() && !main.is_null() && current == main;
+        if !main_thread_and_runloop_are_valid(current_is_main, main_thread) {
+            return Err(TargetError::MainThreadRequired);
+        }
+    }
+    Ok(())
+}
+
+fn main_thread_and_runloop_are_valid(current_is_main: bool, main_thread: bool) -> bool {
+    current_is_main && main_thread
+}
+
+fn cf_name(value: &'static str) -> CFString {
+    CFString::from_static_string(value)
+}
+
+fn attribute_focused_application() -> CFString {
+    cf_name("AXFocusedApplication")
+}
+
+fn attribute_focused_element() -> CFString {
+    cf_name("AXFocusedUIElement")
+}
+
+fn attribute_role() -> CFString {
+    cf_name("AXRole")
+}
+
+fn attribute_subrole() -> CFString {
+    cf_name("AXSubrole")
+}
+
+fn attribute_value() -> CFString {
+    cf_name("AXValue")
+}
+
+fn notification_focused_element() -> CFString {
+    cf_name("AXFocusedUIElementChanged")
+}
+
+fn notification_deactivated() -> CFString {
+    cf_name("AXApplicationDeactivated")
+}
+
+fn notification_focused_window() -> CFString {
+    cf_name("AXFocusedWindowChanged")
+}
+
+fn validate_editable_role(role: &str, subrole: &str) -> Result<(), TargetError> {
+    if subrole == "AXSecureTextField" {
+        return Err(TargetError::SecureField);
+    }
+    if matches!(role, "AXTextField" | "AXTextArea") {
+        Ok(())
+    } else {
+        Err(TargetError::InvalidRole)
+    }
+}
+
+fn validate_bundle_id(value: &str) -> Result<(), TargetError> {
+    if value.is_empty() || value.len() > MAX_BUNDLE_ID_BYTES || value.chars().any(char::is_control)
+    {
+        Err(TargetError::AppIdentityUnavailable)
+    } else {
+        Ok(())
+    }
+}
+
+fn capture_revalidation_succeeds(snapshot_matches: bool, unchanged: bool) -> bool {
+    snapshot_matches && unchanged
+}
+
+fn decode_utf16_bounded(units: &[u16], max_utf8_bytes: usize) -> Result<String, TargetError> {
+    let value = String::from_utf16(units).map_err(|_| TargetError::InvalidValue)?;
+    if value.len() > max_utf8_bytes {
+        return Err(TargetError::ValueTooLarge);
+    }
+    Ok(value)
+}
+
+fn validate_selection_range(
+    units: &[u16],
+    location: isize,
+    length: isize,
+) -> Result<(usize, usize), TargetError> {
+    if location < 0 || length < 0 {
+        return Err(TargetError::InvalidSelection);
+    }
+    let start = usize::try_from(location).map_err(|_| TargetError::InvalidSelection)?;
+    let count = usize::try_from(length).map_err(|_| TargetError::InvalidSelection)?;
+    let end = start
+        .checked_add(count)
+        .ok_or(TargetError::InvalidSelection)?;
+    if end > units.len() {
+        return Err(TargetError::InvalidSelection);
+    }
+    if is_surrogate_boundary(units, start) || is_surrogate_boundary(units, end) {
+        return Err(TargetError::InvalidSelection);
+    }
+    Ok((start, count))
+}
+
+fn is_surrogate_boundary(units: &[u16], boundary: usize) -> bool {
+    boundary > 0
+        && boundary < units.len()
+        && (0xDC00..=0xDFFF).contains(&units[boundary])
+        && (0xD800..=0xDBFF).contains(&units[boundary - 1])
+}
+
+struct OwnedCf(CFTypeRef);
+
+impl OwnedCf {
+    fn new(value: CFTypeRef) -> Result<Self, TargetError> {
+        if value.is_null() {
+            Err(TargetError::AttributeUnavailable)
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    fn as_ptr(&self) -> CFTypeRef {
+        self.0
+    }
+}
+
+impl Drop for OwnedCf {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { CFRelease(self.0) };
+        }
+    }
+}
+
+fn copy_attribute(element: AXUIElementRef, attribute: &CFString) -> Result<OwnedCf, TargetError> {
+    let mut value: CFTypeRef = ptr::null();
+    let error = unsafe {
+        AXUIElementCopyAttributeValue(element, attribute.as_concrete_TypeRef(), &mut value)
+    };
+    if error != AX_SUCCESS {
+        return Err(map_ax_error(error));
+    }
+    OwnedCf::new(value)
+}
+
+fn require_ax_element(value: CFTypeRef) -> Result<(), TargetError> {
+    let actual = unsafe { CFGetTypeID(value) };
+    if actual == unsafe { AXUIElementGetTypeID() } {
+        Ok(())
+    } else {
+        Err(TargetError::AttributeTypeMismatch)
+    }
+}
+
+fn set_messaging_timeout(element: AXUIElementRef) -> Result<(), TargetError> {
+    if unsafe { AXUIElementSetMessagingTimeout(element, MESSAGING_TIMEOUT_SECONDS) } != AX_SUCCESS {
+        Err(TargetError::MessagingTimeout)
+    } else {
+        Ok(())
+    }
+}
+
+fn read_cf_string(
+    value: CFTypeRef,
+    max_utf8_bytes: usize,
+) -> Result<(String, Vec<u16>), TargetError> {
+    if unsafe { CFGetTypeID(value) } != CFString::type_id() {
+        return Err(TargetError::AttributeTypeMismatch);
+    }
+    let string_ref = value as CFStringRef;
+    let length = unsafe { CFStringGetLength(string_ref) };
+    if length < 0
+        || usize::try_from(length).map_err(|_| TargetError::ValueTooLarge)? > max_utf8_bytes
+    {
+        return Err(TargetError::ValueTooLarge);
+    }
+    let mut units = vec![0u16; length as usize];
+    if length > 0 {
+        unsafe {
+            CFStringGetCharacters(
+                string_ref,
+                core_foundation::base::CFRange {
+                    location: 0,
+                    length,
+                },
+                units.as_mut_ptr(),
+            );
+        }
+    }
+    let decoded = decode_utf16_bounded(&units, max_utf8_bytes)?;
+    Ok((decoded, units))
+}
+
+fn read_range(value: &OwnedCf, units: &[u16]) -> Result<(usize, usize), TargetError> {
+    if unsafe { CFGetTypeID(value.as_ptr()) } != unsafe { AXValueGetTypeID() }
+        || unsafe { AXValueGetType(value.as_ptr() as AXValueRef) } != AX_VALUE_CF_RANGE_TYPE
+    {
+        return Err(TargetError::AttributeTypeMismatch);
+    }
+    let mut range = CFRange {
+        location: 0,
+        length: 0,
+    };
+    let valid = unsafe {
+        AXValueGetValue(
+            value.as_ptr() as AXValueRef,
+            AX_VALUE_CF_RANGE_TYPE,
+            &mut range,
+        )
+    };
+    if !valid {
+        return Err(TargetError::InvalidSelection);
+    }
+    validate_selection_range(units, range.location, range.length)
+}
+
+fn read_value_and_selection(field: AXUIElementRef) -> Result<(String, usize, usize), TargetError> {
+    let value = copy_attribute(field, &attribute_value())?;
+    let (text, units) = read_cf_string(value.as_ptr(), MAX_VALUE_UTF8_BYTES)?;
+    let selected_range = copy_attribute(field, &cf_name("AXSelectedTextRange"))?;
+    let (location, length) = read_range(&selected_range, &units)?;
+    Ok((text, location, length))
+}
+
+fn frontmost_application_identity() -> Result<(Pid, String), TargetError> {
+    let pool: *mut Object = unsafe { msg_send![class!(NSAutoreleasePool), new] };
+    if pool.is_null() {
+        return Err(TargetError::AppIdentityUnavailable);
+    }
+    let result = unsafe {
+        let workspace: *mut Object = msg_send![class!(NSWorkspace), sharedWorkspace];
+        let application: *mut Object = if workspace.is_null() {
+            ptr::null_mut()
+        } else {
+            msg_send![workspace, frontmostApplication]
+        };
+        if application.is_null() {
+            Err(TargetError::AppIdentityUnavailable)
+        } else {
+            let pid: Pid = msg_send![application, processIdentifier];
+            let bundle: *mut Object = msg_send![application, bundleIdentifier];
+            if pid <= 0 || bundle.is_null() {
+                Err(TargetError::AppIdentityUnavailable)
+            } else {
+                let byte_len: usize = msg_send![bundle, lengthOfBytesUsingEncoding: 4usize];
+                if byte_len == 0 || byte_len > MAX_BUNDLE_ID_BYTES {
+                    Err(TargetError::AppIdentityUnavailable)
+                } else {
+                    let utf8: *const c_char = msg_send![bundle, UTF8String];
+                    if utf8.is_null() {
+                        Err(TargetError::AppIdentityUnavailable)
+                    } else {
+                        CStr::from_ptr(utf8)
+                            .to_str()
+                            .map_err(|_| TargetError::AppIdentityUnavailable)
+                            .and_then(|value| {
+                                validate_bundle_id(value)?;
+                                Ok((pid, value.to_owned()))
+                            })
+                    }
+                }
+            }
+        }
+    };
+    unsafe {
+        let _: () = msg_send![pool, drain];
+    }
+    result
+}
+
+struct CurrentTarget {
+    application: OwnedCf,
+    field: OwnedCf,
+    pid: Pid,
+    app_id: String,
+}
+
+fn current_target() -> Result<CurrentTarget, TargetError> {
+    require_main_thread()?;
+    let system = OwnedCf::new(unsafe { AXUIElementCreateSystemWide() })?;
+    require_ax_element(system.as_ptr())?;
+    set_messaging_timeout(system.as_ptr() as AXUIElementRef)?;
+    let focused_app = copy_attribute(
+        system.as_ptr() as AXUIElementRef,
+        &attribute_focused_application(),
+    )?;
+    require_ax_element(focused_app.as_ptr())?;
+    let mut pid: Pid = 0;
+    let pid_error = unsafe { AXUIElementGetPid(focused_app.as_ptr() as AXUIElementRef, &mut pid) };
+    if pid_error != AX_SUCCESS || pid <= 0 {
+        return Err(if pid_error == AX_ERROR_API_DISABLED {
+            TargetError::AccessibilityUnavailable
+        } else {
+            TargetError::AppIdentityUnavailable
+        });
+    }
+    set_messaging_timeout(focused_app.as_ptr() as AXUIElementRef)?;
+    let focused_field = copy_attribute(
+        focused_app.as_ptr() as AXUIElementRef,
+        &attribute_focused_element(),
+    )?;
+    require_ax_element(focused_field.as_ptr())?;
+    set_messaging_timeout(focused_field.as_ptr() as AXUIElementRef)?;
+    let (role, _) = read_cf_string(
+        copy_attribute(focused_field.as_ptr() as AXUIElementRef, &attribute_role())?.as_ptr(),
+        MAX_BUNDLE_ID_BYTES,
+    )?;
+    let (subrole, _) = read_cf_string(
+        copy_attribute(
+            focused_field.as_ptr() as AXUIElementRef,
+            &attribute_subrole(),
+        )?
+        .as_ptr(),
+        MAX_BUNDLE_ID_BYTES,
+    )?;
+    validate_editable_role(&role, &subrole)?;
+    let (frontmost_pid, app_id) = frontmost_application_identity()?;
+    if frontmost_pid != pid {
+        return Err(TargetError::AppIdentityMismatch);
+    }
+    Ok(CurrentTarget {
+        application: focused_app,
+        field: focused_field,
+        pid,
+        app_id,
+    })
+}
+
+extern "C" fn observer_callback(
+    _observer: AXObserverRef,
+    _element: AXUIElementRef,
+    _notification: CFStringRef,
+    refcon: *mut c_void,
+) {
+    // The refcon is an opaque monotonic token, never a dereferenced pointer.
+    let token = refcon as usize;
+    if token != 0 {
+        LAST_INVALIDATED_TOKEN.fetch_max(token, Ordering::Release);
+    }
+}
+
+struct NotificationRegistration {
+    element: AXUIElementRef,
+    name: CFString,
+}
+
+struct ObserverResources {
+    observer: AXObserverRef,
+    run_loop: CFRunLoopRef,
+    source: CFRunLoopSourceRef,
+    source_added: bool,
+    registered: Vec<NotificationRegistration>,
+}
+
+impl ObserverResources {
+    fn new(application: AXUIElementRef, pid: Pid, token: usize) -> Result<Self, TargetError> {
+        let run_loop = unsafe { CFRunLoopGetCurrent() };
+        if run_loop.is_null() {
+            return Err(TargetError::ObserverRunLoopUnavailable);
+        }
+        let mut observer = ptr::null();
+        let create_error = unsafe { AXObserverCreate(pid, observer_callback, &mut observer) };
+        if create_error != AX_SUCCESS || observer.is_null() {
+            return Err(TargetError::ObserverUnavailable);
+        }
+        let mut resources = Self {
+            observer,
+            run_loop,
+            source: ptr::null_mut(),
+            source_added: false,
+            registered: Vec::new(),
+        };
+        let refcon = token as *mut c_void;
+        for name in [
+            notification_deactivated(),
+            notification_focused_element(),
+            notification_focused_window(),
+        ] {
+            let error = unsafe {
+                AXObserverAddNotification(
+                    resources.observer,
+                    application,
+                    name.as_concrete_TypeRef(),
+                    refcon,
+                )
+            };
+            if error != AX_SUCCESS {
+                return Err(TargetError::ObserverRegistrationFailed);
+            }
+            resources.registered.push(NotificationRegistration {
+                element: application,
+                name,
+            });
+        }
+        resources.source = unsafe { AXObserverGetRunLoopSource(resources.observer) };
+        if resources.source.is_null() {
+            return Err(TargetError::ObserverRunLoopUnavailable);
+        }
+        unsafe {
+            CFRunLoopAddSource(resources.run_loop, resources.source, kCFRunLoopDefaultMode);
+        }
+        resources.source_added = true;
+        Ok(resources)
+    }
+
+    fn teardown(&mut self) {
+        for registration in self.registered.drain(..) {
+            unsafe {
+                AXObserverRemoveNotification(
+                    self.observer,
+                    registration.element,
+                    registration.name.as_concrete_TypeRef(),
+                );
+            }
+        }
+        if self.source_added {
+            unsafe {
+                CFRunLoopRemoveSource(self.run_loop, self.source, kCFRunLoopDefaultMode);
+            }
+            self.source_added = false;
+        }
+        if !self.observer.is_null() {
+            unsafe {
+                CFRelease(self.observer as CFTypeRef);
+            }
+            self.observer = ptr::null();
+        }
+    }
+}
+
+impl Drop for ObserverResources {
+    fn drop(&mut self) {
+        self.teardown();
+    }
+}
+
+pub struct TargetGuard {
+    application: OwnedCf,
+    field: OwnedCf,
+    app_id: String,
+    pid: Pid,
+    original_text: String,
+    original_location: usize,
+    original_length: usize,
+    token: usize,
+    observer: ObserverResources,
+    // AXUIElement/AXObserver callbacks are main-run-loop confined by contract.
+    _main_thread_only: PhantomData<Rc<()>>,
+}
+
+impl TargetGuard {
+    pub fn capture() -> Result<Self, TargetError> {
+        require_main_thread()?;
+        let token = NEXT_SESSION_TOKEN
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current.checked_add(1)
+            })
+            .map_err(|_| TargetError::SessionTokenExhausted)?;
+        let result = (|| {
+            let target = current_target()?;
+            let (original_text, original_location, original_length) =
+                read_value_and_selection(target.field.as_ptr() as AXUIElementRef)?;
+            let observer = ObserverResources::new(
+                target.application.as_ptr() as AXUIElementRef,
+                target.pid,
+                token,
+            )?;
+            let candidate = Self {
+                application: target.application,
+                field: target.field,
+                app_id: target.app_id,
+                pid: target.pid,
+                original_text,
+                original_location,
+                original_length,
+                token,
+                observer,
+                _main_thread_only: PhantomData,
+            };
+            let snapshot_matches = candidate.snapshot_matches()?;
+            let unchanged = candidate.unchanged()?;
+            if !capture_revalidation_succeeds(snapshot_matches, unchanged) {
+                return Err(TargetError::TargetChanged);
+            }
+            Ok(candidate)
+        })();
+        if result.is_err() {
+            LAST_INVALIDATED_TOKEN.fetch_max(token, Ordering::AcqRel);
+        }
+        result
+    }
+
+    pub fn app_id(&self) -> &str {
+        &self.app_id
+    }
+
+    fn valid_token(&self) -> Result<(), TargetError> {
+        if LAST_INVALIDATED_TOKEN.load(Ordering::Acquire) < self.token {
+            Ok(())
+        } else {
+            Err(TargetError::TargetChanged)
+        }
+    }
+
+    fn matches_current(&self, current: &CurrentTarget) -> bool {
+        let same_native = unsafe {
+            CFEqual(self.application.as_ptr(), current.application.as_ptr()) != 0
+                && CFEqual(self.field.as_ptr(), current.field.as_ptr()) != 0
+        };
+        same_native && self.pid == current.pid && self.app_id == current.app_id
+    }
+
+    pub fn unchanged(&self) -> Result<bool, TargetError> {
+        require_main_thread()?;
+        self.valid_token()?;
+        let current = current_target()?;
+        if self.matches_current(&current) {
+            Ok(true)
+        } else {
+            Err(TargetError::TargetChanged)
+        }
+    }
+
+    pub fn snapshot_matches(&self) -> Result<bool, TargetError> {
+        let observed = self.observed_value_and_selection()?;
+        Ok(observed.0 == self.original_text
+            && observed.1 == self.original_location
+            && observed.2 == self.original_length)
+    }
+
+    pub fn observed_value_and_selection(&self) -> Result<(String, usize, usize), TargetError> {
+        require_main_thread()?;
+        self.valid_token()?;
+        let current = current_target()?;
+        if !self.matches_current(&current) {
+            return Err(TargetError::TargetChanged);
+        }
+        read_value_and_selection(current.field.as_ptr() as AXUIElementRef)
+    }
+}
+
+impl Drop for TargetGuard {
+    fn drop(&mut self) {
+        LAST_INVALIDATED_TOKEN.fetch_max(self.token, Ordering::AcqRel);
+        self.observer.teardown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        capture_revalidation_succeeds, decode_utf16_bounded, main_thread_and_runloop_are_valid,
+        validate_bundle_id, validate_editable_role, validate_selection_range, TargetError,
+    };
+
+    #[test]
+    fn native_calls_require_both_main_run_loop_and_main_thread() {
+        assert!(main_thread_and_runloop_are_valid(true, true));
+        assert!(!main_thread_and_runloop_are_valid(true, false));
+        assert!(!main_thread_and_runloop_are_valid(false, true));
+        assert!(!main_thread_and_runloop_are_valid(false, false));
+    }
+
+    #[test]
+    fn capture_revalidation_requires_stable_identity_and_snapshot() {
+        assert!(capture_revalidation_succeeds(true, true));
+        assert!(!capture_revalidation_succeeds(false, true));
+        assert!(!capture_revalidation_succeeds(true, false));
+        assert!(!capture_revalidation_succeeds(false, false));
+    }
+
+    #[test]
+    fn utf16_decoding_is_strict_and_bounded_in_utf8_bytes() {
+        assert_eq!(
+            decode_utf16_bounded(&[0x0041, 0xD83D, 0xDE00], 5).unwrap(),
+            "A😀"
+        );
+        assert_eq!(
+            decode_utf16_bounded(&[0xD83D], 10),
+            Err(TargetError::InvalidValue)
+        );
+        assert_eq!(
+            decode_utf16_bounded(&[b'a' as u16; 4], 3),
+            Err(TargetError::ValueTooLarge)
+        );
+    }
+
+    #[test]
+    fn selection_uses_utf16_units_and_rejects_surrogate_boundaries() {
+        let value = [0x0041, 0xD83D, 0xDE00, 0x0042];
+        assert_eq!(validate_selection_range(&value, 1, 2), Ok((1, 2)));
+        assert_eq!(
+            validate_selection_range(&value, 2, 1),
+            Err(TargetError::InvalidSelection)
+        );
+        assert_eq!(
+            validate_selection_range(&value, -1, 0),
+            Err(TargetError::InvalidSelection)
+        );
+        assert_eq!(
+            validate_selection_range(&value, isize::MAX, 2),
+            Err(TargetError::InvalidSelection)
+        );
+        assert_eq!(
+            validate_selection_range(&value, 4, 1),
+            Err(TargetError::InvalidSelection)
+        );
+    }
+
+    #[test]
+    fn only_nonsecure_text_roles_are_eligible() {
+        assert!(validate_editable_role("AXTextField", "AXUnknown").is_ok());
+        assert!(validate_editable_role("AXTextArea", "AXUnknown").is_ok());
+        assert_eq!(
+            validate_editable_role("AXTextField", "AXSecureTextField"),
+            Err(TargetError::SecureField)
+        );
+        assert_eq!(
+            validate_editable_role("AXButton", "AXButton"),
+            Err(TargetError::InvalidRole)
+        );
+    }
+
+    #[test]
+    fn bundle_id_is_nonempty_bounded_utf8_without_controls() {
+        assert!(validate_bundle_id("com.example.Editor").is_ok());
+        assert_eq!(
+            validate_bundle_id(""),
+            Err(TargetError::AppIdentityUnavailable)
+        );
+        assert_eq!(
+            validate_bundle_id("com.example\nEditor"),
+            Err(TargetError::AppIdentityUnavailable)
+        );
+        assert_eq!(
+            validate_bundle_id(&"x".repeat(513)),
+            Err(TargetError::AppIdentityUnavailable)
+        );
+    }
+}

--- a/src-tauri/src/presenter/mod.rs
+++ b/src-tauri/src/presenter/mod.rs
@@ -1,0 +1,361 @@
+//! Presenter coordination. All target handles and native actions stay on the
+//! main thread. Inference returns only through a generation-checked callback.
+mod gate;
+#[cfg(any(target_os = "macos", test))]
+mod observation;
+#[cfg(target_os = "macos")]
+mod macos_target;
+#[cfg(target_os = "macos")]
+mod modifiers;
+#[cfg(target_os = "macos")]
+mod utf16;
+
+use std::cell::RefCell;
+#[cfg(target_os = "macos")]
+use std::time::{Duration, Instant};
+use sagascript_cli::presenter::PresenterRequest;
+use sagascript_core::settings::HotkeyMode;
+#[cfg(target_os = "macos")]
+use sagascript_core::settings::PresenterFinishAction;
+use tauri::{Emitter, Manager};
+use crate::{app_controller::{AppState, HotkeyDownResult}, SharedController};
+use gate::{Action, Gate, Phase};
+
+struct Session {
+    generation: u64,
+    gate: Gate,
+    text: Option<String>,
+    #[cfg(target_os = "macos")]
+    target: Option<macos_target::TargetGuard>,
+    #[cfg(target_os = "macos")]
+    expected: Option<(String, usize, usize)>,
+    #[cfg(target_os = "macos")]
+    deadline: Option<Instant>,
+}
+
+thread_local! {
+    static SESSION: RefCell<Option<Session>> = const { RefCell::new(None) };
+}
+
+#[cfg(target_os = "macos")]
+fn action(value: PresenterFinishAction) -> Action {
+    match value {
+        PresenterFinishAction::InsertOnly => Action::InsertOnly,
+        PresenterFinishAction::Return => Action::Return,
+        PresenterFinishAction::CommandReturn => Action::CommandReturn,
+    }
+}
+
+fn status(app: &tauri::AppHandle, phase: Phase) {
+    let value = match phase {
+        Phase::Listening => "listening",
+        Phase::Transcribing => "transcribing",
+        Phase::AwaitingInsertion => "verifying_insertion",
+        Phase::Inserted => "inserted",
+        Phase::Submitting => "submitting",
+        Phase::Sent => "sent",
+        Phase::Cancelled => "cancelled",
+        Phase::Draft => "draft",
+        Phase::Failed => "failed",
+        Phase::NoSpeech => "no_speech",
+        Phase::SubmitUncertain => "submit_uncertain",
+    };
+    let _ = app.emit("presenter-status", value);
+}
+
+/// Entry points are dispatched on the main thread by both hotkey and argv
+/// transports. No target text is accepted from those transports.
+pub fn handle_request(app: &tauri::AppHandle, request: PresenterRequest) {
+    match request {
+        PresenterRequest::Start { profile_id } => start(app, profile_id.as_deref()),
+        PresenterRequest::Finish => finish(app),
+        PresenterRequest::Cancel => cancel(app),
+    }
+}
+
+fn start(app: &tauri::AppHandle, requested_profile: Option<&str>) {
+    let controller: tauri::State<'_, SharedController> = app.state();
+    let settings = {
+        let c = controller.lock().unwrap();
+        if c.state() != AppState::Idle || c.settings().hotkey_mode != HotkeyMode::Presenter {
+            return;
+        }
+        c.settings().clone()
+    };
+    if settings.validate_shortcut_configuration().is_err() {
+        let _ = app.emit(crate::events::event::ERROR, "Presenter shortcut configuration is invalid.");
+        return;
+    }
+    let profiles = settings.resolved_hotkey_profiles();
+    let profile = match requested_profile {
+        Some(id) => profiles.into_iter().find(|p| p.id == id),
+        None => profiles.iter().find(|p| p.id == "default").cloned()
+            .or_else(|| profiles.into_iter().next()),
+    };
+    let Some(profile) = profile else {
+        let _ = app.emit(crate::events::event::ERROR, "Presenter profile was not found.");
+        return;
+    };
+    // Capture before audio-start feedback or any overlay/window operation.
+    #[cfg(target_os = "macos")]
+    let target = match macos_target::TargetGuard::capture() {
+        Ok(target) => Some(target),
+        Err(code) => {
+            tracing::warn!(?code, "Presenter target cannot be verified; keeping a draft only");
+            None
+        }
+    };
+    #[cfg(target_os = "macos")]
+    let selected_action = target.as_ref()
+        .and_then(|t| settings.presenter.app_actions.get(t.app_id()).copied())
+        .map(action).unwrap_or_default();
+    #[cfg(not(target_os = "macos"))]
+    let selected_action = Action::InsertOnly;
+    #[cfg(target_os = "macos")]
+    let target_known = target.is_some();
+    #[cfg(not(target_os = "macos"))]
+    let target_known = false;
+    let mut c = controller.lock().unwrap();
+    if c.settings().hotkey_mode != HotkeyMode::Presenter
+        || c.settings().presenter != settings.presenter
+        || c.settings().resolved_hotkey_profiles() != settings.resolved_hotkey_profiles() {
+        return;
+    }
+    match c.handle_hotkey_down_for_profile(profile.clone()) {
+        Ok(HotkeyDownResult::StartedRecording) => {
+            let generation = c.recording_generation();
+            SESSION.with(|slot| *slot.borrow_mut() = Some(Session {
+                generation, gate: Gate::new(selected_action, target_known), text: None,
+                #[cfg(target_os = "macos")]
+                target,
+                #[cfg(target_os = "macos")]
+                expected: None,
+                #[cfg(target_os = "macos")]
+                deadline: None,
+            }));
+            drop(c);
+            crate::select_profile_menu(app, &profile);
+            let _ = app.emit(crate::events::event::ACTIVE_HOTKEY_PROFILE_CHANGED, profile);
+            let _ = app.emit(crate::events::event::STATE_CHANGED, "recording");
+            status(app, Phase::Listening);
+            crate::update_tray_status(app, "recording");
+            if settings.show_overlay { crate::overlay::show(app); }
+        }
+        Ok(_) => {}
+        Err(error) => { let _ = app.emit(crate::events::event::ERROR, error.to_string()); }
+    }
+}
+
+fn finish(app: &tauri::AppHandle) {
+    let controller: tauri::State<'_, SharedController> = app.state();
+    let c = controller.lock().unwrap();
+    if !c.should_finish_presenter() { return; }
+    let generation = c.recording_generation();
+    let accepted = SESSION.with(|slot| slot.borrow_mut().as_mut()
+        .filter(|s| s.generation == generation).is_some_and(|s| s.gate.finish()));
+    drop(c);
+    if accepted {
+        status(app, Phase::Transcribing);
+        crate::stop_recording_and_transcribe(app, &controller);
+    }
+}
+
+pub fn cancel(app: &tauri::AppHandle) {
+    let controller: tauri::State<'_, SharedController> = app.state();
+    let mut c = controller.lock().unwrap();
+    if !c.is_presenter_session() { return; }
+    let generation = c.recording_generation();
+    let recording = c.state() == AppState::Recording;
+    SESSION.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if let Some(session) = slot.as_mut().filter(|s| s.generation == generation) {
+            session.gate.cancel();
+            if recording { *slot = None; }
+        }
+    });
+    if recording { c.cancel_recording(); }
+    drop(c);
+    status(app, Phase::Cancelled);
+    // During inference remain busy until its worker finishes. A new Start
+    // cannot inherit a queued insertion or receive the old worker's result.
+    if recording { idle_ui(app); }
+}
+
+fn idle_ui(app: &tauri::AppHandle) {
+    crate::overlay::hide(app);
+    crate::update_tray_status(app, "idle");
+    let _ = app.emit(crate::events::event::STATE_CHANGED, "idle");
+}
+
+fn terminal(app: &tauri::AppHandle, session: Session, error: Option<String>) {
+    let controller: tauri::State<'_, SharedController> = app.state();
+    let mut c = controller.lock().unwrap();
+    if c.recording_generation() != session.generation { return; }
+    let phase = session.gate.phase();
+    if phase == Phase::Cancelled {
+        c.complete_cancelled_recording();
+    } else if let Some(error) = error {
+        c.on_transcription_error(&error);
+        let _ = app.emit(crate::events::event::ERROR, error);
+    } else if let Some(text) = &session.text {
+        c.on_transcription_success(text);
+        let _ = app.emit(crate::events::event::TRANSCRIPTION_RESULT, text);
+        crate::update_tray_last_result(app, text);
+    } else {
+        c.on_no_speech_detected();
+    }
+    drop(c);
+    idle_ui(app);
+    status(app, phase);
+    let message = match phase {
+        Phase::Inserted => "Presenter: inserted; not submitted",
+        Phase::Sent => "Presenter: Submit key sent; delivery not confirmed",
+        Phase::Cancelled => "Presenter: cancelled",
+        Phase::Draft => "Presenter: not sent; copy the draft from Dictate",
+        Phase::Failed => "Presenter: failed; check Dictate",
+        Phase::NoSpeech => "Presenter: no speech detected",
+        Phase::SubmitUncertain => "Presenter: may have submitted; check the destination",
+        _ => "Presenter: check Dictate",
+    };
+    if !app.state::<crate::hotkey::HotkeyHealth>().is_failed() {
+        crate::set_status_menu_text(app, message);
+        if let Some(tray) = app.tray_by_id("main") {
+            let _ = tray.set_tooltip(Some(&format!("Sagascript\n{message}")));
+        }
+    }
+    // Do not focus Settings: a native key may have been queued, or the user
+    // may intentionally be editing elsewhere. The draft remains in Dictate.
+}
+
+/// Called on the main thread after the existing transcription pipeline. A
+/// stale generation, cancellation or missing target can never reach paste.
+pub fn complete(app: &tauri::AppHandle, generation: u64, result: Result<String, String>) {
+    let session = SESSION.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.as_ref().is_some_and(|s| s.generation == generation) { slot.take() } else { None }
+    });
+    let Some(mut session) = session else { return; };
+    let error = result.as_ref().err().cloned();
+    session.gate.transcribed(result.is_ok(), result.as_ref().is_ok_and(|s| !s.trim().is_empty()));
+    if session.gate.phase() != Phase::Cancelled {
+        session.text = result.ok().filter(|s| !s.trim().is_empty());
+    }
+    if session.gate.phase() != Phase::AwaitingInsertion {
+        terminal(app, session, error);
+        return;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let controller: tauri::State<'_, SharedController> = app.state();
+        let auto_paste = controller.lock().unwrap().settings().auto_paste;
+        let before = session.target.as_ref().and_then(|t| {
+            if !auto_paste || !modifiers::modifiers_released()
+                || t.snapshot_matches() != Ok(true) { return None; }
+            t.observed_value_and_selection().ok()
+        });
+        let expected = before.and_then(|(original, location, length)| {
+            let payload = crate::paste::service::paste_payload(session.text.as_deref()?);
+            let value = utf16::replace_utf16_range(&original, location, length, &payload)?;
+            Some((value, location.checked_add(payload.encode_utf16().count())?, 0))
+        });
+        if session.gate.may_insert(expected.is_some()) {
+            let pasted = crate::paste::PasteService::new().paste_checked(
+                session.text.as_deref().unwrap_or_default(),
+                || session.target.as_ref().is_some_and(|t| t.snapshot_matches() == Ok(true))
+                    && modifiers::modifiers_released(),
+            );
+            if pasted.is_ok() {
+                session.expected = expected;
+                session.deadline = Some(Instant::now() + Duration::from_secs(2));
+                SESSION.with(|slot| *slot.borrow_mut() = Some(session));
+                status(app, Phase::AwaitingInsertion);
+                schedule_observation(app, generation);
+                return;
+            }
+            session.gate.insertion_timed_out();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    session.gate.target_changed();
+    session.gate.insertion_timed_out();
+    terminal(app, session, None);
+}
+
+#[cfg(target_os = "macos")]
+fn schedule_observation(app: &tauri::AppHandle, generation: u64) {
+    let handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        crate::dispatch_to_main(&handle, move |app| observe(app, generation));
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn observe(app: &tauri::AppHandle, generation: u64) {
+    let session = SESSION.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.as_ref().is_some_and(|s| s.generation == generation) { slot.take() } else { None }
+    });
+    let Some(mut session) = session else { return; };
+    if session.gate.phase() == Phase::Cancelled {
+        terminal(app, session, None);
+        return;
+    }
+    if session.deadline.is_none_or(|deadline| Instant::now() >= deadline) {
+        session.gate.insertion_timed_out();
+        terminal(app, session, None);
+        return;
+    }
+    let observation = session.target.as_ref().and_then(|t| t.observed_value_and_selection().ok());
+    let decision = observation::decide(
+        observation.is_some(), observation == session.expected,
+        session.deadline.is_some_and(|deadline| Instant::now() < deadline),
+        modifiers::modifiers_released(),
+    );
+    if decision == observation::Decision::Draft {
+        session.gate.target_changed();
+        session.gate.insertion_timed_out();
+    } else if decision == observation::Decision::Proven {
+        let target = session.target.as_ref().expect("observation requires target");
+        let controller: tauri::State<'_, SharedController> = app.state();
+        let c = controller.lock().unwrap();
+        let still_allowed = c.settings().hotkey_mode == HotkeyMode::Presenter
+            && c.settings().auto_paste
+            && c.settings().presenter.app_actions.get(target.app_id()).copied().map(action)
+                == Some(session.gate.action());
+        drop(c);
+        let same_target = target.unchanged() == Ok(true)
+            && session.deadline.is_some_and(|deadline| Instant::now() < deadline);
+        if let Some(submit) = session.gate.authorize_submit(true, same_target, still_allowed) {
+            // Guard again inside the native action immediately before the key.
+            let success = submit_return(submit, || target.unchanged() == Ok(true)
+                && target.observed_value_and_selection().ok() == session.expected
+                && session.deadline.is_some_and(|deadline| Instant::now() < deadline));
+            session.gate.submit_completed(success);
+        }
+    } else if decision == observation::Decision::Wait {
+        SESSION.with(|slot| *slot.borrow_mut() = Some(session));
+        schedule_observation(app, generation);
+        return;
+    } else {
+        session.gate.insertion_timed_out();
+    }
+    terminal(app, session, None);
+}
+
+#[cfg(target_os = "macos")]
+fn submit_return(action: Action, verify: impl FnOnce() -> bool) -> bool {
+    use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+    if !matches!(action, Action::Return | Action::CommandReturn)
+        || !crate::platform::macos::is_accessibility_trusted() { return false; }
+    let Ok(mut enigo) = Enigo::new(&Settings::default()) else { return false; };
+    if !verify() || !modifiers::modifiers_released() { return false; }
+    if action == Action::Return { return enigo.key(Key::Return, Direction::Click).is_ok(); }
+    if enigo.key(Key::Meta, Direction::Press).is_err() {
+        let _ = enigo.key(Key::Meta, Direction::Release);
+        return false;
+    }
+    let clicked = enigo.key(Key::Return, Direction::Click).is_ok();
+    let released = enigo.key(Key::Meta, Direction::Release).is_ok();
+    clicked && released
+}

--- a/src-tauri/src/presenter/mod.rs
+++ b/src-tauri/src/presenter/mod.rs
@@ -18,7 +18,7 @@ use sagascript_core::settings::HotkeyMode;
 #[cfg(target_os = "macos")]
 use sagascript_core::settings::PresenterFinishAction;
 use tauri::{Emitter, Manager};
-use crate::{app_controller::{AppState, HotkeyDownResult}, SharedController};
+use crate::{app_controller::AppState, SharedController};
 use gate::{Action, Gate, Phase};
 
 struct Session {
@@ -121,8 +121,8 @@ fn start(app: &tauri::AppHandle, requested_profile: Option<&str>) {
         || c.settings().resolved_hotkey_profiles() != settings.resolved_hotkey_profiles() {
         return;
     }
-    match c.handle_hotkey_down_for_profile(profile.clone()) {
-        Ok(HotkeyDownResult::StartedRecording) => {
+    match c.start_presenter_recording_for_profile(profile.clone()) {
+        Ok(true) => {
             let generation = c.recording_generation();
             SESSION.with(|slot| *slot.borrow_mut() = Some(Session {
                 generation, gate: Gate::new(selected_action, target_known), text: None,
@@ -246,37 +246,61 @@ pub fn complete(app: &tauri::AppHandle, generation: u64, result: Result<String, 
     }
     #[cfg(target_os = "macos")]
     {
-        let controller: tauri::State<'_, SharedController> = app.state();
-        let auto_paste = controller.lock().unwrap().settings().auto_paste;
-        let before = session.target.as_ref().and_then(|t| {
-            if !auto_paste || !modifiers::modifiers_released()
-                || t.snapshot_matches() != Ok(true) { return None; }
-            t.observed_value_and_selection().ok()
-        });
-        let expected = before.and_then(|(original, location, length)| {
+        // A quick transcript may finish before the user releases Finish's
+        // modifiers. Wait without blocking the main thread, within the same
+        // deadline used for insertion proof. Never release the user's keys.
+        session.deadline = Some(Instant::now() + Duration::from_secs(2));
+        attempt_insertion(app, session);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        session.gate.target_changed();
+        session.gate.insertion_timed_out();
+        terminal(app, session, None);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn attempt_insertion(app: &tauri::AppHandle, mut session: Session) {
+    let generation = session.generation;
+    let controller: tauri::State<'_, SharedController> = app.state();
+    let auto_paste = controller.lock().unwrap().settings().auto_paste;
+    let before = session.target.as_ref().and_then(|target| {
+        if !auto_paste || target.snapshot_matches() != Ok(true) { return None; }
+        target.observed_value_and_selection().ok()
+    });
+    let decision = observation::decide(
+        before.is_some(), true,
+        session.deadline.is_some_and(|deadline| Instant::now() < deadline),
+        modifiers::modifiers_released(),
+    );
+    if decision == observation::Decision::Wait {
+        SESSION.with(|slot| *slot.borrow_mut() = Some(session));
+        status(app, Phase::AwaitingInsertion);
+        schedule_observation(app, generation);
+        return;
+    }
+    let expected = before.filter(|_| decision == observation::Decision::Proven)
+        .and_then(|(original, location, length)| {
             let payload = crate::paste::service::paste_payload(session.text.as_deref()?);
             let value = utf16::replace_utf16_range(&original, location, length, &payload)?;
             Some((value, location.checked_add(payload.encode_utf16().count())?, 0))
         });
-        if session.gate.may_insert(expected.is_some()) {
-            let pasted = crate::paste::PasteService::new().paste_checked(
-                session.text.as_deref().unwrap_or_default(),
-                || session.target.as_ref().is_some_and(|t| t.snapshot_matches() == Ok(true))
-                    && modifiers::modifiers_released(),
-            );
-            if pasted.is_ok() {
-                session.expected = expected;
-                session.deadline = Some(Instant::now() + Duration::from_secs(2));
-                SESSION.with(|slot| *slot.borrow_mut() = Some(session));
-                status(app, Phase::AwaitingInsertion);
-                schedule_observation(app, generation);
-                return;
-            }
-            session.gate.insertion_timed_out();
+    if session.gate.may_insert(expected.is_some()) {
+        let pasted = crate::paste::PasteService::new().paste_checked(
+            session.text.as_deref().unwrap_or_default(),
+            || session.target.as_ref().is_some_and(|t| t.snapshot_matches() == Ok(true))
+                && modifiers::modifiers_released()
+                && session.deadline.is_some_and(|deadline| Instant::now() < deadline),
+        );
+        if pasted.is_ok() {
+            session.expected = expected;
+            SESSION.with(|slot| *slot.borrow_mut() = Some(session));
+            status(app, Phase::AwaitingInsertion);
+            schedule_observation(app, generation);
+            return;
         }
     }
-    #[cfg(not(target_os = "macos"))]
-    session.gate.target_changed();
     session.gate.insertion_timed_out();
     terminal(app, session, None);
 }
@@ -304,6 +328,10 @@ fn observe(app: &tauri::AppHandle, generation: u64) {
     if session.deadline.is_none_or(|deadline| Instant::now() >= deadline) {
         session.gate.insertion_timed_out();
         terminal(app, session, None);
+        return;
+    }
+    if session.expected.is_none() {
+        attempt_insertion(app, session);
         return;
     }
     let observation = session.target.as_ref().and_then(|t| t.observed_value_and_selection().ok());

--- a/src-tauri/src/presenter/modifiers.rs
+++ b/src-tauri/src/presenter/modifiers.rs
@@ -1,0 +1,51 @@
+const SHIFT_FLAG: u64 = 0x0002_0000;
+const CONTROL_FLAG: u64 = 0x0004_0000;
+const ALTERNATE_FLAG: u64 = 0x0008_0000;
+const COMMAND_FLAG: u64 = 0x0010_0000;
+const FN_FLAG: u64 = 0x0080_0000;
+const BLOCKING_MODIFIERS: u64 = SHIFT_FLAG | CONTROL_FLAG | ALTERNATE_FLAG | COMMAND_FLAG | FN_FLAG;
+
+fn modifiers_released_from_flags(flags: u64) -> bool {
+    flags & BLOCKING_MODIFIERS == 0
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreGraphics", kind = "framework")]
+#[allow(dead_code)]
+extern "C" {
+    fn CGEventSourceFlagsState(state_id: i32) -> u64;
+}
+
+/// Read the combined-session modifier state without synthesizing or mutating
+/// any event. Caps Lock is intentionally not part of the blocking mask.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub(crate) fn modifiers_released() -> bool {
+    const COMBINED_SESSION_STATE: i32 = 0;
+    let flags = unsafe { CGEventSourceFlagsState(COMBINED_SESSION_STATE) };
+    modifiers_released_from_flags(flags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::modifiers_released_from_flags;
+
+    #[test]
+    fn modifier_flags_block_readiness() {
+        for flags in [
+            0x0002_0000, // Shift
+            0x0004_0000, // Control
+            0x0008_0000, // Alternate
+            0x0010_0000, // Command
+            0x0080_0000, // Fn
+        ] {
+            assert!(!modifiers_released_from_flags(flags));
+        }
+    }
+
+    #[test]
+    fn caps_lock_is_not_a_blocking_modifier() {
+        assert!(modifiers_released_from_flags(0x0001_0000));
+        assert!(modifiers_released_from_flags(0));
+    }
+}

--- a/src-tauri/src/presenter/observation.rs
+++ b/src-tauri/src/presenter/observation.rs
@@ -62,4 +62,13 @@ mod tests {
     fn held_modifiers_keep_a_valid_observation_waiting() {
         assert_eq!(decide(true, true, true, false), Decision::Wait);
     }
+
+    #[test]
+    fn proof_progression_waits_for_release_and_rejects_late_or_changed_targets() {
+        assert_eq!(decide(true, false, true, false), Decision::Wait);
+        assert_eq!(decide(true, true, true, false), Decision::Wait);
+        assert_eq!(decide(true, true, true, true), Decision::Proven);
+        assert_eq!(decide(true, true, false, true), Decision::Draft);
+        assert_eq!(decide(false, true, true, true), Decision::Draft);
+    }
 }

--- a/src-tauri/src/presenter/observation.rs
+++ b/src-tauri/src/presenter/observation.rs
@@ -1,0 +1,65 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Decision {
+    Wait,
+    Proven,
+    Draft,
+}
+
+pub(crate) fn decide(
+    target_matches: bool,
+    observed_matches: bool,
+    before_deadline: bool,
+    modifiers_released: bool,
+) -> Decision {
+    if !target_matches || !before_deadline {
+        Decision::Draft
+    } else if observed_matches && modifiers_released {
+        Decision::Proven
+    } else {
+        Decision::Wait
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decide, Decision};
+
+    #[test]
+    fn decision_truth_table_covers_all_inputs() {
+        for target_matches in [false, true] {
+            for observed_matches in [false, true] {
+                for before_deadline in [false, true] {
+                    for modifiers_released in [false, true] {
+                        let expected = if !target_matches || !before_deadline {
+                            Decision::Draft
+                        } else if observed_matches && modifiers_released {
+                            Decision::Proven
+                        } else {
+                            Decision::Wait
+                        };
+                        assert_eq!(
+                            decide(
+                                target_matches,
+                                observed_matches,
+                                before_deadline,
+                                modifiers_released,
+                            ),
+                            expected,
+                            "target={target_matches} observed={observed_matches} before_deadline={before_deadline} modifiers_released={modifiers_released}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn late_observation_cannot_prove_target_that_left_and_returned() {
+        assert_eq!(decide(false, true, false, false), Decision::Draft);
+    }
+
+    #[test]
+    fn held_modifiers_keep_a_valid_observation_waiting() {
+        assert_eq!(decide(true, true, true, false), Decision::Wait);
+    }
+}

--- a/src-tauri/src/presenter/utf16.rs
+++ b/src-tauri/src/presenter/utf16.rs
@@ -1,0 +1,110 @@
+const MAX_TEXT_BYTES: usize = 32_768;
+
+fn utf16_boundary(text: &str, unit: usize) -> Option<usize> {
+    let mut units = 0usize;
+    for (byte, character) in text.char_indices() {
+        if unit == units {
+            return Some(byte);
+        }
+        let next = units.checked_add(character.len_utf16())?;
+        if unit < next {
+            return None;
+        }
+        units = next;
+    }
+    (unit == units).then_some(text.len())
+}
+
+pub fn replace_utf16_range(
+    original: &str,
+    location: usize,
+    length: usize,
+    inserted: &str,
+) -> Option<String> {
+    if original.len() > MAX_TEXT_BYTES || inserted.len() > MAX_TEXT_BYTES {
+        return None;
+    }
+    let end = location.checked_add(length)?;
+    let start_byte = utf16_boundary(original, location)?;
+    let end_byte = utf16_boundary(original, end)?;
+    let result_bytes = original[..start_byte]
+        .len()
+        .checked_add(inserted.len())?
+        .checked_add(original[end_byte..].len())?;
+    if result_bytes > MAX_TEXT_BYTES {
+        return None;
+    }
+
+    let mut result = String::with_capacity(result_bytes);
+    result.push_str(&original[..start_byte]);
+    result.push_str(inserted);
+    result.push_str(&original[end_byte..]);
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::replace_utf16_range;
+
+    #[test]
+    fn ascii_insert_replace_and_end() {
+        assert_eq!(replace_utf16_range("abc", 1, 0, "X"), Some("aXbc".into()));
+        assert_eq!(replace_utf16_range("abc", 1, 1, "X"), Some("aXc".into()));
+        assert_eq!(replace_utf16_range("abc", 3, 0, "!"), Some("abc!".into()));
+    }
+
+    #[test]
+    fn swedish_text_uses_utf16_units() {
+        assert_eq!(
+            replace_utf16_range("Tack så mycket", 5, 2, "gärna"),
+            Some("Tack gärna mycket".into())
+        );
+    }
+
+    #[test]
+    fn emoji_accepts_codepoint_boundaries_and_rejects_surrogates() {
+        assert_eq!(replace_utf16_range("a😀b", 1, 2, "X"), Some("aXb".into()));
+        assert_eq!(replace_utf16_range("a😀b", 3, 1, "!"), Some("a😀!".into()));
+        assert_eq!(replace_utf16_range("a😀b", 2, 0, "X"), None);
+        assert_eq!(replace_utf16_range("a😀b", 2, 1, "X"), None);
+    }
+
+    #[test]
+    fn combining_marks_are_not_normalized() {
+        assert_eq!(
+            replace_utf16_range("e\u{301}x", 1, 1, ""),
+            Some("ex".into())
+        );
+        assert_eq!(
+            replace_utf16_range("e\u{301}x", 0, 1, "é"),
+            Some("é\u{301}x".into())
+        );
+    }
+
+    #[test]
+    fn overflow_and_out_of_range_are_rejected() {
+        assert_eq!(replace_utf16_range("abc", usize::MAX, 1, ""), None);
+        assert_eq!(replace_utf16_range("abc", usize::MAX, 0, ""), None);
+        assert_eq!(replace_utf16_range("abc", 4, 0, ""), None);
+        assert_eq!(replace_utf16_range("abc", 2, 2, ""), None);
+    }
+
+    #[test]
+    fn byte_caps_are_exact_and_excess_is_rejected() {
+        let exact = "a".repeat(32_768);
+        assert_eq!(
+            replace_utf16_range(&exact, 32_768, 0, ""),
+            Some(exact.clone())
+        );
+        assert_eq!(replace_utf16_range(&exact, 32_768, 0, "x"), None);
+        let inserted = "b".repeat(32_768);
+        assert_eq!(replace_utf16_range("", 0, 0, &inserted), Some(inserted));
+        assert_eq!(replace_utf16_range("", 0, 0, &"c".repeat(32_769)), None);
+        assert_eq!(replace_utf16_range(&"d".repeat(32_769), 0, 0, ""), None);
+        assert_eq!(
+            replace_utf16_range(&"😀".repeat(8_192), 0, 0, ""),
+            Some("😀".repeat(8_192))
+        );
+        assert_eq!(replace_utf16_range(&"😀".repeat(8_192), 0, 0, "x"), None);
+    }
+}

--- a/src/lib/PresenterSettings.svelte
+++ b/src/lib/PresenterSettings.svelte
@@ -1,0 +1,535 @@
+<script lang="ts">
+  import type { PresenterConfig, PresenterFinishAction } from "./api";
+  import { canUseBareHotkey, supportedBareFunctionKeyRange, tauriKeyName } from "./hotkey.js";
+
+  type PresenterSettingsProps = {
+    config: PresenterConfig;
+    profileShortcuts: string[];
+    platform: string;
+    onSave: (config: PresenterConfig) => Promise<string | null>;
+  };
+
+  let {
+    config,
+    profileShortcuts,
+    platform,
+    onSave,
+  }: PresenterSettingsProps = $props();
+
+  let draft: PresenterConfig = $state({
+    finish_shortcut: "",
+    cancel_shortcut: null,
+    app_actions: {},
+  });
+  let newAppId = $state("");
+  let localError = $state("");
+  let saveError = $state("");
+  let saving = $state(false);
+  let recordingField = $state<"finish" | "cancel" | null>(null);
+  let initialized = false;
+  let lastConfigJson = "";
+
+  const actionLabels: Record<PresenterFinishAction, string> = {
+    insert_only: "Insert only",
+    return: "Insert, then Return",
+    command_return: "Insert, then Command+Return",
+  };
+
+  const supportsAutoSubmit = () => platform === "macos";
+
+  function cloneConfig(source: PresenterConfig): PresenterConfig {
+    return {
+      finish_shortcut: source.finish_shortcut,
+      cancel_shortcut: source.cancel_shortcut,
+      app_actions: { ...source.app_actions },
+    };
+  }
+
+  // A failed backend save can cause the parent to refresh Settings. Keep the
+  // unsaved draft when the refreshed config has the same serialized value.
+  $effect(() => {
+    const incoming = JSON.stringify(config);
+    const current = JSON.stringify(draft);
+    if (!initialized || (incoming !== lastConfigJson && incoming !== current)) {
+      draft = cloneConfig(config);
+      localError = "";
+      saveError = "";
+    }
+    lastConfigJson = incoming;
+    initialized = true;
+  });
+
+  function modifierCanonical(modifier: string): string {
+    switch (modifier.toLowerCase()) {
+      case "control":
+      case "ctrl":
+        return "control";
+      case "alt":
+      case "option":
+        return "alt";
+      case "super":
+      case "command":
+      case "cmd":
+        return "super";
+      case "commandorcontrol":
+      case "commandorctrl":
+      case "cmdorctrl":
+      case "cmdorcontrol":
+        return platform === "macos" ? "super" : "control";
+      case "shift":
+        return "shift";
+      default:
+        return modifier.toLowerCase();
+    }
+  }
+
+  function canonicalShortcut(shortcut: string): string {
+    const tokens = shortcut.split("+").map((token) => token.trim()).filter(Boolean);
+    if (tokens.length === 0) return "";
+    const key = tokens[tokens.length - 1].toLowerCase();
+    const normalizedKey = key.length === 1 && /^[a-z]$/.test(key) ? `key${key}` : key;
+    return [
+      ...new Set(tokens.slice(0, -1).map(modifierCanonical)),
+    ].sort().concat(normalizedKey).join("+");
+  }
+
+  function updateDraft(changes: Partial<PresenterConfig>): void {
+    draft = { ...draft, ...changes };
+    localError = "";
+    saveError = "";
+  }
+
+  function modifierNames(): { ctrl: string; alt: string; meta: string } {
+    return platform === "macos"
+      ? { ctrl: "Control", alt: "Option", meta: "Cmd" }
+      : { ctrl: "Ctrl", alt: "Alt", meta: "Win" };
+  }
+
+  function formatShortcutDisplay(shortcut: string | null): string {
+    if (!shortcut) return "Disabled — click to set";
+    const names = modifierNames();
+    return shortcut
+      .replace(/Control/g, names.ctrl)
+      .replace(/Alt/g, names.alt)
+      .replace(/Super/g, names.meta)
+      .split("+")
+      .join(" + ");
+  }
+
+  function beginShortcutCapture(field: "finish" | "cancel"): void {
+    recordingField = field;
+    localError = "";
+    saveError = "";
+  }
+
+  function onShortcutKeydown(event: KeyboardEvent, field: "finish" | "cancel"): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.key === "Escape") {
+      recordingField = null;
+      return;
+    }
+    if (["Control", "Shift", "Alt", "Meta"].includes(event.key)) return;
+    const keyName = tauriKeyName(event.key);
+    if (!keyName) {
+      localError = `"${event.key}" is not a supported key.`;
+      return;
+    }
+    const hasModifier = event.ctrlKey || event.altKey || event.metaKey || event.shiftKey;
+    if (!hasModifier && !canUseBareHotkey(keyName, platform)) {
+      const range = supportedBareFunctionKeyRange(platform);
+      localError = `Shortcut must include a modifier.${range ? ` ${range} may be used alone.` : ""}`;
+      return;
+    }
+    const parts: string[] = [];
+    if (event.ctrlKey) parts.push("Control");
+    if (event.altKey) parts.push("Alt");
+    if (event.metaKey) parts.push("Super");
+    if (event.shiftKey) parts.push("Shift");
+    parts.push(keyName);
+    updateDraft(field === "finish"
+      ? { finish_shortcut: parts.join("+") }
+      : { cancel_shortcut: parts.join("+") });
+    recordingField = null;
+  }
+
+  function updateAppAction(appId: string, action: PresenterFinishAction): void {
+    draft = {
+      ...draft,
+      app_actions: { ...draft.app_actions, [appId]: action },
+    };
+    localError = "";
+    saveError = "";
+  }
+
+  function removeAppAction(appId: string): void {
+    const appActions = { ...draft.app_actions };
+    delete appActions[appId];
+    draft = { ...draft, app_actions: appActions };
+    localError = "";
+    saveError = "";
+  }
+
+  function validateDraft(): string | null {
+    if (!draft.finish_shortcut.trim()) return "Finish shortcut is required.";
+    const profileKeys = new Set(profileShortcuts.map(canonicalShortcut));
+    const finishKey = canonicalShortcut(draft.finish_shortcut);
+    if (profileKeys.has(finishKey)) {
+      return "Finish shortcut conflicts with a presenter start shortcut.";
+    }
+    if (draft.cancel_shortcut) {
+      const cancelKey = canonicalShortcut(draft.cancel_shortcut);
+      if (cancelKey === finishKey) return "Finish and cancel shortcuts must differ.";
+      if (profileKeys.has(cancelKey)) {
+        return "Cancel shortcut conflicts with a presenter start shortcut.";
+      }
+    }
+    const appIds = Object.keys(draft.app_actions);
+    if (appIds.length > 32) return "Presenter supports at most 32 app actions.";
+    for (const appId of appIds) {
+      if (!appId || new TextEncoder().encode(appId).length > 512 || [...appId].some((char) => /\p{Cc}/u.test(char))) {
+        return "App identifiers must be non-empty, at most 512 bytes, and contain no control characters.";
+      }
+      if (!supportsAutoSubmit() && draft.app_actions[appId] !== "insert_only") {
+        return "Automatic Return actions are currently supported only on macOS.";
+      }
+    }
+    return null;
+  }
+
+  async function save(): Promise<void> {
+    localError = validateDraft() ?? "";
+    if (localError) return;
+    saving = true;
+    saveError = "";
+    try {
+      saveError = (await onSave(cloneConfig(draft))) ?? "";
+    } catch (error: any) {
+      saveError = typeof error === "string" ? error : error?.message || "Failed to save presenter settings.";
+    } finally {
+      saving = false;
+    }
+  }
+
+  function addAppAction(): void {
+    const appId = newAppId.trim();
+    if (!appId) {
+      localError = "Enter a stable application identifier first.";
+      return;
+    }
+    if (Object.hasOwn(draft.app_actions, appId)) {
+      localError = "That application identifier is already configured.";
+      return;
+    }
+    draft = { ...draft, app_actions: { ...draft.app_actions, [appId]: "insert_only" } };
+    newAppId = "";
+    localError = "";
+    saveError = "";
+  }
+</script>
+
+<section class="presenter-settings" aria-labelledby="presenter-settings-title">
+  <div class="presenter-heading">
+    <div>
+      <h3 id="presenter-settings-title">Presenter mode</h3>
+      <p class="presenter-description">
+        Profile shortcuts start dictation; Finish ends it. These controls configure behavior only.
+        Application identifiers are stable IDs you enter yourself — Sagascript does not detect titles,
+        sites, or the foreground app here.
+      </p>
+    </div>
+    <span class="presenter-platform">{platform === "macos" ? "macOS support" : "Manual copy on this platform"}</span>
+  </div>
+
+  <div class="presenter-fields">
+    <label for="presenter-finish">Finish shortcut</label>
+    {#if recordingField === "finish"}
+      <button
+        id="presenter-finish"
+        class="presenter-hotkey-recorder recording"
+        onkeydown={(event) => onShortcutKeydown(event, "finish")}
+        onblur={() => { recordingField = null; }}
+      >Press shortcut…</button>
+    {:else}
+      <button
+        id="presenter-finish"
+        class="presenter-hotkey-recorder"
+        onclick={() => beginShortcutCapture("finish")}
+      >{formatShortcutDisplay(draft.finish_shortcut)}</button>
+    {/if}
+    <span id="presenter-finish-help" class="presenter-hint">Global shortcut used to finish the current presenter dictation.</span>
+
+    <label for="presenter-cancel">Cancel shortcut <span class="optional">(optional)</span></label>
+    {#if recordingField === "cancel"}
+      <button
+        id="presenter-cancel"
+        class="presenter-hotkey-recorder recording"
+        onkeydown={(event) => onShortcutKeydown(event, "cancel")}
+        onblur={() => { recordingField = null; }}
+      >Press shortcut…</button>
+    {:else}
+      <button
+        id="presenter-cancel"
+        class="presenter-hotkey-recorder"
+        onclick={() => beginShortcutCapture("cancel")}
+      >{formatShortcutDisplay(draft.cancel_shortcut)}</button>
+    {/if}
+    {#if draft.cancel_shortcut}
+      <button type="button" class="link-btn secondary presenter-disable-cancel" onclick={() => updateDraft({ cancel_shortcut: null })}>Disable</button>
+    {/if}
+    <span id="presenter-cancel-help" class="presenter-hint">Leave empty to disable cancel.</span>
+  </div>
+
+  <div class="presenter-actions">
+    <div class="presenter-actions-heading">
+      <div>
+        <strong>Application actions</strong>
+        <div class="presenter-hint">Default: Insert only. Automatic Return actions require the supported macOS path; each action requires Accessibility permission and a verifiable focused text field.</div>
+      </div>
+      <span class="presenter-count">{Object.keys(draft.app_actions).length}/32</span>
+    </div>
+    {#each Object.entries(draft.app_actions) as [appId, action] (appId)}
+      <div class="presenter-action-row">
+        <code title={appId}>{appId}</code>
+        <select
+          aria-label={`Action for ${appId}`}
+          value={action}
+          onchange={(event) => updateAppAction(appId, (event.target as HTMLSelectElement).value as PresenterFinishAction)}
+        >
+          <option value="insert_only">{actionLabels.insert_only}</option>
+          <option value="return" disabled={!supportsAutoSubmit()}>{actionLabels.return}</option>
+          <option value="command_return" disabled={!supportsAutoSubmit()}>{actionLabels.command_return}</option>
+        </select>
+        <button type="button" class="presenter-remove" onclick={() => removeAppAction(appId)}>Remove</button>
+      </div>
+    {/each}
+    <div class="presenter-add-row">
+      <input
+        type="text"
+        aria-label="New application identifier"
+        placeholder="com.example.editor"
+        value={newAppId}
+        oninput={(event) => { newAppId = (event.target as HTMLInputElement).value; }}
+        onkeydown={(event) => { if (event.key === "Enter") addAppAction(); }}
+      />
+      <button type="button" class="link-btn secondary" onclick={addAppAction}>Add app</button>
+    </div>
+  </div>
+
+  {#if platform !== "macos"}
+    <div class="presenter-hint presenter-platform-warning">
+      Automatic Return and Command+Return actions are disabled here; recognized text remains a draft for manual copying.
+    </div>
+  {/if}
+  {#if localError}
+    <div class="presenter-error" role="alert">{localError}</div>
+  {/if}
+  {#if saveError}
+    <div class="presenter-error" role="alert">{saveError}</div>
+  {/if}
+  <button type="button" class="presenter-save" onclick={save} disabled={saving}>
+    {saving ? "Saving…" : "Save presenter settings"}
+  </button>
+</section>
+
+<style>
+  .presenter-settings {
+    margin: 18px 0;
+    padding: 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+  }
+
+  .presenter-heading,
+  .presenter-actions-heading,
+  .presenter-action-row,
+  .presenter-add-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .presenter-heading,
+  .presenter-actions-heading {
+    justify-content: space-between;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .presenter-description {
+    max-width: 620px;
+    margin: 4px 0 0;
+    color: var(--text-secondary, #888);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .presenter-platform,
+  .presenter-count,
+  .optional {
+    color: var(--text-muted);
+    font-size: 10px;
+  }
+
+  .presenter-platform {
+    min-width: max-content;
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  .presenter-fields {
+    display: grid;
+    grid-template-columns: minmax(130px, 0.35fr) minmax(180px, 1fr);
+    align-items: center;
+    gap: 6px 10px;
+    margin-top: 14px;
+  }
+
+  .presenter-fields label {
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .presenter-hotkey-recorder,
+  .presenter-add-row input,
+  .presenter-action-row select {
+    min-width: 0;
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  .presenter-fields .presenter-hint {
+    grid-column: 2;
+  }
+
+  .presenter-hotkey-recorder {
+    padding: 7px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg);
+    color: var(--accent);
+    cursor: pointer;
+    font-family: monospace;
+    text-align: left;
+  }
+
+  .presenter-hotkey-recorder.recording {
+    border-color: var(--accent);
+    color: var(--text-muted);
+  }
+
+  .presenter-disable-cancel {
+    grid-column: 2;
+    justify-self: end;
+  }
+
+  .presenter-actions {
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+
+  .presenter-actions-heading {
+    align-items: flex-start;
+  }
+
+  .presenter-action-row {
+    margin-top: 8px;
+  }
+
+  .presenter-action-row code {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .presenter-action-row select {
+    flex: 0 1 230px;
+  }
+
+  .presenter-remove {
+    border: none;
+    background: none;
+    color: var(--danger);
+    cursor: pointer;
+    font-size: 11px;
+  }
+
+  .presenter-add-row {
+    margin-top: 10px;
+  }
+
+  .presenter-add-row input {
+    flex: 1;
+  }
+
+  .presenter-add-row .link-btn {
+    flex: 0 0 auto;
+  }
+
+  .presenter-hint {
+    color: var(--text-secondary, #888);
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .presenter-platform-warning,
+  .presenter-error {
+    margin-top: 10px;
+  }
+
+  .presenter-error {
+    color: var(--danger);
+    font-size: 11px;
+  }
+
+  .presenter-save {
+    margin-top: 14px;
+    padding: 7px 12px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius);
+    background: var(--accent);
+    color: var(--bg);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .presenter-save:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+
+  @media (max-width: 520px) {
+    .presenter-action-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+    }
+
+    .presenter-action-row code {
+      grid-column: 1 / -1;
+      width: 100%;
+      overflow-wrap: anywhere;
+      white-space: normal;
+    }
+
+    .presenter-action-row select {
+      grid-column: 1;
+      width: 100%;
+      flex: none;
+    }
+
+    .presenter-action-row .presenter-remove {
+      grid-column: 2;
+      grid-row: 2;
+    }
+  }
+</style>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -6,6 +6,7 @@
     getLastTranscription,
     setLanguage,
     setHotkeyMode,
+    setPresenterConfig,
     setHotkeyProfiles,
     setAutoPaste,
     setInitialPrompt,
@@ -35,7 +36,9 @@
     type WhisperModel,
     type HotkeyStatus,
     type HotkeyProfile,
+    type PresenterConfig,
   } from "./api";
+  import PresenterSettings from "./PresenterSettings.svelte";
   import { listen } from "@tauri-apps/api/event";
   import { open } from "@tauri-apps/plugin-dialog";
   import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -102,6 +105,39 @@
   let testResult: string = $state("");
   let testError: string = $state("");
 
+  type PresenterStatus =
+    | "listening"
+    | "transcribing"
+    | "verifying_insertion"
+    | "inserted"
+    | "submitting"
+    | "sent"
+    | "cancelled"
+    | "draft"
+    | "failed"
+    | "no_speech"
+    | "submit_uncertain";
+
+  const presenterStatusLabels: Record<PresenterStatus, string> = {
+    listening: "Presenter listening",
+    transcribing: "Presenter transcribing",
+    verifying_insertion: "Verifying insertion…",
+    inserted: "Recognized text inserted",
+    submitting: "Sending submit key…",
+    sent: "Submit key sent; delivery not confirmed",
+    cancelled: "Presenter cancelled",
+    draft: "Not sent — copy recognized text from Dictate",
+    failed: "Presenter failed",
+    no_speech: "No speech detected",
+    submit_uncertain: "Submit may have been sent — check destination before retrying",
+  };
+
+  let presenterStatus: PresenterStatus | null = $state(null);
+
+  function isPresenterStatus(value: string): value is PresenterStatus {
+    return Object.prototype.hasOwnProperty.call(presenterStatusLabels, value);
+  }
+
   onMount(() => {
     let disposed = false;
     let revision = 0;
@@ -123,9 +159,14 @@
         testError = "";
       }
     }).then(remember);
+    const presenterStatusListener = listen("presenter-status", (event) => {
+      if (typeof event.payload !== "string" || !isPresenterStatus(event.payload)) return;
+      presenterStatus = event.payload;
+      activeTab = "dictate";
+    }).then(remember);
     // A failed background dictation may create this window after its event.
     // Recover the persisted-in-memory result without racing newer events.
-    Promise.all([errorListener, resultListener, stateListener]).then(async () => {
+    Promise.all([errorListener, resultListener, stateListener, presenterStatusListener]).then(async () => {
       const initialRevision = revision;
       const [error, text] = await Promise.all([getLastError(), getLastTranscription()]);
       if (!disposed && revision === initialRevision) {
@@ -447,6 +488,11 @@
   async function onHotkeyModeChange(e: Event) {
     const value = (e.target as HTMLSelectElement).value as HotkeyMode;
     await applySetting(() => setHotkeyMode(value));
+  }
+
+  async function onPresenterSave(config: PresenterConfig): Promise<string | null> {
+    const ok = await applySetting(() => setPresenterConfig(config));
+    return ok ? null : settingsError || "Failed to save presenter settings.";
   }
 
   async function onAutoPasteToggle() {
@@ -988,7 +1034,7 @@
       {#if activeTab === "dictate"}
         <div class="field profile-field">
           <div class="profile-heading">
-            <span class="field-label">Dictation shortcuts</span>
+            <span class="field-label">{settings.hotkey_mode === "presenter" ? "Presenter start shortcuts" : "Dictation shortcuts"}</span>
             <button class="link-btn" onclick={addProfile}>+ Add language</button>
           </div>
           {#each settings.hotkey_profiles as profile (profile.id)}
@@ -1072,8 +1118,18 @@
           <select id="hotkey-mode" value={settings.hotkey_mode} onchange={onHotkeyModeChange}>
             <option value="push">Push-to-talk</option>
             <option value="toggle">Toggle</option>
+            <option value="presenter">Presenter</option>
           </select>
         </div>
+
+        {#if settings.hotkey_mode === "presenter"}
+          <PresenterSettings
+            config={settings.presenter}
+            profileShortcuts={settings.hotkey_profiles.map((profile) => profile.shortcut)}
+            {platform}
+            onSave={onPresenterSave}
+          />
+        {/if}
 
         <div class="field-row">
           <span class="field-label">Auto-paste transcription</span>
@@ -1117,6 +1173,11 @@
           </button>
           {#if testError}
             <div class="transcribe-error">{testError}</div>
+          {/if}
+          {#if presenterStatus}
+            <div class="presenter-status" role="status" aria-live="polite">
+              {presenterStatusLabels[presenterStatus]}
+            </div>
           {/if}
           <textarea
             class="test-result"
@@ -2051,6 +2112,13 @@
   .test-record-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+
+  .presenter-status {
+    margin-top: 8px;
+    color: var(--text-muted);
+    font-size: 12px;
+    line-height: 1.4;
   }
 
   .recording-dot {

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -162,7 +162,6 @@
     const presenterStatusListener = listen("presenter-status", (event) => {
       if (typeof event.payload !== "string" || !isPresenterStatus(event.payload)) return;
       presenterStatus = event.payload;
-      activeTab = "dictate";
     }).then(remember);
     // A failed background dictation may create this window after its event.
     // Recover the persisted-in-memory result without racing newer events.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export type Language = "en" | "sv" | "no" | "auto";
-export type HotkeyMode = "push" | "toggle";
+export type HotkeyMode = "push" | "toggle" | "presenter";
+
+export type PresenterFinishAction = "insert_only" | "return" | "command_return";
+
+export interface PresenterConfig {
+  finish_shortcut: string;
+  cancel_shortcut: string | null;
+  app_actions: Record<string, PresenterFinishAction>;
+}
 
 export interface HotkeyProfile {
   id: string;
@@ -23,6 +31,7 @@ export interface Settings {
   language: Language;
   whisper_model: string;
   hotkey_mode: HotkeyMode;
+  presenter: PresenterConfig;
   show_overlay: boolean;
   auto_paste: boolean;
   auto_select_model: boolean;
@@ -101,6 +110,10 @@ export async function setAutoSelectModel(enabled: boolean): Promise<void> {
 
 export async function setHotkeyMode(mode: HotkeyMode): Promise<void> {
   return invoke("set_hotkey_mode", { mode });
+}
+
+export async function setPresenterConfig(config: PresenterConfig): Promise<void> {
+  return invoke("set_presenter_config", { config });
 }
 
 export async function setHotkey(shortcut: string): Promise<void> {


### PR DESCRIPTION
## Summary

Related: #162. The issue remains open; this is a draft implementation, not a completed feature or release.

- Atomic Presenter Start via language-profile shortcuts, separate Finish and optional Cancel; push-to-talk and Toggle remain available.
- CLI request and configuration equivalents, strict hidden single-instance transport and no false completion acknowledgment.
- Transactional registration of profile/Finish/Cancel bindings, stale-generation protection, cancellation and late-callback guards.
- Explicit per-application Insert only / Return / Command+Return policy. macOS native target and UTF-16 selection checks, focus invalidation, observed post-paste state, held-modifier/deadline checks and one-shot dispatch. No unchecked Submit fallback.
- Windows/Linux currently retain drafts for manual copy. Presenter status distinguishes a dispatched Submit key from actual destination delivery.
- Responsive settings/status UI and a documented native/hardware acceptance contract.

## Verification

- `cargo check --workspace`: pass.
- `cargo test --workspace`: 870 passed, 0 failed (254 app, 173 CLI unit, 36 CLI integration, 407 core).
- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
- `cargo build -p sagascript-cli --no-default-features`: pass.
- Frontend: 101 passed, 1 Windows-only skipped; Svelte check 0 errors/warnings; build 130 modules.
- Visual inspection of actual Settings component through isolated in-memory mocks: draft/sent/uncertain, 760px and 390px, no horizontal overflow; narrow app identifiers remain readable. No native app/settings/clipboard interaction in the visual harness.
- The existing isolated macOS named-pasteboard fixture required a network/native-enabled test rerun after a sandbox-only failure. No new Presenter native acceptance is inferred from that fixture.
- Follow-up isolated Chrome visual test at 390x900: Settings and Transcribe remain selected after status events; Dictate shows the fixed delivery disclaimer. No horizontal overflow. Shared browser profile was not modified or terminated.
- Actual independent reviewer `claude-fable-5-1` APPROVE on `6f272285595a18ee756b59641b34c76b3d8124b5`, session `cbfdbf42-378a-45ac-93c9-3111620bb09d`. Prior REQUEST_CHANGES fixed with red/green tests: explicit Presenter ownership isolates manual recording, optional AX subrole absence remains distinguishable from transport/permission failures, and all hotkey requests dispatch on the main thread. Also bounded pre-insertion modifier waiting, reduced redundant AX traversal, preserved selected UI tab, and corrected cross-platform helper cfgs.

## Remaining gates

- CI must pass on this PR head.
- Signed macOS device tests for Accessibility, focus continuity, actual insertion observation, modifier handling and Submit dispatch have not been performed. Logitech Spotlight long-press mapping remains a physical acceptance gate.
- No Windows/Linux target-field adapter or automatic submission is claimed. No app installation, stable release or production deployment is part of this PR.

Full implementation and acceptance details: `docs/presenter-mode-design.md`.
