### PR TITLE
fix: explicit dictionary save and unsaved-change navigation

### DIFF
--- a/docs/personal-glossary.md
+++ b/docs/personal-glossary.md
@@ -56,6 +56,10 @@ additional confidence-gated one-edit correction for plain single-word hints.
   Global hints scope or a selected explicit-language profile scope. The global
   file remains visible and editable; clearing or migrating it is not required
   to disable its aliases.
+  Edit the existing text normally, then choose **Save changes** to persist the draft.
+  Typing and leaving the text field do not save. **Discard changes** restores
+  the saved text. An **Unsaved changes** indicator identifies a pending draft;
+  switching dictionary scope or tab asks you to save, discard, or stay.
   If that same dictionary changes through the CLI while you are editing, the
   GUI rejects the stale save and preserves your draft. Copy your edits, then
   switch away and reselect the scope to load the current stored text before

--- a/scripts/test-dictionary-explicit-save.mjs
+++ b/scripts/test-dictionary-explicit-save.mjs
@@ -288,6 +288,23 @@ test("Discard restores the saved source without persisting", () => {
   assert.equal(state.calls.length, 0);
 });
 
+test("clean dictionary action buttons do not advertise an active wait", () => {
+  const disabledActionRule = settingsSource.match(
+    /\.dictionary-actions button:disabled,[\s\S]*?opacity:\s*0\.6;/,
+  )?.[0];
+  assert.ok(disabledActionRule, "dictionary disabled-button styling should remain explicit");
+  assert.match(
+    disabledActionRule,
+    /cursor:\s*default/,
+    "a clean disabled Save button must not show macOS's spinning wait cursor",
+  );
+  assert.doesNotMatch(
+    disabledActionRule,
+    /cursor:\s*wait/,
+    "the disabled state is also used when no save is in progress",
+  );
+});
+
 test("dirty scope navigation offers Save, Discard, and Stay", async () => {
   const exercise = createHarness();
   input(exercise, "global draft");

--- a/scripts/test-dictionary-explicit-save.mjs
+++ b/scripts/test-dictionary-explicit-save.mjs
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+import vm from "node:vm";
+
+const settingsSource = await readFile(
+  new URL("../src/lib/Settings.svelte", import.meta.url),
+  "utf8",
+);
+const scriptSource = settingsSource.match(/<script lang="ts">([\s\S]*?)<\/script>/)?.[1];
+assert.ok(scriptSource, "Settings.svelte should have a TypeScript script block");
+
+function functionSource(name) {
+  const plainStart = scriptSource.indexOf(`function ${name}`);
+  const asyncStart = scriptSource.indexOf(`async function ${name}`);
+  const start = asyncStart >= 0 && (plainStart < 0 || asyncStart < plainStart)
+    ? asyncStart
+    : plainStart;
+  assert.ok(start >= 0, `Settings.svelte should define ${name}`);
+  let brace = scriptSource.indexOf("{", start);
+  assert.ok(brace >= 0, `${name} should have a body`);
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  for (let i = brace; i < scriptSource.length; i += 1) {
+    const ch = scriptSource[i];
+    const next = scriptSource[i + 1];
+    if (lineComment) {
+      if (ch === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (ch === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "\"" || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return scriptSource.slice(start, i + 1);
+  }
+  throw new Error(`Could not find the end of ${name}`);
+}
+
+function transpile(source) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.None,
+      verbatimModuleSyntax: false,
+    },
+  }).outputText;
+}
+
+function createHarness({ failure = null } = {}) {
+  const functions = [
+    "glossaryHasUnsavedChanges",
+    "saveGlossary",
+    "onGlossaryInput",
+    "discardGlossaryChanges",
+    "commitGlossaryScopeChange",
+    "onGlossaryScopeChange",
+    "promptGlossaryNavigation",
+    "restoreGlossaryNavigationFocus",
+    "finishPendingGlossaryNavigation",
+    "saveAndFinishGlossaryNavigation",
+    "discardAndFinishGlossaryNavigation",
+    "stayOnGlossaryDraft",
+    "requestTabChange",
+  ].map(functionSource).join("\n");
+  const harness = `
+    let settings = {
+      initial_prompt: "global saved",
+      profile_glossaries: { english: "english saved", swedish: "swedish saved" },
+      hotkey_profiles: [
+        { id: "english", name: "English", language: "en" },
+        { id: "swedish", name: "Swedish", language: "sv" },
+      ],
+    };
+    let settingsError = "";
+    let activeTab = "settings";
+    let glossaryScopeId = "";
+    let glossaryDraft = settings.initial_prompt;
+    let glossaryDraftInitialized = true;
+    let glossaryScopeGeneration = 0;
+    let glossaryDraftGeneration = 0;
+    let lastStoredGlossarySources = { "": settings.initial_prompt };
+    let glossaryEditBaseline = null;
+    let glossarySaving = false;
+    let glossarySaveInFlight = null;
+    let pendingGlossaryNavigation = null;
+    let glossaryReturnFocusEl = null;
+    let recoveredGlossaryDrafts = [];
+    let glossaryConflictScopeId = null;
+    class HTMLElement {}
+    const calls = [];
+    const dictionaryConflictPrefix = "Dictionary changed elsewhere:";
+    const failure = ${JSON.stringify(failure)};
+
+    function explicitProfiles(source = settings) {
+      return source?.hotkey_profiles.filter((profile) => profile.language !== "auto") ?? [];
+    }
+    function profileForId(profileId, source = settings) {
+      if (!profileId) return null;
+      return explicitProfiles(source).find((profile) => profile.id === profileId) ?? null;
+    }
+    function glossarySourceForScope(scopeId, source = settings) {
+      if (!source || scopeId === "") return source?.initial_prompt ?? "";
+      return source.profile_glossaries[scopeId] ?? "";
+    }
+    function isValidGlossaryScope(scopeId, source = settings) {
+      return scopeId === "" || profileForId(scopeId, source) !== null;
+    }
+    function rememberGlossaryRecovery(scopeId, draft, conflicted = false) {
+      recoveredGlossaryDrafts.push({ scopeId, draft, conflicted });
+    }
+    function removeGlossaryRecovery(scopeId, draft) {
+      recoveredGlossaryDrafts = recoveredGlossaryDrafts.filter(
+        (recovery) => recovery.scopeId !== scopeId || recovery.draft !== draft,
+      );
+    }
+    function isCurrentGlossaryRequest(request) {
+      return request.generation === glossaryScopeGeneration
+        && request.scopeId === glossaryScopeId
+        && request.draftGeneration === glossaryDraftGeneration;
+    }
+    async function getSettings() {
+      return settings;
+    }
+    async function refreshProfileModels() {}
+    async function setInitialPrompt(value, expectedSource) {
+      calls.push({ command: "setInitialPrompt", scopeId: "", value, expectedSource });
+      if (failure) throw new Error(failure);
+      settings = { ...settings, initial_prompt: value };
+    }
+    async function setProfileGlossary(scopeId, value, expectedSource) {
+      calls.push({ command: "setProfileGlossary", scopeId, value, expectedSource });
+      if (failure) throw new Error(failure);
+      settings = {
+        ...settings,
+        profile_glossaries: { ...settings.profile_glossaries, [scopeId]: value },
+      };
+    }
+    async function applySetting(mutate, errorSink, reportError = true) {
+      if (reportError) settingsError = "";
+      try {
+        await mutate();
+        settings = await getSettings();
+        await refreshProfileModels(settings.hotkey_profiles);
+        return true;
+      } catch (error) {
+        const message = typeof error === "string" ? error : error?.message || "Failed to save setting.";
+        if (reportError) settingsError = message;
+        if (errorSink) errorSink.value = message;
+        return false;
+      }
+    }
+    async function refreshDictionaryAfterConflict(primaryError, request) {
+      settings = await getSettings();
+      if (isCurrentGlossaryRequest(request)) {
+        settingsError = primaryError;
+        glossaryConflictScopeId = request.scopeId;
+      } else {
+        rememberGlossaryRecovery(request.scopeId, request.value, true);
+      }
+    }
+    ${functions}
+    globalThis.exercise = {
+      saveGlossary,
+      onGlossaryInput,
+      discardGlossaryChanges,
+      commitGlossaryScopeChange,
+      onGlossaryScopeChange,
+      saveAndFinishGlossaryNavigation,
+      discardAndFinishGlossaryNavigation,
+      stayOnGlossaryDraft,
+      requestTabChange,
+      snapshot: () => ({
+        settings,
+        settingsError,
+        activeTab,
+        glossaryScopeId,
+        glossaryDraft,
+        glossaryDraftGeneration,
+        glossaryEditBaseline,
+        glossarySaving,
+        pendingGlossaryNavigation,
+        glossaryConflictScopeId,
+        calls: [...calls],
+      }),
+    };
+  `;
+  const context = vm.createContext({ console, queueMicrotask, setTimeout, clearTimeout });
+  vm.runInContext(transpile(harness), context, { timeout: 1000 });
+  return context.exercise;
+}
+
+function input(exercise, value) {
+  exercise.onGlossaryInput({ target: { value } });
+}
+
+test("caret edits are local: input and blur do not persist", async () => {
+  assert.doesNotMatch(settingsSource, /onblur=\{onInitialPromptBlur\}/);
+  const exercise = createHarness();
+  input(exercise, "global d");
+  input(exercise, "global draft");
+  assert.equal(exercise.snapshot().calls.length, 0);
+  assert.equal(exercise.snapshot().glossaryDraft, "global draft");
+  await Promise.resolve();
+  assert.equal(exercise.snapshot().calls.length, 0);
+});
+
+test("the first dictionary edit establishes a reactive dirty baseline", () => {
+  assert.match(
+    scriptSource,
+    /let glossaryEditBaseline: \{ scopeId: string; source: string; generation: number \} \| null = \$state\(null\)/,
+    "the dirty baseline must participate in Svelte reactivity",
+  );
+  const exercise = createHarness();
+  assert.equal(exercise.snapshot().glossaryEditBaseline, null);
+  input(exercise, "global draft");
+  const state = exercise.snapshot();
+  assert.deepEqual(JSON.parse(JSON.stringify(state.glossaryEditBaseline)), {
+    scopeId: "",
+    source: "global saved",
+    generation: 1,
+  });
+  exercise.requestTabChange("dictate");
+  assert.equal(exercise.snapshot().pendingGlossaryNavigation.kind, "tab");
+});
+
+test("Save persists the active scope with its edit baseline as expected_source", async () => {
+  const exercise = createHarness();
+  input(exercise, "global draft");
+  assert.equal(await exercise.saveGlossary(), true);
+  assert.deepEqual(JSON.parse(JSON.stringify(exercise.snapshot().calls)), [{
+    command: "setInitialPrompt",
+    scopeId: "",
+    value: "global draft",
+    expectedSource: "global saved",
+  }]);
+
+  exercise.commitGlossaryScopeChange("english");
+  input(exercise, "english draft");
+  assert.equal(await exercise.saveGlossary(), true);
+  assert.deepEqual(JSON.parse(JSON.stringify(exercise.snapshot().calls.at(-1))), {
+    command: "setProfileGlossary",
+    scopeId: "english",
+    value: "english draft",
+    expectedSource: "english saved",
+  });
+});
+
+test("Discard restores the saved source without persisting", () => {
+  const exercise = createHarness();
+  input(exercise, "global draft");
+  exercise.discardGlossaryChanges();
+  const state = exercise.snapshot();
+  assert.equal(state.glossaryDraft, "global saved");
+  assert.equal(state.glossaryEditBaseline, null);
+  assert.equal(state.calls.length, 0);
+});
+
+test("dirty scope navigation offers Save, Discard, and Stay", async () => {
+  const exercise = createHarness();
+  input(exercise, "global draft");
+  exercise.onGlossaryScopeChange({ target: { value: "english" }, currentTarget: { value: "english" } });
+  assert.equal(exercise.snapshot().pendingGlossaryNavigation.kind, "scope");
+  assert.equal(exercise.snapshot().pendingGlossaryNavigation.scopeId, "english");
+  assert.equal(exercise.snapshot().glossaryScopeId, "");
+
+  exercise.stayOnGlossaryDraft();
+  assert.equal(exercise.snapshot().pendingGlossaryNavigation, null);
+  assert.equal(exercise.snapshot().glossaryScopeId, "");
+
+  exercise.onGlossaryScopeChange({ target: { value: "english" }, currentTarget: { value: "english" } });
+  exercise.discardAndFinishGlossaryNavigation();
+  assert.equal(exercise.snapshot().glossaryScopeId, "english");
+  assert.equal(exercise.snapshot().glossaryDraft, "english saved");
+
+  exercise.commitGlossaryScopeChange("");
+  input(exercise, "global draft 2");
+  exercise.onGlossaryScopeChange({ target: { value: "english" }, currentTarget: { value: "english" } });
+  await exercise.saveAndFinishGlossaryNavigation();
+  assert.equal(exercise.snapshot().glossaryScopeId, "english");
+  assert.equal(exercise.snapshot().calls.at(-1).expectedSource, "global saved");
+});
+
+test("dirty tab navigation offers the same decisions", () => {
+  const exercise = createHarness();
+  input(exercise, "global draft");
+  exercise.requestTabChange("dictate");
+  assert.equal(exercise.snapshot().pendingGlossaryNavigation.kind, "tab");
+  assert.equal(exercise.snapshot().pendingGlossaryNavigation.tab, "dictate");
+  assert.equal(exercise.snapshot().activeTab, "settings");
+  exercise.stayOnGlossaryDraft();
+  assert.equal(exercise.snapshot().activeTab, "settings");
+  exercise.requestTabChange("dictate");
+  exercise.discardAndFinishGlossaryNavigation();
+  assert.equal(exercise.snapshot().activeTab, "dictate");
+});
+
+for (const failure of ["write failed", "Dictionary changed elsewhere: current source"]) {
+  test(`failed or conflict save retains the draft and blocks navigation (${failure})`, async () => {
+    const exercise = createHarness({ failure });
+    input(exercise, "draft that must survive");
+    assert.equal(await exercise.saveGlossary(), false);
+    const failed = exercise.snapshot();
+    assert.equal(failed.glossaryDraft, "draft that must survive");
+    assert.notEqual(failed.glossaryEditBaseline, null);
+    exercise.requestTabChange("dictate");
+    const blocked = exercise.snapshot();
+    assert.equal(blocked.activeTab, "settings");
+    assert.equal(blocked.pendingGlossaryNavigation.kind, "tab");
+    assert.equal(blocked.pendingGlossaryNavigation.tab, "dictate");
+    if (failure.startsWith("Dictionary")) {
+      assert.equal(blocked.glossaryConflictScopeId, "");
+      assert.match(blocked.settingsError, /^Dictionary changed elsewhere:/);
+    }
+  });
+}

--- a/scripts/test-language-glossary.mjs
+++ b/scripts/test-language-glossary.mjs
@@ -34,7 +34,7 @@ test("dictionary scope exposes only explicit profiles and keeps migration guidan
   assert.match(settingsSource, /function explicitProfiles\(source: Settings \| null = settings\)/);
   assert.match(settingsSource, /profile\.language !== "auto"/);
   assert.match(settingsSource, /let glossaryScopeId: string = \$state\(""\)/);
-  assert.match(settingsSource, /<select id="dictionary-scope" value=\{glossaryScopeId\} onchange=\{onGlossaryScopeChange\}>/);
+  assert.match(settingsSource, /<select id="dictionary-scope" value=\{glossaryScopeId\} onchange=\{onGlossaryScopeChange\} disabled=\{glossarySaving\}>/);
   assert.match(settingsSource, /<option value="">Global hints<\/option>/);
   assert.match(settingsSource, /Global entries are hint-only and remain stored/);
   assert.match(settingsSource, /copy an entry into the explicit-language profile/);
@@ -52,7 +52,7 @@ test("scope switching is local and stale saves cannot overwrite a newer scope", 
   assert.ok(switchStart >= 0 && switchEnd > switchStart);
   const switchSource = settingsSource.slice(switchStart, switchEnd);
   assert.doesNotMatch(switchSource, /setInitialPrompt|setProfileGlossary|applySetting/);
-  assert.match(settingsSource, /let glossaryScopeGeneration = 0/);
+  assert.match(settingsSource, /let glossaryScopeGeneration = \$state\(0\)/);
   assert.match(settingsSource, /function isCurrentGlossaryRequest\(request: GlossarySaveRequest\)[\s\S]*request\.generation === glossaryScopeGeneration[\s\S]*request\.scopeId === glossaryScopeId[\s\S]*request\.draftGeneration === glossaryDraftGeneration/);
   assert.doesNotMatch(settingsSource, /else if \(!conflict && settings\)[\s\S]*glossaryDraft = glossarySourceForScope/);
 });
@@ -62,15 +62,14 @@ test("clean scopes follow persisted refreshes while dirty and newer drafts survi
   assert.match(settingsSource, /const previousStored = lastStoredGlossarySources\[currentScope\]/);
   assert.match(settingsSource, /glossaryDraft === previousStored/);
   assert.match(settingsSource, /lastStoredGlossarySources\[currentScope\] = currentStored/);
-  assert.match(settingsSource, /let glossaryDraftGeneration = 0/);
+  assert.match(settingsSource, /let glossaryDraftGeneration = \$state\(0\)/);
   assert.match(settingsSource, /glossaryDraftGeneration \+= 1/);
   assert.match(settingsSource, /draftGeneration: glossaryDraftGeneration/);
   assert.match(settingsSource, /let requestIsCurrent\s*=\s*[\s\S]*draftGeneration === glossaryDraftGeneration/);
-  assert.match(settingsSource, /if \(!requestIsCurrent\) return;/);
 });
 
 test("dictionary saves use the edit baseline and preserve concurrent conflicts", () => {
-  assert.match(settingsSource, /let glossaryEditBaseline: \{ scopeId: string; source: string; generation: number \} \| null = null/);
+  assert.match(settingsSource, /let glossaryEditBaseline: \{ scopeId: string; source: string; generation: number \} \| null = \$state\(null\)/);
   assert.match(settingsSource, /const editBaseline = glossaryEditBaseline/);
   assert.match(settingsSource, /editBaseline\.generation <= draftGeneration/);
   assert.match(settingsSource, /setInitialPrompt\(value, expectedSource\)/);
@@ -81,9 +80,7 @@ test("dictionary saves use the edit baseline and preserve concurrent conflicts",
   assert.match(settingsSource, /const conflict = saveError\.value\.startsWith\(dictionaryConflictPrefix\)/);
   assert.match(settingsSource, /glossaryEditBaseline === editBaseline/);
   assert.match(settingsSource, /glossaryEditBaseline = \{ \.\.\.editBaseline, source: value \}/);
-  assert.match(settingsSource, /if \(saved\) \{[\s\S]*glossaryEditBaseline = null;/);
   assert.match(settingsSource, /settingsError = saved \? "" : saveError\.value/);
-  assert.match(settingsSource, /if \(previousConflict\) \{[\s\S]*settingsError = ""/);
   assert.match(settingsSource, /This dictionary changed elsewhere\. Your draft is preserved[\s\S]*close and reopen Settings/);
   assert.match(settingsSource, /type RecoveredGlossaryDraft = \{ scopeId: string; draft: string; conflicted: boolean \}/);
   assert.match(settingsSource, /let recoveredGlossaryDrafts: RecoveredGlossaryDraft\[\] = \$state\(\[\]\)/);
@@ -100,15 +97,14 @@ test("late saves preserve scoped drafts without replacing newer scope state", ()
   assert.match(settingsSource, /else \{\s*rememberGlossaryRecovery\(request\.scopeId, request\.value, true\);/);
   assert.match(settingsSource, /function isCurrentGlossaryRequest\(request: GlossarySaveRequest\)/);
   assert.match(settingsSource, /requestIsCurrent = isCurrentGlossaryRequest\(request\);/);
-  assert.match(settingsSource, /if \(!requestIsCurrent\) return;/);
-  assert.match(settingsSource, /const previousConflict = glossaryConflictScopeId === previousScope/);
-  assert.match(settingsSource, /rememberGlossaryRecovery\(previousScope, glossaryDraft, previousConflict\)/);
   assert.match(settingsSource, /recoveredGlossaryDrafts as recovery \(recovery\.scopeId \+ "\\u0000" \+ recovery\.draft\)/);
 });
 
-test("clean unchanged blur does not invoke a dictionary save", () => {
-  assert.match(settingsSource, /if \(!editBaseline && value === \(lastStoredGlossarySources\[scopeId\] \?\? glossarySourceForScope\(scopeId\)\)\) return;/);
-  assert.match(settingsSource, /setProfileGlossary\(scopeId, value, expectedSource\), saveError, false/);
+test("dictionary edits use explicit Save and never persist from blur", () => {
+  assert.doesNotMatch(settingsSource, /onblur=\{onInitialPromptBlur\}/);
+  assert.match(settingsSource, /oninput=\{onGlossaryInput\}/);
+  assert.match(settingsSource, /onclick=\{\(\) => void saveGlossary\(\)\}/);
+  assert.match(settingsSource, /disabled=\{!glossaryHasUnsavedChanges\(\) \|\| glossarySaving\}/);
 });
 
 test("non-CAS dictionary failures retain the typed draft and baseline", () => {

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -2399,7 +2399,7 @@
 
   .dictionary-actions button:disabled,
   .dialog-actions button:disabled {
-    cursor: wait;
+    cursor: default;
     opacity: 0.6;
   }
 

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -68,7 +68,8 @@
   let settings: Settings | null = $state(null);
   let buildInfo: BuildInfo | null = $state(null);
   let models: WhisperModel[] = $state([]);
-  let activeTab: "dictate" | "transcribe" | "settings" = $state("dictate");
+  type SettingsTab = "dictate" | "transcribe" | "settings";
+  let activeTab: SettingsTab = $state("dictate");
   let downloading: string | null = $state(null);
   let downloadingName: string = $state("");
   let downloadProgress: number = $state(0);
@@ -158,7 +159,7 @@
     const errorListener = listen<string>("error", (event) => {
       revision++;
       testError = event.payload;
-      activeTab = "dictate";
+      requestTabChange("dictate");
     }).then(remember);
     const resultListener = listen<string>("transcription-result", (event) => {
       revision++;
@@ -223,10 +224,18 @@
   let glossaryScopeId: string = $state("");
   let glossaryDraft: string = $state("");
   let glossaryDraftInitialized = false;
-  let glossaryScopeGeneration = 0;
-  let glossaryDraftGeneration = 0;
+  let glossaryScopeGeneration = $state(0);
+  let glossaryDraftGeneration = $state(0);
   let lastStoredGlossarySources: Record<string, string> = {};
-  let glossaryEditBaseline: { scopeId: string; source: string; generation: number } | null = null;
+  let glossaryEditBaseline: { scopeId: string; source: string; generation: number } | null = $state(null);
+  let glossarySaving: boolean = $state(false);
+  let glossarySaveInFlight: Promise<boolean> | null = null;
+  type PendingGlossaryNavigation =
+    | { kind: "scope"; scopeId: string }
+    | { kind: "tab"; tab: SettingsTab; afterNavigate?: () => void };
+  let pendingGlossaryNavigation: PendingGlossaryNavigation | null = $state(null);
+  let glossaryDialogEl: HTMLDivElement | undefined = $state();
+  let glossaryReturnFocusEl: HTMLElement | null = null;
   type RecoveredGlossaryDraft = { scopeId: string; draft: string; conflicted: boolean };
   type GlossarySaveRequest = {
     scopeId: string;
@@ -238,6 +247,30 @@
   let glossaryConflictScopeId: string | null = $state(null);
 
   const dictionaryConflictPrefix = "Dictionary changed elsewhere:";
+
+  // The dictionary editor is intentionally local state. Settings reloads may
+  // update the saved source, but must never replace a draft that differs from
+  // the source we last saw for this scope.
+  function glossaryHasUnsavedChanges(): boolean {
+    if (glossarySaving) return true;
+    const baseline = glossaryEditBaseline;
+    const draftChanged = baseline?.scopeId === glossaryScopeId
+      && glossaryDraft !== baseline.source;
+    const conflict = glossaryConflictScopeId === glossaryScopeId
+      && settingsError.startsWith(dictionaryConflictPrefix);
+    return Boolean(draftChanged || conflict);
+  }
+
+  $effect(() => {
+    if (!pendingGlossaryNavigation || !glossaryDialogEl) return;
+    queueMicrotask(() => {
+      if (glossarySaving) {
+        glossaryDialogEl?.focus();
+      } else {
+        glossaryDialogEl?.querySelector<HTMLButtonElement>("[data-dialog-stay]")?.focus();
+      }
+    });
+  });
 
   function explicitProfiles(source: Settings | null = settings): HotkeyProfile[] {
     return source?.hotkey_profiles.filter((profile) => profile.language !== "auto") ?? [];
@@ -410,7 +443,7 @@
     listen("navigate_tab", (event: any) => {
       const t = event.payload;
       if (t === "dictate" || t === "transcribe" || t === "settings") {
-        activeTab = t;
+        requestTabChange(t);
       }
     });
 
@@ -423,8 +456,7 @@
         dragOver = false;
         const paths = event.payload.paths;
         if (paths.length > 0) {
-          activeTab = "transcribe";
-          handleFileTranscription(paths[0]);
+          requestTabChange("transcribe", () => handleFileTranscription(paths[0]));
         }
       } else {
         dragOver = false;
@@ -467,7 +499,7 @@
         const params = new URLSearchParams(window.location.search);
         const tab = params.get("tab");
         if (tab === "dictate" || tab === "transcribe" || tab === "settings") {
-          activeTab = tab;
+          requestTabChange(tab);
         }
       } catch (e: any) {
         initError = typeof e === "string" ? e : e?.message || "Failed to load settings.";
@@ -617,66 +649,81 @@
     }
   }
 
-  async function onInitialPromptBlur(e: Event) {
+  async function saveGlossary(): Promise<boolean> {
+    if (glossarySaveInFlight) return glossarySaveInFlight;
+
     const request: GlossarySaveRequest = {
       scopeId: glossaryScopeId,
       generation: glossaryScopeGeneration,
       draftGeneration: glossaryDraftGeneration,
-      value: (e.target as HTMLTextAreaElement).value,
+      value: glossaryDraft,
     };
     const scopeId = request.scopeId;
     const draftGeneration = request.draftGeneration;
-    const value = (e.target as HTMLTextAreaElement).value;
+    const value = request.value;
     const editBaseline = glossaryEditBaseline;
     const expectedSource = editBaseline?.scopeId === scopeId
       && editBaseline.generation <= draftGeneration
       ? editBaseline.source
       : lastStoredGlossarySources[scopeId] ?? glossarySourceForScope(scopeId);
-    glossaryDraft = value;
-    if (!settings || !isValidGlossaryScope(scopeId)) return;
-    if (!editBaseline && value === (lastStoredGlossarySources[scopeId] ?? glossarySourceForScope(scopeId))) return;
+
+    if (!settings || !isValidGlossaryScope(scopeId)) return false;
+    if (!glossaryHasUnsavedChanges()) {
+      if (glossaryEditBaseline?.scopeId === scopeId) glossaryEditBaseline = null;
+      return true;
+    }
 
     const saveError = { value: "" };
-    const saved = await applySetting(() => scopeId === ""
-      ? setInitialPrompt(value, expectedSource)
-      : setProfileGlossary(scopeId, value, expectedSource), saveError, false);
-    const conflict = saveError.value.startsWith(dictionaryConflictPrefix);
-    let requestIsCurrent = isCurrentGlossaryRequest(request);
-    if (conflict) {
-      await refreshDictionaryAfterConflict(saveError.value, request);
-      requestIsCurrent = isCurrentGlossaryRequest(request);
-    } else if (!saved && !requestIsCurrent) {
-      rememberGlossaryRecovery(scopeId, value);
-    }
+    const operation = (async (): Promise<boolean> => {
+      glossarySaving = true;
+      settingsError = "";
+      try {
+        const saved = await applySetting(() => scopeId === ""
+          ? setInitialPrompt(value, expectedSource)
+          : setProfileGlossary(scopeId, value, expectedSource), saveError, false);
+        const conflict = saveError.value.startsWith(dictionaryConflictPrefix);
+        let requestIsCurrent = isCurrentGlossaryRequest(request);
+        if (conflict) {
+          await refreshDictionaryAfterConflict(saveError.value, request);
+          requestIsCurrent = isCurrentGlossaryRequest(request);
+        } else if (!saved && !requestIsCurrent) {
+          rememberGlossaryRecovery(scopeId, value);
+        }
 
-    if (requestIsCurrent) {
-      settingsError = saved ? "" : saveError.value;
-      if (saved) glossaryConflictScopeId = null;
-    }
-    if (saved) removeGlossaryRecovery(scopeId, value);
+        if (requestIsCurrent) {
+          settingsError = saved ? "" : saveError.value;
+          if (saved) glossaryConflictScopeId = null;
+        }
+        if (saved) removeGlossaryRecovery(scopeId, value);
 
-    // If our own save won the CAS race while the user kept typing in the
-    // same edit lineage, advance only that lineage's baseline to our value.
-    // A reselected scope has a different baseline object and is never
-    // silently advanced from a fresh settings read.
-    if (
-      saved
-      && editBaseline
-      && glossaryEditBaseline === editBaseline
-      && editBaseline.scopeId === scopeId
-    ) {
-      if (draftGeneration === glossaryDraftGeneration) {
-        glossaryEditBaseline = null;
-      } else {
-        glossaryEditBaseline = { ...editBaseline, source: value };
+        // If our own save won the CAS race while the user kept typing in the
+        // same edit lineage, advance only that lineage's baseline to our
+        // value. A stale request never clears a newer draft.
+        if (
+          saved
+          && editBaseline
+          && glossaryEditBaseline === editBaseline
+          && editBaseline.scopeId === scopeId
+        ) {
+          if (draftGeneration === glossaryDraftGeneration) {
+            glossaryEditBaseline = null;
+          } else {
+            glossaryEditBaseline = { ...editBaseline, source: value };
+          }
+        }
+
+        // A scope removal/reload while the invoke was pending owns the
+        // textarea now; never navigate based on a stale request.
+        return saved && requestIsCurrent;
+      } finally {
+        glossarySaving = false;
       }
-    }
-
-    // A selector change while the invoke was pending owns the textarea now;
-    // never overwrite its newer scope with this request's result.
-    if (!requestIsCurrent) return;
-    if (saved) {
-      if (glossaryEditBaseline === editBaseline) glossaryEditBaseline = null;
+    })();
+    glossarySaveInFlight = operation;
+    try {
+      return await operation;
+    } finally {
+      if (glossarySaveInFlight === operation) glossarySaveInFlight = null;
     }
   }
 
@@ -692,27 +739,138 @@
     glossaryDraft = (e.target as HTMLTextAreaElement).value;
   }
 
-  function onGlossaryScopeChange(e: Event) {
-    const nextScope = (e.target as HTMLSelectElement).value;
-    if (!settings || !isValidGlossaryScope(nextScope)) return;
-    const previousScope = glossaryScopeId;
-    const previousConflict = glossaryConflictScopeId === previousScope
-      && settingsError.startsWith(dictionaryConflictPrefix);
-    if (
-      glossaryEditBaseline?.scopeId === previousScope
-      || previousConflict
-    ) {
-      rememberGlossaryRecovery(previousScope, glossaryDraft, previousConflict);
+  function discardGlossaryChanges(): void {
+    if (!settings || glossarySaving) return;
+    const currentSource = glossarySourceForScope(glossaryScopeId, settings);
+    glossaryDraftGeneration += 1;
+    glossaryDraft = currentSource;
+    glossaryDraftInitialized = true;
+    lastStoredGlossarySources[glossaryScopeId] = currentSource;
+    glossaryEditBaseline = null;
+    if (glossaryConflictScopeId === glossaryScopeId) {
+      glossaryConflictScopeId = null;
+      if (settingsError.startsWith(dictionaryConflictPrefix)) settingsError = "";
     }
+  }
+
+  function commitGlossaryScopeChange(nextScope: string): void {
+    if (!settings || !isValidGlossaryScope(nextScope)) return;
     glossaryScopeGeneration += 1;
     glossaryDraftGeneration += 1;
     glossaryEditBaseline = null;
-    if (previousConflict) {
-      settingsError = "";
-      glossaryConflictScopeId = null;
-    }
+    glossaryConflictScopeId = null;
+    settingsError = settingsError.startsWith(dictionaryConflictPrefix) ? "" : settingsError;
     glossaryScopeId = nextScope;
     glossaryDraft = glossarySourceForScope(nextScope, settings);
+    glossaryDraftInitialized = true;
+    lastStoredGlossarySources[nextScope] = glossaryDraft;
+  }
+
+  function onGlossaryScopeChange(e: Event) {
+    const nextScope = (e.target as HTMLSelectElement).value;
+    if (!settings || !isValidGlossaryScope(nextScope)) return;
+    if (nextScope === glossaryScopeId) return;
+    if (glossaryHasUnsavedChanges()) {
+      // The browser changes a select's displayed value before onchange fires.
+      // Restore the current scope until the user makes an explicit decision.
+      (e.currentTarget as HTMLSelectElement).value = glossaryScopeId;
+      promptGlossaryNavigation({ kind: "scope", scopeId: nextScope }, e.currentTarget as HTMLElement);
+      return;
+    }
+    commitGlossaryScopeChange(nextScope);
+  }
+
+  function promptGlossaryNavigation(
+    pending: PendingGlossaryNavigation,
+    returnFocusEl?: HTMLElement,
+  ): void {
+    const activeElement = returnFocusEl
+      ?? (typeof document === "undefined" ? null : document.activeElement);
+    glossaryReturnFocusEl = activeElement instanceof HTMLElement ? activeElement : null;
+    pendingGlossaryNavigation = pending;
+  }
+
+  function restoreGlossaryNavigationFocus(): void {
+    const returnFocusEl = glossaryReturnFocusEl;
+    glossaryReturnFocusEl = null;
+    queueMicrotask(() => {
+      if (returnFocusEl?.isConnected && !returnFocusEl.matches(":disabled")) {
+        returnFocusEl.focus();
+      }
+    });
+  }
+
+  function onGlossaryDialogKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!glossarySaving) stayOnGlossaryDraft();
+      return;
+    }
+    if (event.key !== "Tab") return;
+
+    const dialog = glossaryDialogEl;
+    if (!dialog) return;
+    const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(
+      "button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+    )).filter((element) => !element.matches(":disabled"));
+    event.preventDefault();
+    if (focusable.length === 0) {
+      dialog.focus();
+      return;
+    }
+
+    const activeElement = typeof document === "undefined" ? null : document.activeElement;
+    const activeIndex = activeElement ? focusable.indexOf(activeElement as HTMLElement) : -1;
+    const nextIndex = activeIndex < 0
+      ? (event.shiftKey ? focusable.length - 1 : 0)
+      : (activeIndex + (event.shiftKey ? -1 : 1) + focusable.length) % focusable.length;
+    focusable[nextIndex]?.focus();
+  }
+
+  function finishPendingGlossaryNavigation(pending: PendingGlossaryNavigation): void {
+    pendingGlossaryNavigation = null;
+    restoreGlossaryNavigationFocus();
+    if (pending.kind === "scope") {
+      commitGlossaryScopeChange(pending.scopeId);
+    } else {
+      activeTab = pending.tab;
+      pending.afterNavigate?.();
+    }
+  }
+
+  async function saveAndFinishGlossaryNavigation(): Promise<void> {
+    const pending = pendingGlossaryNavigation;
+    if (!pending || glossarySaving) return;
+    if (await saveGlossary() && pendingGlossaryNavigation === pending) {
+      finishPendingGlossaryNavigation(pending);
+    }
+  }
+
+  function discardAndFinishGlossaryNavigation(): void {
+    const pending = pendingGlossaryNavigation;
+    if (!pending || glossarySaving) return;
+    discardGlossaryChanges();
+    finishPendingGlossaryNavigation(pending);
+  }
+
+  function stayOnGlossaryDraft(): void {
+    pendingGlossaryNavigation = null;
+    restoreGlossaryNavigationFocus();
+  }
+
+  function requestTabChange(nextTab: SettingsTab, afterNavigate?: () => void): void {
+    if (nextTab === activeTab) {
+      afterNavigate?.();
+      return;
+    }
+    if (glossarySaving) return;
+    if (glossaryHasUnsavedChanges()) {
+      promptGlossaryNavigation({ kind: "tab", tab: nextTab, afterNavigate });
+      return;
+    }
+    activeTab = nextTab;
+    afterNavigate?.();
   }
 
   async function onBeamSizeChange(e: Event) {
@@ -1206,13 +1364,13 @@
   </header>
 
   <div class="tabs">
-    <button class="tab" class:active={activeTab === "dictate"} onclick={() => (activeTab = "dictate")}>
+    <button class="tab" class:active={activeTab === "dictate"} onclick={() => requestTabChange("dictate")}>
       Dictate
     </button>
-    <button class="tab" class:active={activeTab === "transcribe"} onclick={() => (activeTab = "transcribe")}>
+    <button class="tab" class:active={activeTab === "transcribe"} onclick={() => requestTabChange("transcribe")}>
       Transcribe
     </button>
-    <button class="tab" class:active={activeTab === "settings"} onclick={() => (activeTab = "settings")}>
+    <button class="tab" class:active={activeTab === "settings"} onclick={() => requestTabChange("settings")}>
       Settings
     </button>
   </div>
@@ -1382,7 +1540,7 @@
         </div>
 
       {:else if activeTab === "transcribe"}
-        <button class="active-config-bar" onclick={() => (activeTab = "settings")}>
+        <button class="active-config-bar" onclick={() => requestTabChange("settings")}>
           <div class="active-config-row">
             <span class="active-config-label">Language</span>
             <span class="active-config-value">{languageLabel(transcribeLanguage())}</span>
@@ -1511,8 +1669,13 @@
         </div>
 
         <div class="field">
-          <label for="initial-prompt">Personal dictionary</label>
-          <select id="dictionary-scope" value={glossaryScopeId} onchange={onGlossaryScopeChange}>
+          <div class="dictionary-heading">
+            <label for="initial-prompt">Personal dictionary</label>
+            {#if glossaryHasUnsavedChanges()}
+              <span class="unsaved-indicator" role="status">Unsaved changes</span>
+            {/if}
+          </div>
+          <select id="dictionary-scope" value={glossaryScopeId} onchange={onGlossaryScopeChange} disabled={glossarySaving}>
             <option value="">Global hints</option>
             {#each explicitProfiles() as profile (profile.id)}
               <option value={profile.id}>{profile.name} · {languageLabel(profile.language)}</option>
@@ -1523,17 +1686,31 @@
             class="initial-prompt-input"
             rows="5"
             value={glossaryDraft}
-            onblur={onInitialPromptBlur}
             oninput={onGlossaryInput}
+            disabled={glossarySaving}
             placeholder="OpenRouter = open router | open vrouter&#10;merge = merch&#10;Cloudflare = cloud flare"
           ></textarea>
+          <div class="dictionary-actions">
+            <button
+              type="button"
+              class="primary"
+              onclick={() => void saveGlossary()}
+              disabled={!glossaryHasUnsavedChanges() || glossarySaving}
+            >{glossarySaving ? "Saving…" : "Save changes"}</button>
+            <button
+              type="button"
+              class="secondary"
+              onclick={discardGlossaryChanges}
+              disabled={!glossaryHasUnsavedChanges() || glossarySaving}
+            >Discard changes</button>
+          </div>
           {#if glossaryScopeId === ""}
             <div class="hotkey-hint glossary-migration">
               Global entries are hint-only and remain stored. To enable deterministic alias replacements, copy an entry into the explicit-language profile that should use it.
             </div>
           {:else}
             <div class="hotkey-hint glossary-migration">
-              This explicit-language profile supplies deterministic aliases for its language. Leaving this field saves this profile only; switching scope never moves entries to another dictionary.
+              This explicit-language profile supplies deterministic aliases for its language. Save changes explicitly; switching scope never moves entries to another dictionary.
             </div>
           {/if}
           {#if glossaryConflictScopeId === glossaryScopeId && settingsError.startsWith(dictionaryConflictPrefix)}
@@ -1563,7 +1740,7 @@
           {/if}
           <div class="hotkey-hint">
             One preferred spelling per line. Add exact mishearings after <code>=</code>, separated by <code>|</code>.
-            Plain terms still guide Whisper. Saved automatically when you leave the field and used for live dictation and batch jobs.
+            Plain terms still guide Whisper. Save explicitly to use changes for live dictation and batch jobs.
           </div>
         </div>
 
@@ -1677,6 +1854,46 @@
       </div>
       <div class="download-status-track">
         <div class="download-status-fill" style="width: {downloadProgress}%"></div>
+      </div>
+    </div>
+  {/if}
+
+  {#if pendingGlossaryNavigation}
+    <div class="dialog-backdrop">
+      <div
+        class="unsaved-dialog"
+        bind:this={glossaryDialogEl}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="unsaved-dialog-title"
+        aria-describedby="unsaved-dialog-description"
+        tabindex="-1"
+        onkeydown={onGlossaryDialogKeydown}
+      >
+        <h2 id="unsaved-dialog-title">Unsaved dictionary changes</h2>
+        <p id="unsaved-dialog-description">
+          {pendingGlossaryNavigation.kind === "scope"
+            ? `Save changes before switching to ${glossaryScopeLabel(pendingGlossaryNavigation.scopeId)}?`
+            : "Save changes before leaving Settings?"}
+        </p>
+        {#if settingsError}
+          <div class="hotkey-error" role="alert">{settingsError}</div>
+        {/if}
+        <div class="dialog-actions">
+          <button
+            type="button"
+            class="primary"
+            onclick={() => void saveAndFinishGlossaryNavigation()}
+            disabled={glossarySaving}
+          >{glossarySaving ? "Saving…" : "Save"}</button>
+          <button
+            type="button"
+            class="danger"
+            onclick={discardAndFinishGlossaryNavigation}
+            disabled={glossarySaving}
+          >Discard</button>
+          <button type="button" class="secondary" data-dialog-stay onclick={stayOnGlossaryDraft} disabled={glossarySaving}>Stay</button>
+        </div>
       </div>
     </div>
   {/if}
@@ -2150,10 +2367,71 @@
     line-height: 1.5;
     resize: vertical;
     outline: none;
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .initial-prompt-input:focus {
     border-color: var(--accent);
+  }
+
+  .dictionary-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .unsaved-indicator {
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .dictionary-actions,
+  .dialog-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+  }
+
+  .dictionary-actions button:disabled,
+  .dialog-actions button:disabled {
+    cursor: wait;
+    opacity: 0.6;
+  }
+
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    background: color-mix(in srgb, var(--bg) 78%, transparent);
+  }
+
+  .unsaved-dialog {
+    width: min(100%, 420px);
+    padding: 20px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+  }
+
+  .unsaved-dialog h2 {
+    margin-bottom: 8px;
+    color: var(--text);
+    font-size: 15px;
+  }
+
+  .unsaved-dialog p {
+    color: var(--text-muted);
+    font-size: 13px;
   }
 
   .loading {


### PR DESCRIPTION
## Summary

Follow-up to manual R2 acceptance: make Personal dictionary an ordinary draft editor with explicit Save changes / Discard changes, an unsaved indicator, and Save / Discard / Stay before changing dictionary scope or tab. Preserve existing CAS conflict handling, scope isolation and draft recovery.

The modal traps keyboard focus and restores focus on exit. Text selection is explicitly enabled for the dictionary textarea. Typing and blur no longer persist changes.

Implemented once on latest main; existing R1–R4 artifacts remain unchanged. No backend, permissions, model data or stable release changes.

## Verification

- Frontend tests: 139 passed, 0 failed, 1 Windows-only skipped locally.
- Svelte check: 0 errors / 0 warnings.
- Production frontend build and diff checks pass.
- Isolated Chromium with synthetic Tauri IPC: caret insertion, no blur save, first-edit dirty indicator, save/discard, scope isolation, navigation decisions, failed-save retention, Tab/Shift+Tab trapping. No browser errors; screenshots visually inspected.
- Native test build and real-user acceptance pending.

## Review gate

Read-only Claude Fable review was attempted with tools/MCP/persistence disabled. Account session limit prevented inference (reset reported 12:00 Europe/Stockholm); no reviewer model ran and no approval is claimed. Keep this PR draft/unmerged until independent Claude review and all CI checks pass. Luna xhigh implementation/test leaves were conductor-checked, not a substitute for Claude approval.
