### PR TITLE
fix(ci): pin and verify Windows candidate build identity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src-tauri/Cargo.toml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,9 @@ jobs:
           restore-keys: |
             windows-models-
 
+      - name: Test Windows build identity gates
+        run: node --test scripts/test-ci-build-identity.mjs scripts/test-windows-release-identity.mjs scripts/test-windows-package-workflow.mjs
+
       - name: Install npm dependencies
         run: npm ci
 

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".gitattributes"
       - ".github/workflows/windows-package.yml"
       - "package.json"
       - "package-lock.json"

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -124,6 +124,9 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Pin validated Windows build identity
+        run: node scripts/ci-build-identity.mjs --initialize
+
       - name: Install npm dependencies
         run: npm ci
 
@@ -160,6 +163,9 @@ jobs:
         if: matrix.architecture == 'x64'
         shell: pwsh
         run: ./scripts/verify-windows-x64-cpu-policy.ps1 -TargetRoot src-tauri/target -PolicyFile scripts/cmake/windows-x64-portable.cmake
+
+      - name: Verify source before release CLI build
+        run: node scripts/ci-build-identity.mjs --verify
 
       - name: Gate real Windows transcription
         shell: pwsh
@@ -223,6 +229,9 @@ jobs:
             }
           }
 
+      - name: Verify source before installer build
+        run: node scripts/ci-build-identity.mjs --verify
+
       - name: Build unsigned internal installers
         run: npx tauri build --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }}
 
@@ -230,6 +239,9 @@ jobs:
         if: matrix.architecture == 'x64'
         shell: pwsh
         run: ./scripts/verify-windows-x64-cpu-policy.ps1 -TargetRoot src-tauri/target -PolicyFile scripts/cmake/windows-x64-portable.cmake
+
+      - name: Verify source after installer build
+        run: node scripts/ci-build-identity.mjs --verify
 
       - name: Prepare and verify candidate artifacts
         shell: pwsh
@@ -266,6 +278,7 @@ jobs:
           ./scripts/verify-windows-release.ps1 `
             -CliExe "artifacts\Sagascript-Windows-$architecture-CLI.exe" `
             -ExpectedVersion $version `
+            -ExpectedGitHash $env:SAGASCRIPT_GIT_HASH `
             -Artifacts @(
               "artifacts\Sagascript-Windows-$architecture-Portable.exe",
               "artifacts\Sagascript-Windows-$architecture-CLI.exe",

--- a/scripts/ci-build-identity.mjs
+++ b/scripts/ci-build-identity.mjs
@@ -1,0 +1,234 @@
+import { appendFileSync, lstatSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const ALLOWED_GENERATED_PATHS = Object.freeze([
+  "src-tauri/gen/schemas/acl-manifests.json",
+  "src-tauri/gen/schemas/capabilities.json",
+  "src-tauri/gen/schemas/desktop-schema.json",
+  "src-tauri/gen/schemas/windows-schema.json",
+]);
+const ALLOWED_GENERATED_SET = new Set(ALLOWED_GENERATED_PATHS);
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.error || result.status !== 0 || !result.stdout) {
+    const detail = result.error && typeof result.error.code === "string"
+      ? "error=" + result.error.code
+      : "status=" + String(result.status);
+    throw new Error("git command failed: " + args.join(" ") + " (" + detail + ")");
+  }
+  return result.stdout;
+}
+
+function headSha() {
+  const value = runGit(["rev-parse", "HEAD"]).toString("utf8").trim();
+  if (!SHA_PATTERN.test(value)) {
+    throw new Error("git HEAD is not a full lowercase SHA-1");
+  }
+  return value;
+}
+
+function expectedSha() {
+  const value = process.env.GITHUB_SHA;
+  if (!SHA_PATTERN.test(value ?? "")) {
+    throw new Error("GITHUB_SHA must be a full lowercase SHA-1");
+  }
+  return value;
+}
+
+function assertExpectedHead() {
+  const expected = expectedSha();
+  const head = headSha();
+  if (expected !== head) {
+    throw new Error("GITHUB_SHA does not match git HEAD");
+  }
+  return expected;
+}
+
+function statusEntries() {
+  const bytes = runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
+  const fields = [];
+  let start = 0;
+  for (let index = 0; index < bytes.length; index += 1) {
+    if (bytes[index] === 0) {
+      if (index > start) {
+        fields.push(bytes.subarray(start, index));
+      }
+      start = index + 1;
+    }
+  }
+  if (start !== bytes.length) {
+    throw new Error("git status output was malformed");
+  }
+
+  const entries = [];
+  for (let index = 0; index < fields.length; index += 1) {
+    const record = fields[index].toString("utf8");
+    if (record.length < 3 || record[2] !== " ") {
+      throw new Error("git status output was malformed");
+    }
+    const xy = record.slice(0, 2);
+    const path = record.slice(3);
+    if (!path) {
+      throw new Error("git status output contained an empty path");
+    }
+    let oldPath;
+    if (xy.includes("R") || xy.includes("C")) {
+      if (index + 1 >= fields.length) {
+        throw new Error("git status rename output was malformed");
+      }
+      oldPath = fields[++index].toString("utf8");
+      if (!oldPath) {
+        throw new Error("git status rename output contained an empty path");
+      }
+    }
+    entries.push({ xy, path, oldPath });
+  }
+  return entries;
+}
+
+function validDate(value) {
+  if (!DATE_PATTERN.test(value ?? "")) {
+    return false;
+  }
+  const parsed = new Date(value + "T00:00:00.000Z");
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function outputPathIsRegular(relativePath) {
+  try {
+    return lstatSync(resolve(process.cwd(), relativePath)).isFile();
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return false;
+    }
+    const code = error && typeof error.code === "string" ? error.code : "unknown";
+    throw new Error("could not inspect generated output " + JSON.stringify(relativePath) + " (" + code + ")");
+  }
+}
+
+function statusError(entry, reason) {
+  return new Error(
+    reason +
+      " path=" +
+      JSON.stringify(entry.path) +
+      " xy=" +
+      JSON.stringify(entry.xy),
+  );
+}
+
+function verifyStatus(entries) {
+  const observed = new Set();
+  for (const entry of entries) {
+    if (
+      entry.xy.includes("R") ||
+      entry.xy.includes("C") ||
+      entry.xy.includes("D") ||
+      [...entry.xy].some((code) => ![" ", "M", "A", "?"].includes(code))
+    ) {
+      throw statusError(entry, "working tree contains a deletion, rename, type change, conflict, or unsupported status");
+    }
+    if (!ALLOWED_GENERATED_SET.has(entry.path)) {
+      throw statusError(entry, "working tree contains a modified or untracked source path");
+    }
+    if (entry.oldPath !== undefined || !outputPathIsRegular(entry.path)) {
+      throw statusError(entry, "generated output is not a regular file");
+    }
+    observed.add(entry.path);
+  }
+
+  for (const relativePath of ALLOWED_GENERATED_PATHS) {
+    try {
+      if (!lstatSync(resolve(process.cwd(), relativePath)).isFile()) {
+        throw new Error("generated output is not a regular file");
+      }
+    } catch (error) {
+      if (error && error.code === "ENOENT") {
+        continue;
+      }
+      if (error instanceof Error && error.message === "generated output is not a regular file") {
+        throw error;
+      }
+      const code = error && typeof error.code === "string" ? error.code : "unknown";
+      throw new Error("could not inspect generated output " + JSON.stringify(relativePath) + " (" + code + ")");
+    }
+  }
+  return [...observed].sort();
+}
+
+function emit(mode, sha, buildDate, observed = []) {
+  const payload = {
+    mode,
+    git_sha: sha,
+    build_date: buildDate,
+    allowed_generated_paths: ALLOWED_GENERATED_PATHS,
+  };
+  if (mode === "verify") {
+    payload.observed_generated_paths = observed;
+  }
+  process.stdout.write(JSON.stringify(payload) + "\n");
+}
+
+function initialize() {
+  const sha = assertExpectedHead();
+  const entries = statusEntries();
+  if (entries.length !== 0) {
+    throw statusError(entries[0], "working tree must be clean before initialization");
+  }
+  const githubEnv = process.env.GITHUB_ENV;
+  if (!githubEnv) {
+    throw new Error("GITHUB_ENV is required");
+  }
+  const buildDate = new Date().toISOString().slice(0, 10);
+  try {
+    appendFileSync(
+      githubEnv,
+      "SAGASCRIPT_GIT_HASH=" + sha + "\nSAGASCRIPT_BUILD_DATE=" + buildDate + "\n",
+      { encoding: "utf8" },
+    );
+  } catch (error) {
+    const code = error && typeof error.code === "string" ? error.code : "unknown";
+    throw new Error("could not append build identity to GITHUB_ENV (" + code + ")");
+  }
+  emit("initialize", sha, buildDate);
+}
+
+function verify() {
+  const sha = assertExpectedHead();
+  const exportedSha = process.env.SAGASCRIPT_GIT_HASH;
+  if (!SHA_PATTERN.test(exportedSha ?? "") || exportedSha !== sha) {
+    throw new Error("SAGASCRIPT_GIT_HASH does not match the validated source SHA");
+  }
+  const buildDate = process.env.SAGASCRIPT_BUILD_DATE;
+  if (!validDate(buildDate)) {
+    throw new Error("SAGASCRIPT_BUILD_DATE is not a valid UTC date");
+  }
+  emit("verify", sha, buildDate, verifyStatus(statusEntries()));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 1 || !["--initialize", "--verify"].includes(args[0])) {
+    throw new Error("expected exactly one of --initialize or --verify");
+  }
+  if (args[0] === "--initialize") {
+    initialize();
+  } else {
+    verify();
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : "verification failed";
+  console.error("ci-build-identity: " + message);
+  process.exitCode = 1;
+}

--- a/scripts/test-ci-build-identity.mjs
+++ b/scripts/test-ci-build-identity.mjs
@@ -11,14 +11,17 @@ const fixtureManifest = fileURLToPath(new URL("../src-tauri/Cargo.toml", import.
 const fixtureAttributes = fileURLToPath(new URL("../.gitattributes", import.meta.url));
 const repos = [];
 const envDirs = [];
+const fixtureEnvironments = new Map();
 const allowedOutput = "src-tauri/gen/schemas/desktop-schema.json";
 
-function git(cwd, args) {
+function git(cwd, args, extraEnv = {}) {
   return execFileSync("git", args, {
     cwd,
     encoding: "utf8",
     env: {
       ...process.env,
+      ...(fixtureEnvironments.get(cwd) ?? {}),
+      ...extraEnv,
       GIT_CONFIG_NOSYSTEM: "1",
       GIT_AUTHOR_NAME: "CI Fixture",
       GIT_AUTHOR_EMAIL: "ci@example.invalid",
@@ -29,16 +32,32 @@ function git(cwd, args) {
   }).trim();
 }
 
+async function isolatedGitEnvironment() {
+  const directory = await mkdtemp(join(tmpdir(), "sagascript-ci-git-"));
+  envDirs.push(directory);
+  const globalConfig = join(directory, "global.gitconfig");
+  await writeFile(globalConfig, "");
+  return { GIT_CONFIG_GLOBAL: globalConfig, GIT_CONFIG_NOSYSTEM: "1" };
+}
+
 async function fixture({ withAttributes = true } = {}) {
   const cwd = await mkdtemp(join(tmpdir(), "sagascript-ci-identity-"));
   repos.push(cwd);
+  fixtureEnvironments.set(cwd, await isolatedGitEnvironment());
   git(cwd, ["init", "-q"]);
   git(cwd, ["config", "user.email", "ci@example.invalid"]);
   git(cwd, ["config", "user.name", "CI Fixture"]);
   git(cwd, ["config", "commit.gpgsign", "false"]);
+  await mkdir(join(cwd, ".git/info"), { recursive: true });
+  const attributesFile = join(cwd, ".git/info/attributes");
+  const excludesFile = join(cwd, ".git/info/exclude");
+  await writeFile(attributesFile, "");
+  await writeFile(excludesFile, "");
+  git(cwd, ["config", "core.attributesfile", attributesFile.replaceAll("\\", "/")]);
+  git(cwd, ["config", "core.excludesfile", excludesFile.replaceAll("\\", "/")]);
   await mkdir(join(cwd, "src-tauri/capabilities"), { recursive: true });
   await mkdir(join(cwd, "src-tauri/gen/schemas"), { recursive: true });
-  await writeFile(join(cwd, "src-tauri/Cargo.toml"), await readFile(fixtureManifest));
+  await writeFile(join(cwd, "src-tauri/Cargo.toml"), normalizeCrlf(await readFile(fixtureManifest)));
   if (withAttributes) {
     await writeFile(join(cwd, ".gitattributes"), await readFile(fixtureAttributes));
   }
@@ -93,9 +112,28 @@ function invoke(cwd, args, extraEnv = {}) {
   return spawnSync(process.execPath, [helper, ...args], {
     cwd,
     encoding: "utf8",
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, ...(fixtureEnvironments.get(cwd) ?? {}), ...extraEnv },
     stdio: ["ignore", "pipe", "pipe"],
   });
+}
+
+async function withEnvironment(overrides, action) {
+  const previous = new Map();
+  for (const [name, value] of Object.entries(overrides)) {
+    previous.set(name, process.env[name]);
+    process.env[name] = value;
+  }
+  try {
+    return await action();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
 }
 
 function assertRejected(result) {
@@ -125,7 +163,11 @@ function verifyEnv(repo, date, overrides = {}) {
 }
 
 afterEach(async () => {
-  await Promise.all(repos.splice(0).map((repo) => rm(repo, { recursive: true, force: true })));
+  const finishedRepos = repos.splice(0);
+  for (const repo of finishedRepos) {
+    fixtureEnvironments.delete(repo);
+  }
+  await Promise.all(finishedRepos.map((repo) => rm(repo, { recursive: true, force: true })));
   await Promise.all(envDirs.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
 });
 
@@ -283,7 +325,7 @@ test("legacy CRLF checkout exposes the pre-attribute line-ending hazard", async 
   const manifestPath = await forceManifestCheckout(repo);
   const checkedOut = await readFile(manifestPath);
   const tauriRewrite = normalizeCrlf(checkedOut);
-  const sourceLf = await readFile(fixtureManifest);
+  const sourceLf = normalizeCrlf(await readFile(fixtureManifest));
 
   assert.ok(countByte(checkedOut, 0x0d) > 0, "legacy checkout should contain CRLF bytes");
   assert.notDeepEqual(checkedOut, tauriRewrite, "LF serialization must differ from the legacy checkout bytes");
@@ -314,4 +356,37 @@ test("repo attributes force LF checkout and preserve strict verification", async
   const changed = invoke(repo.cwd, ["--verify"], verifyEnv(repo, date));
   assertRejected(changed);
   assert.match(changed.stderr, /Cargo\.toml/);
+});
+
+test("fixture Git operations ignore hostile global configuration", async () => {
+  const hostileDirectory = await mkdtemp(join(tmpdir(), "sagascript-ci-hostile-git-"));
+  envDirs.push(hostileDirectory);
+  const hostileIgnore = join(hostileDirectory, "global-ignore");
+  const hostileAttributes = join(hostileDirectory, "global-attributes");
+  const hostileGlobal = join(hostileDirectory, "global.gitconfig");
+  await writeFile(hostileIgnore, "unexpected.txt\n");
+  await writeFile(hostileAttributes, "src-tauri/Cargo.toml text eol=crlf\n");
+  await writeFile(
+    hostileGlobal,
+    "[core]\n" +
+      "\texcludesfile = \"" + hostileIgnore.replaceAll("\\", "/") + "\"\n" +
+      "\tattributesfile = \"" + hostileAttributes.replaceAll("\\", "/") + "\"\n" +
+      "\tautocrlf = true\n" +
+      "\teol = crlf\n",
+  );
+
+  await withEnvironment({ GIT_CONFIG_GLOBAL: hostileGlobal, GIT_CONFIG_NOSYSTEM: "1" }, async () => {
+    const lineEndingRepo = await fixture({ withAttributes: false });
+    const manifestPath = await forceManifestCheckout(lineEndingRepo);
+    assert.equal(countByte(await readFile(manifestPath), 0x0d), 0, "hostile global autocrlf must not leak into fixtures");
+
+    const helperRepo = await fixture();
+    await writeFile(join(helperRepo.cwd, "unexpected.txt"), "untracked\n");
+    const result = invoke(helperRepo.cwd, ["--initialize"], {
+      GITHUB_SHA: helperRepo.sha,
+      GITHUB_ENV: await envPath(),
+    });
+    assertRejected(result);
+    assert.match(result.stderr, /unexpected\.txt/);
+  });
 });

--- a/scripts/test-ci-build-identity.mjs
+++ b/scripts/test-ci-build-identity.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, test } from "node:test";
+
+const helper = fileURLToPath(new URL("./ci-build-identity.mjs", import.meta.url));
+const repos = [];
+const envDirs = [];
+const allowedOutput = "src-tauri/gen/schemas/desktop-schema.json";
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_AUTHOR_NAME: "CI Fixture",
+      GIT_AUTHOR_EMAIL: "ci@example.invalid",
+      GIT_COMMITTER_NAME: "CI Fixture",
+      GIT_COMMITTER_EMAIL: "ci@example.invalid",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+async function fixture() {
+  const cwd = await mkdtemp(join(tmpdir(), "sagascript-ci-identity-"));
+  repos.push(cwd);
+  git(cwd, ["init", "-q"]);
+  git(cwd, ["config", "user.email", "ci@example.invalid"]);
+  git(cwd, ["config", "user.name", "CI Fixture"]);
+  git(cwd, ["config", "commit.gpgsign", "false"]);
+  await mkdir(join(cwd, "src-tauri/capabilities"), { recursive: true });
+  await mkdir(join(cwd, "src-tauri/gen/schemas"), { recursive: true });
+  await writeFile(join(cwd, "src-tauri/capabilities/default.json"), "{\"permission\":true}\n");
+  for (const relativePath of [
+    "src-tauri/gen/schemas/acl-manifests.json",
+    "src-tauri/gen/schemas/capabilities.json",
+    "src-tauri/gen/schemas/desktop-schema.json",
+  ]) {
+    await writeFile(join(cwd, relativePath), "{}\n");
+  }
+  git(cwd, ["add", "."]);
+  git(cwd, ["commit", "-qm", "fixture baseline"]);
+  const sha = git(cwd, ["rev-parse", "HEAD"]);
+  return { cwd, sha };
+}
+
+async function envPath() {
+  const directory = await mkdtemp(join(tmpdir(), "sagascript-ci-env-"));
+  envDirs.push(directory);
+  return join(directory, "github.env");
+}
+
+function invoke(cwd, args, extraEnv = {}) {
+  return spawnSync(process.execPath, [helper, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...extraEnv },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function assertRejected(result) {
+  assert.notEqual(result.status, 0, "expected helper rejection");
+  assert.equal(result.stdout, "");
+}
+
+async function initialized(repo) {
+  const githubEnv = await envPath();
+  const result = invoke(repo.cwd, ["--initialize"], {
+    GITHUB_SHA: repo.sha,
+    GITHUB_ENV: githubEnv,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const envText = await readFile(githubEnv, "utf8");
+  assert.match(envText, new RegExp("^SAGASCRIPT_GIT_HASH=" + repo.sha + "\\nSAGASCRIPT_BUILD_DATE=\\d{4}-\\d{2}-\\d{2}\\n$"));
+  return envText.match(/SAGASCRIPT_BUILD_DATE=(\d{4}-\d{2}-\d{2})/)[1];
+}
+
+function verifyEnv(repo, date, overrides = {}) {
+  return {
+    GITHUB_SHA: repo.sha,
+    SAGASCRIPT_GIT_HASH: repo.sha,
+    SAGASCRIPT_BUILD_DATE: date,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(repos.splice(0).map((repo) => rm(repo, { recursive: true, force: true })));
+  await Promise.all(envDirs.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+test("initialize emits full SHA and UTC date for a clean fixture", async () => {
+  const repo = await fixture();
+  const githubEnv = await envPath();
+  const result = invoke(repo.cwd, ["--initialize"], { GITHUB_SHA: repo.sha, GITHUB_ENV: githubEnv });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.mode, "initialize");
+  assert.equal(output.git_sha, repo.sha);
+  assert.match(output.build_date, /^\d{4}-\d{2}-\d{2}$/);
+  assert.deepEqual(output.allowed_generated_paths, [
+    "src-tauri/gen/schemas/acl-manifests.json",
+    "src-tauri/gen/schemas/capabilities.json",
+    "src-tauri/gen/schemas/desktop-schema.json",
+    "src-tauri/gen/schemas/windows-schema.json",
+  ]);
+  assert.equal((await readFile(githubEnv, "utf8")).split("\n").length, 3);
+});
+
+test("initialize rejects wrong or malformed expected SHA", async () => {
+  for (const expected of ["0".repeat(40), "A".repeat(40), "not-a-sha"]) {
+    const repo = await fixture();
+    const githubEnv = await envPath();
+    const result = invoke(repo.cwd, ["--initialize"], { GITHUB_SHA: expected, GITHUB_ENV: githubEnv });
+    assertRejected(result);
+    await assert.rejects(readFile(githubEnv, "utf8"));
+  }
+});
+
+test("initialize rejects git failure and dirty tracked or untracked files", async () => {
+  const outside = await mkdtemp(join(tmpdir(), "sagascript-ci-not-repo-"));
+  repos.push(outside);
+  const failedGit = invoke(outside, ["--initialize"], {
+    GITHUB_SHA: "0".repeat(40),
+    GITHUB_ENV: await envPath(),
+  });
+  assertRejected(failedGit);
+
+  const repo = await fixture();
+  await writeFile(join(repo.cwd, "src-tauri/capabilities/default.json"), "{\"permission\":false}\n");
+  await writeFile(join(repo.cwd, "unexpected.txt"), "untracked\n");
+  const result = invoke(repo.cwd, ["--initialize"], {
+    GITHUB_SHA: repo.sha,
+    GITHUB_ENV: await envPath(),
+  });
+  assertRejected(result);
+});
+
+test("initialize rejects missing GITHUB_ENV and malformed CLI arguments", async () => {
+  const repo = await fixture();
+  assertRejected(invoke(repo.cwd, ["--initialize"], { GITHUB_SHA: repo.sha, GITHUB_ENV: "" }));
+  assertRejected(invoke(repo.cwd, [], { GITHUB_SHA: repo.sha }));
+  assertRejected(invoke(repo.cwd, ["--verify", "extra"], { GITHUB_SHA: repo.sha }));
+});
+
+test("verify rejects a changed HEAD after initialization", async () => {
+  const repo = await fixture();
+  const date = await initialized(repo);
+  await writeFile(join(repo.cwd, "new-source.txt"), "new commit\n");
+  git(repo.cwd, ["add", "new-source.txt"]);
+  git(repo.cwd, ["commit", "-qm", "second fixture commit"]);
+  assertRejected(invoke(repo.cwd, ["--verify"], verifyEnv(repo, date)));
+});
+
+test("verify permits only regular generated schema outputs", async () => {
+  const repo = await fixture();
+  const date = await initialized(repo);
+  await writeFile(join(repo.cwd, allowedOutput), "{\"generated\":true}\n");
+  await writeFile(join(repo.cwd, "src-tauri/gen/schemas/windows-schema.json"), "{}\n");
+  const result = invoke(repo.cwd, ["--verify"], verifyEnv(repo, date));
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.observed_generated_paths, [
+    "src-tauri/gen/schemas/desktop-schema.json",
+    "src-tauri/gen/schemas/windows-schema.json",
+  ]);
+});
+
+test("verify rejects unexpected, untracked, and capability-source changes", async () => {
+  for (const change of [
+    async (repo) => writeFile(join(repo.cwd, "unexpected.txt"), "nope\n"),
+    async (repo) => writeFile(join(repo.cwd, "src-tauri/capabilities/default.json"), "{\"permission\":false}\n"),
+  ]) {
+    const repo = await fixture();
+    const date = await initialized(repo);
+    await change(repo);
+    const result = invoke(repo.cwd, ["--verify"], verifyEnv(repo, date));
+    assertRejected(result);
+  }
+});
+
+test("verify rejects generated deletion and rename", async () => {
+  const deleted = await fixture();
+  const deletedDate = await initialized(deleted);
+  await rm(join(deleted.cwd, allowedOutput));
+  assertRejected(invoke(deleted.cwd, ["--verify"], verifyEnv(deleted, deletedDate)));
+
+  const renamed = await fixture();
+  const renamedDate = await initialized(renamed);
+  git(renamed.cwd, ["mv", allowedOutput, allowedOutput + ".renamed"]);
+  assertRejected(invoke(renamed.cwd, ["--verify"], verifyEnv(renamed, renamedDate)));
+});
+
+test("verify rejects generated symlink", async (t) => {
+  const symlinked = await fixture();
+  const symlinkedDate = await initialized(symlinked);
+  await rm(join(symlinked.cwd, allowedOutput));
+  try {
+    await symlink("capabilities.json", join(symlinked.cwd, allowedOutput));
+  } catch (error) {
+    if (error && (error.code === "EPERM" || error.code === "EACCES")) {
+      t.skip("host denied symlink creation");
+      return;
+    }
+    throw error;
+  }
+  assertRejected(invoke(symlinked.cwd, ["--verify"], verifyEnv(symlinked, symlinkedDate)));
+});
+
+test("verify rejects missing, wrong, and invalid metadata", async () => {
+  for (const metadata of [
+    { SAGASCRIPT_GIT_HASH: "", SAGASCRIPT_BUILD_DATE: "" },
+    { SAGASCRIPT_GIT_HASH: "0".repeat(40) },
+    { SAGASCRIPT_GIT_HASH: "not-a-sha", SAGASCRIPT_BUILD_DATE: "2026-09-06" },
+  ]) {
+    const repo = await fixture();
+    const result = invoke(repo.cwd, ["--verify"], verifyEnv(repo, "2026-09-06", metadata));
+    assertRejected(result);
+  }
+});
+
+test("verify rejects an invalid build date after SHA validation", async () => {
+  const repo = await fixture();
+  const result = invoke(repo.cwd, ["--verify"], verifyEnv(repo, "2026-02-30"));
+  assertRejected(result);
+  assert.match(result.stderr, /SAGASCRIPT_BUILD_DATE/);
+});
+
+test("status diagnostics preserve a Unicode untracked path", async () => {
+  const repo = await fixture();
+  await writeFile(join(repo.cwd, "naïve.txt"), "untracked\n");
+  const result = invoke(repo.cwd, ["--initialize"], {
+    GITHUB_SHA: repo.sha,
+    GITHUB_ENV: await envPath(),
+  });
+  assertRejected(result);
+  assert.match(result.stderr, /path="naïve\.txt" xy="\?\?"/);
+});

--- a/scripts/test-ci-build-identity.mjs
+++ b/scripts/test-ci-build-identity.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 import { afterEach, test } from "node:test";
 
 const helper = fileURLToPath(new URL("./ci-build-identity.mjs", import.meta.url));
+const fixtureManifest = fileURLToPath(new URL("../src-tauri/Cargo.toml", import.meta.url));
+const fixtureAttributes = fileURLToPath(new URL("../.gitattributes", import.meta.url));
 const repos = [];
 const envDirs = [];
 const allowedOutput = "src-tauri/gen/schemas/desktop-schema.json";
@@ -27,7 +29,7 @@ function git(cwd, args) {
   }).trim();
 }
 
-async function fixture() {
+async function fixture({ withAttributes = true } = {}) {
   const cwd = await mkdtemp(join(tmpdir(), "sagascript-ci-identity-"));
   repos.push(cwd);
   git(cwd, ["init", "-q"]);
@@ -36,6 +38,10 @@ async function fixture() {
   git(cwd, ["config", "commit.gpgsign", "false"]);
   await mkdir(join(cwd, "src-tauri/capabilities"), { recursive: true });
   await mkdir(join(cwd, "src-tauri/gen/schemas"), { recursive: true });
+  await writeFile(join(cwd, "src-tauri/Cargo.toml"), await readFile(fixtureManifest));
+  if (withAttributes) {
+    await writeFile(join(cwd, ".gitattributes"), await readFile(fixtureAttributes));
+  }
   await writeFile(join(cwd, "src-tauri/capabilities/default.json"), "{\"permission\":true}\n");
   for (const relativePath of [
     "src-tauri/gen/schemas/acl-manifests.json",
@@ -48,6 +54,33 @@ async function fixture() {
   git(cwd, ["commit", "-qm", "fixture baseline"]);
   const sha = git(cwd, ["rev-parse", "HEAD"]);
   return { cwd, sha };
+}
+
+function configureCrlfCheckout(repo) {
+  git(repo.cwd, ["config", "core.autocrlf", "true"]);
+  git(repo.cwd, ["config", "core.eol", "crlf"]);
+}
+
+async function forceManifestCheckout(repo) {
+  const manifestPath = join(repo.cwd, "src-tauri/Cargo.toml");
+  await rm(manifestPath, { force: true });
+  git(repo.cwd, ["checkout", "--", "src-tauri/Cargo.toml"]);
+  return manifestPath;
+}
+
+function normalizeCrlf(bytes) {
+  const normalized = [];
+  for (let index = 0; index < bytes.length; index += 1) {
+    if (bytes[index] === 0x0d && bytes[index + 1] === 0x0a) {
+      continue;
+    }
+    normalized.push(bytes[index]);
+  }
+  return Buffer.from(normalized);
+}
+
+function countByte(bytes, expected) {
+  return bytes.reduce((count, byte) => count + (byte === expected ? 1 : 0), 0);
 }
 
 async function envPath() {
@@ -242,4 +275,43 @@ test("status diagnostics preserve a Unicode untracked path", async () => {
   });
   assertRejected(result);
   assert.match(result.stderr, /path="naïve\.txt" xy="\?\?"/);
+});
+
+test("legacy CRLF checkout exposes the pre-attribute line-ending hazard", async () => {
+  const repo = await fixture({ withAttributes: false });
+  configureCrlfCheckout(repo);
+  const manifestPath = await forceManifestCheckout(repo);
+  const checkedOut = await readFile(manifestPath);
+  const tauriRewrite = normalizeCrlf(checkedOut);
+  const sourceLf = await readFile(fixtureManifest);
+
+  assert.ok(countByte(checkedOut, 0x0d) > 0, "legacy checkout should contain CRLF bytes");
+  assert.notDeepEqual(checkedOut, tauriRewrite, "LF serialization must differ from the legacy checkout bytes");
+  assert.deepEqual(tauriRewrite, sourceLf, "LF serialization should restore the committed manifest bytes");
+});
+
+test("repo attributes force LF checkout and preserve strict verification", async () => {
+  const attributes = await readFile(fixtureAttributes, "utf8");
+  assert.match(attributes, /^src-tauri\/Cargo\.toml text eol=lf$/m);
+
+  const repo = await fixture();
+  configureCrlfCheckout(repo);
+  const manifestPath = await forceManifestCheckout(repo);
+  const checkedOut = await readFile(manifestPath);
+
+  assert.equal(countByte(checkedOut, 0x0d), 0, "repo attribute must force LF checkout");
+  assert.ok(countByte(checkedOut, 0x0a) > 0, "manifest should retain line endings");
+
+  const date = await initialized(repo);
+  await writeFile(manifestPath, normalizeCrlf(checkedOut));
+  assert.deepEqual(await readFile(manifestPath), checkedOut, "Tauri-style LF rewrite must be byte-identical");
+
+  const result = invoke(repo.cwd, ["--verify"], verifyEnv(repo, date));
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(git(repo.cwd, ["status", "--short"]), "");
+
+  await writeFile(manifestPath, Buffer.concat([checkedOut, Buffer.from("\n# source change\n")]));
+  const changed = invoke(repo.cwd, ["--verify"], verifyEnv(repo, date));
+  assertRejected(changed);
+  assert.match(changed.stderr, /Cargo\.toml/);
 });

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -4,6 +4,39 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+test("Windows PR CI runs build identity regression tests before compilation", async () => {
+  const ci = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+  const windows = ci.slice(ci.indexOf("  check-windows:"));
+  const command = "node --test scripts/test-ci-build-identity.mjs scripts/test-windows-release-identity.mjs scripts/test-windows-package-workflow.mjs";
+  const checks = windows.indexOf(command);
+  assert.ok(checks > windows.indexOf("name: Install Node.js"));
+  assert.ok(checks < windows.indexOf("name: Cargo check"));
+});
+
+test("Windows candidates pin and verify source identity around release compilation", async () => {
+  const workflow = await readFile(
+    new URL("../.github/workflows/windows-package.yml", import.meta.url),
+    "utf8",
+  );
+  const initialize = workflow.indexOf("node scripts/ci-build-identity.mjs --initialize");
+  const installNode = workflow.indexOf("name: Install Node.js");
+  const installDependencies = workflow.indexOf("name: Install npm dependencies");
+  const rustTests = workflow.indexOf("name: Test and lint Rust workspace");
+  assert.ok(initialize > installNode && initialize < installDependencies);
+  assert.ok(initialize < rustTests);
+
+  const cliBuild = workflow.indexOf("name: Gate real Windows transcription");
+  const installerBuild = workflow.indexOf("name: Build unsigned internal installers");
+  const artifacts = workflow.indexOf("name: Prepare and verify candidate artifacts");
+  const verifies = [...workflow.matchAll(/node scripts\/ci-build-identity\.mjs --verify/g)]
+    .map((match) => match.index);
+  assert.equal(verifies.length, 3);
+  assert.ok(verifies[0] > rustTests && verifies[0] < cliBuild);
+  assert.ok(verifies[1] > cliBuild && verifies[1] < installerBuild);
+  assert.ok(verifies[2] > installerBuild && verifies[2] < artifacts);
+  assert.match(workflow.slice(artifacts), /-ExpectedGitHash \$env:SAGASCRIPT_GIT_HASH/);
+});
+
 const workflow = await readFile(
   new URL("../.github/workflows/windows-package.yml", import.meta.url),
   "utf8",

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -52,6 +52,7 @@ const acceptanceScript = await readFile(
 
 test("Windows candidate workflow stays non-publishing and explicitly unsigned", () => {
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /- "\.gitattributes"/, "checkout normalization changes must trigger candidate builds");
   assert.match(workflow, /permissions:\s*\n\s*contents: read/);
   assert.match(workflow, /tauri build --ci --bundles nsis,msi --no-sign/);
   assert.match(workflow, /SignaturePolicy Internal/);

--- a/scripts/test-windows-release-identity.mjs
+++ b/scripts/test-windows-release-identity.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const verifierPath = join(scriptDirectory, "verify-windows-release.ps1");
+const expectedVersion = "1.1.3";
+const expectedGitHash = "0123456789abcdef0123456789abcdef01234567";
+
+function findPowerShell(probeCwd) {
+  const candidates = [
+    process.env.SAGASCRIPT_PWSH,
+    join(homedir(), ".dotnet", "tools", "pwsh"),
+    "pwsh",
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const probe = spawnSync(
+      candidate,
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "$PSVersionTable.PSVersion.ToString()"],
+      { cwd: probeCwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (probe.status === 0) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function writePowerShellFixtures(root) {
+  const cliPath = join(root, "stub-cli.ps1");
+  const runnerPath = join(root, "run-verifier.ps1");
+
+  writeFileSync(
+    cliPath,
+    [
+      "#!/usr/bin/env pwsh",
+      "param([string]$Argument)",
+      "if ($Argument -eq \"--version\") {",
+      "    Write-Output $env:SAGASCRIPT_TEST_VERSION_OUTPUT",
+      "    exit 0",
+      "}",
+      "if ($Argument -eq \"--help\") {",
+      "    Write-Output \"help\"",
+      "    exit 0",
+      "}",
+      "exit 17",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(cliPath, 0o755);
+
+  writeFileSync(
+    runnerPath,
+    [
+      "param(",
+      "    [Parameter(Mandatory = $true)][string]$VerifierPath,",
+      "    [Parameter(Mandatory = $true)][string]$CliPath,",
+      "    [Parameter(Mandatory = $true)][string]$ChecksumPath,",
+      "    [Parameter(Mandatory = $true)][string]$ExpectedVersion,",
+      "    [string]$ExpectedGitHash,",
+      "    [switch]$OmitExpectedGitHash",
+      ")",
+      "$ErrorActionPreference = \"Stop\"",
+      "# Test-only mock: this does not make any Authenticode claim.",
+      "function Get-AuthenticodeSignature {",
+      "    param([string]$FilePath)",
+      "    [pscustomobject]@{ Status = \"NotSigned\" }",
+      "}",
+      "if ($OmitExpectedGitHash) {",
+      "    & $VerifierPath -CliExe $CliPath -ExpectedVersion $ExpectedVersion -Artifacts $CliPath -ChecksumOutput $ChecksumPath",
+      "} else {",
+      "    & $VerifierPath -CliExe $CliPath -ExpectedVersion $ExpectedVersion -ExpectedGitHash $ExpectedGitHash -Artifacts $CliPath -ChecksumOutput $ChecksumPath",
+      "}",
+      "if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }",
+      "",
+    ].join("\n"),
+  );
+
+  return { cliPath, runnerPath };
+}
+
+function runVerifier({ powershell, runnerPath, cliPath, checksumPath, output, expectedGitHash, omitExpectedGitHash }) {
+  const args = [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    runnerPath,
+    "-VerifierPath",
+    verifierPath,
+    "-CliPath",
+    cliPath,
+    "-ChecksumPath",
+    checksumPath,
+    "-ExpectedVersion",
+    expectedVersion,
+  ];
+  if (omitExpectedGitHash) {
+    args.push("-OmitExpectedGitHash");
+  } else {
+    args.push("-ExpectedGitHash", expectedGitHash);
+  }
+
+  return spawnSync(powershell, args, {
+    cwd: dirname(cliPath),
+    encoding: "utf8",
+    env: { ...process.env, SAGASCRIPT_TEST_VERSION_OUTPUT: output },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+test("Windows release verifier enforces clean full build identity", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "sagascript-windows-release-identity-"));
+  try {
+    const powershell = findPowerShell(root);
+    if (!powershell) {
+      if (process.platform === "win32") {
+        assert.fail("pwsh is required for the Windows release identity test on native Windows");
+      }
+      t.skip("pwsh unavailable outside native Windows");
+      return;
+    }
+
+    const { cliPath, runnerPath } = writePowerShellFixtures(root);
+    const run = (output, expected = expectedGitHash, omitExpectedGitHash = false) => {
+      const checksumPath = join(root, `SHA256SUMS-${Math.random().toString(16).slice(2)}`);
+      const result = runVerifier({
+        powershell,
+        runnerPath,
+        cliPath,
+        checksumPath,
+        output,
+        expectedGitHash: expected,
+        omitExpectedGitHash,
+      });
+      return { result, checksumPath };
+    };
+    const validOutput = `sagascript ${expectedVersion} (git ${expectedGitHash}, built 2026-09-06)`;
+
+    const backwardsCompatible = run(
+      "sagascript 1.1.3 (git 0949345, built 2026-09-06)",
+      "",
+      true,
+    );
+    assert.equal(backwardsCompatible.result.status, 0, `${backwardsCompatible.result.stderr}\nstdout=${backwardsCompatible.result.stdout}`);
+    assert.ok(existsSync(backwardsCompatible.checksumPath));
+
+    const valid = run(validOutput);
+    assert.equal(valid.result.status, 0, `${valid.result.stderr}\nstdout=${valid.result.stdout}`);
+    assert.ok(existsSync(valid.checksumPath));
+
+    const rejectedOutputs = [
+      `sagascript ${expectedVersion} (git ${expectedGitHash}-dirty, built 2026-09-06)`,
+      `sagascript ${expectedVersion} (git unknown, built 2026-09-06)`,
+      `sagascript ${expectedVersion} (git ${"0".repeat(40)}, built 2026-09-06)`,
+      `sagascript ${expectedVersion} (git ${expectedGitHash}, built 2026-09-06) trailing`,
+      `sagascript ${expectedVersion} (git ${expectedGitHash}, built 2026-02-30)`,
+      `sagascript ${expectedVersion} (git ${expectedGitHash}deadbeef, built 2026-09-06)`,
+    ];
+    for (const output of rejectedOutputs) {
+      const rejected = run(output);
+      assert.notEqual(rejected.result.status, 0, `unexpectedly accepted: ${output}`);
+    }
+
+    const malformedExpectedHashes = [
+      "",
+      expectedGitHash.toUpperCase(),
+      expectedGitHash.slice(0, 39),
+      `${expectedGitHash}0`,
+    ];
+    for (const malformedExpectedHash of malformedExpectedHashes) {
+      const rejected = run(validOutput, malformedExpectedHash);
+      assert.notEqual(
+        rejected.result.status,
+        0,
+        `unexpectedly accepted expected hash: ${malformedExpectedHash}`,
+      );
+    }
+
+    const mismatchedExpectedHash = run(validOutput, "1".repeat(40));
+    assert.notEqual(mismatchedExpectedHash.result.status, 0);
+
+    const malformedVersion = run(`sagascript ${expectedVersion}.0 (git ${expectedGitHash}, built 2026-09-06)`);
+    assert.notEqual(malformedVersion.result.status, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-windows-release.ps1
+++ b/scripts/verify-windows-release.ps1
@@ -14,7 +14,9 @@ param(
     [ValidateSet("Internal", "Release")]
     [string]$SignaturePolicy = "Internal",
 
-    [string]$ChecksumOutput = "SHA256SUMS-Windows"
+    [string]$ChecksumOutput = "SHA256SUMS-Windows",
+
+    [string]$ExpectedGitHash
 )
 
 Set-StrictMode -Version Latest
@@ -59,6 +61,11 @@ function Invoke-CliProbe {
 if ($ExpectedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$') {
     throw "ExpectedVersion is not a semantic version: $ExpectedVersion"
 }
+if ($PSBoundParameters.ContainsKey("ExpectedGitHash")) {
+    if ($ExpectedGitHash -cnotmatch '^[0-9a-f]{40}$') {
+        throw "ExpectedGitHash must be exactly 40 lowercase hexadecimal characters when provided"
+    }
+}
 if ($Artifacts.Count -eq 0) {
     throw "Artifacts must contain at least one file"
 }
@@ -89,9 +96,29 @@ if (-not $pathSet.Contains($cliExePath)) {
 }
 
 $versionOutput = Invoke-CliProbe -Executable $cliExePath -Argument "--version"
-$versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
-if ($versionOutput -notmatch $versionPattern) {
-    throw "Version output does not contain exact version '$ExpectedVersion': $versionOutput"
+$versionOutputTrimmed = $versionOutput.Trim()
+if ($PSBoundParameters.ContainsKey("ExpectedGitHash")) {
+    $identityPattern = "\Asagascript $([regex]::Escape($ExpectedVersion)) \(git $([regex]::Escape($ExpectedGitHash)), built (\d{4}-\d{2}-\d{2})\)\z"
+    $identityMatch = [regex]::Match($versionOutputTrimmed, $identityPattern)
+    if (-not $identityMatch.Success) {
+        throw "Version output does not contain the exact clean build identity for '$ExpectedVersion' and '$ExpectedGitHash': $versionOutput"
+    }
+
+    try {
+        [void][DateTime]::ParseExact(
+            $identityMatch.Groups[1].Value,
+            "yyyy-MM-dd",
+            [Globalization.CultureInfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::None
+        )
+    } catch {
+        throw "Version output contains an invalid UTC build date: $($identityMatch.Groups[1].Value)"
+    }
+} else {
+    $versionPattern = "(?<![0-9.])$([regex]::Escape($ExpectedVersion))(?![0-9.])"
+    if ($versionOutput -notmatch $versionPattern) {
+        throw "Version output does not contain exact version '$ExpectedVersion': $versionOutput"
+    }
 }
 [void](Invoke-CliProbe -Executable $cliExePath -Argument "--help")
 Write-Host "Executable probes passed for Sagascript $ExpectedVersion"


### PR DESCRIPTION
## Summary
- Pin Windows candidate builds to the full validated source SHA and UTC build date before compilation.
- Require a clean initial checkout; verify it around release builds, allowing only four regular Tauri-generated schema outputs.
- Require the packaged CLI to report the exact clean SHA, semantic version, and valid build date; preserve legacy verifier callers.
- Run real Git-fixture and PowerShell regression tests on native Windows PR CI.

The previous R4 Windows candidates reported `0949345-dirty`; they remain unpublished and preserved. Tauri-generated schema changes are the source-backed likely explanation, not a runner-log-proven attribution. This change fails closed on any other source change.

## Verification
- Frontend/script suite: 128 passed, 1 existing native-Windows-only test skipped on macOS; the new PowerShell identity test ran successfully using actual PowerShell with a test-only Authenticode mock.
- Svelte check: 0 errors, 0 warnings; frontend build passed.
- Release consistency and license-notice checks passed.
- actionlint passed for both changed workflows; git diff --check passed.
- Native platform CI and independent Claude review pending; required before merge.

Related to #198 and #168. Does not close native Finnish/manual GUI acceptance. No installation, production release, or changes to signature policy. New test builds will use the eventual merge SHA and a new immutable test tag.
