### PR TITLE
feat: simultaneous push-to-talk and toggle shortcuts per language

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,32 @@ automatically assigned a profile/language.
 The GUI and CLI watch and update the same files. Atomic writes preserve
 user-managed symlinks, so the files can be checked into a dotfiles repository.
 
+## Push-to-talk and toggle together
+
+Each language profile can have a push-to-talk shortcut, a toggle shortcut, or
+both. Hold the push-to-talk shortcut while speaking; release it to transcribe.
+Press and release the toggle shortcut to start, then press it again to finish.
+Only the shortcut that started the recording can finish it.
+
+For example, on macOS use Command+S and Command+E for Swedish and English
+push-to-talk, with Shift+Command+S and Shift+Command+E for toggle. A programmable
+button can send the appropriate toggle combination; configuring that device
+is separate from configuring Sagascript.
+
+Set these in Settings, or use `sagascript config profiles --help` and the
+`add`/`set` commands' `--push-to-talk-shortcut` and `--toggle-shortcut` options.
+Use `sagascript config profiles list` to find the profile IDs first.
+The CLI's `--clear-push-to-talk-shortcut` and `--clear-toggle-shortcut` options
+remove explicit bindings. Clearing both restores legacy shortcut behavior;
+it does not disable the profile.
+
+Existing profiles without explicit per-mode shortcuts retain their saved
+shortcut and legacy push/toggle behavior. Opening Settings does not migrate
+or save them. Once either per-mode shortcut is configured, those explicit
+bindings determine the behavior, independently of the legacy global mode.
+Presenter remains a separate mode: it uses the profile's primary shortcut
+to start and its dedicated Finish/Cancel shortcuts, not the toggle binding.
+
 ## Extended function-key shortcuts
 
 Bare F13–F24 shortcuts are supported on macOS and Windows. Ordinary keys and

--- a/scripts/test-profile-shortcuts.mjs
+++ b/scripts/test-profile-shortcuts.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  allProfileShortcutValues,
+  canonicalShortcut,
+  displayProfileShortcut,
+  profileWithShortcut,
+  suggestedProfileShortcuts,
+} from "../src/lib/profile-shortcuts.js";
+
+const legacyProfile = {
+  id: "en",
+  name: "English",
+  shortcut: "Control+Option+E",
+  language: "en",
+};
+
+test("legacy profiles display the old binding in the matching mode only", () => {
+  assert.equal(displayProfileShortcut(legacyProfile, "push_to_talk_shortcut", "push"), "Control+Option+E");
+  assert.equal(displayProfileShortcut(legacyProfile, "toggle_shortcut", "push"), "");
+  assert.equal(displayProfileShortcut(legacyProfile, "toggle_shortcut", "toggle"), "Control+Option+E");
+  assert.equal(legacyProfile.push_to_talk_shortcut, undefined, "display must not migrate or auto-save");
+
+  const toggleOnly = { ...legacyProfile, push_to_talk_shortcut: null, toggle_shortcut: "Super+T", shortcut: "Super+T" };
+  assert.equal(displayProfileShortcut(toggleOnly, "push_to_talk_shortcut", "push"), "");
+  assert.equal(displayProfileShortcut(toggleOnly, "toggle_shortcut", "push"), "Super+T");
+});
+
+test("explicit profile bindings replace legacy routing and keep the compatibility field synchronized", () => {
+  const withPush = profileWithShortcut(legacyProfile, "push_to_talk_shortcut", "Super+S");
+  assert.deepEqual(allProfileShortcutValues([withPush], "toggle"), ["Super+S"]);
+  assert.equal(withPush.shortcut, "Super+S");
+
+  const withBoth = profileWithShortcut(withPush, "toggle_shortcut", "Shift+Super+S");
+  assert.deepEqual(allProfileShortcutValues([withBoth], "push"), ["Super+S", "Shift+Super+S"]);
+  assert.deepEqual(allProfileShortcutValues([withBoth], "presenter"), ["Super+S"]);
+  assert.equal(withBoth.shortcut, "Super+S");
+
+  const cleared = profileWithShortcut(withBoth, "push_to_talk_shortcut", null);
+  assert.equal(cleared.shortcut, "Shift+Super+S");
+  assert.deepEqual(allProfileShortcutValues([cleared], "push"), ["Shift+Super+S"]);
+});
+
+test("adding a second explicit binding preserves the legacy slot and mode", () => {
+  const legacyPush = profileWithShortcut(legacyProfile, "toggle_shortcut", "Shift+Super+S", "push");
+  assert.equal(legacyPush.push_to_talk_shortcut, legacyProfile.shortcut);
+  assert.equal(legacyPush.toggle_shortcut, "Shift+Super+S");
+  assert.equal(legacyPush.shortcut, legacyProfile.shortcut);
+  assert.deepEqual(allProfileShortcutValues([legacyPush], "toggle"), [legacyProfile.shortcut, "Shift+Super+S"]);
+
+  const legacyToggle = profileWithShortcut(legacyProfile, "push_to_talk_shortcut", "Super+S", "toggle");
+  assert.equal(legacyToggle.toggle_shortcut, legacyProfile.shortcut);
+  assert.equal(legacyToggle.push_to_talk_shortcut, "Super+S");
+  assert.equal(legacyToggle.shortcut, "Super+S");
+});
+
+test("new profile suggestions avoid legacy and customized bindings", () => {
+  const existing = [
+    legacyProfile,
+    {
+      id: "sv",
+      name: "Swedish",
+      shortcut: "Super+S",
+      push_to_talk_shortcut: "Super+S",
+      toggle_shortcut: "Shift+Super+S",
+      language: "sv",
+    },
+  ];
+  const suggestion = suggestedProfileShortcuts(existing, "Control+Option+F12", "macos");
+  assert.equal(suggestion.push_to_talk_shortcut, "Super+E");
+  assert.equal(suggestion.toggle_shortcut, "Shift+Super+E");
+  assert.equal(suggestion.shortcut, "Super+E");
+  assert.equal(canonicalShortcut(suggestion.push_to_talk_shortcut), "super+keye");
+});
+
+test("suggestions use the Windows modifier spelling outside macOS", () => {
+  const suggestion = suggestedProfileShortcuts([], "Control+Option+Shift+F12", "windows");
+  assert.equal(suggestion.push_to_talk_shortcut, "Control+S");
+  assert.equal(suggestion.toggle_shortcut, "Control+Shift+S");
+});
+
+test("exhausted suggestions use null slots and normalize the untouched PTT slot", () => {
+  const occupied = [
+    { shortcut: "Super+S", push_to_talk_shortcut: "Super+S", toggle_shortcut: "Shift+Super+S" },
+    { shortcut: "Super+E", push_to_talk_shortcut: "Super+E", toggle_shortcut: "Shift+Super+E" },
+  ];
+  const suggestion = suggestedProfileShortcuts(occupied, "Control+Option+F12", "macos");
+  assert.equal(suggestion.push_to_talk_shortcut, null);
+  assert.equal(suggestion.toggle_shortcut, null);
+
+  const draft = profileWithShortcut(
+    { ...suggestion, id: "third", name: "Third", language: "en" },
+    "push_to_talk_shortcut",
+    "Super+N",
+  );
+  assert.equal(draft.push_to_talk_shortcut, "Super+N");
+  assert.equal(draft.toggle_shortcut, null);
+  assert.equal(draft.shortcut, "Super+N");
+});
+
+test("exhausted suggestions normalize the untouched toggle slot", () => {
+  const occupied = [
+    { shortcut: "Super+S", push_to_talk_shortcut: "Super+S", toggle_shortcut: "Shift+Super+S" },
+    { shortcut: "Super+E", push_to_talk_shortcut: "Super+E", toggle_shortcut: "Shift+Super+E" },
+  ];
+  const suggestion = suggestedProfileShortcuts(occupied, "Control+Option+F12", "macos");
+  const draft = profileWithShortcut(
+    { ...suggestion, id: "third", name: "Third", language: "en" },
+    "toggle_shortcut",
+    "Shift+Super+N",
+  );
+  assert.equal(draft.push_to_talk_shortcut, null);
+  assert.equal(draft.toggle_shortcut, "Shift+Super+N");
+  assert.equal(draft.shortcut, "Shift+Super+N");
+});

--- a/src-tauri/crates/sagascript-cli/src/config.rs
+++ b/src-tauri/crates/sagascript-cli/src/config.rs
@@ -138,22 +138,40 @@ pub enum ProfileAction {
     /// List all dictation profiles
     List,
     /// Create a dictation profile
+    #[command(alias = "add")]
     Create {
         id: String,
         #[arg(long)]
         name: String,
         #[arg(long)]
-        hotkey: String,
+        hotkey: Option<String>,
+        #[arg(long = "push-to-talk-shortcut", conflicts_with = "clear_push_to_talk_shortcut")]
+        push_to_talk_shortcut: Option<String>,
+        #[arg(long = "toggle-shortcut", conflicts_with = "clear_toggle_shortcut")]
+        toggle_shortcut: Option<String>,
+        #[arg(long = "clear-push-to-talk-shortcut")]
+        clear_push_to_talk_shortcut: bool,
+        #[arg(long = "clear-toggle-shortcut")]
+        clear_toggle_shortcut: bool,
         #[arg(long)]
         language: String,
     },
     /// Update a dictation profile
+    #[command(alias = "set")]
     Update {
         id: String,
         #[arg(long)]
         name: Option<String>,
         #[arg(long)]
         hotkey: Option<String>,
+        #[arg(long = "push-to-talk-shortcut", conflicts_with = "clear_push_to_talk_shortcut")]
+        push_to_talk_shortcut: Option<String>,
+        #[arg(long = "toggle-shortcut", conflicts_with = "clear_toggle_shortcut")]
+        toggle_shortcut: Option<String>,
+        #[arg(long = "clear-push-to-talk-shortcut")]
+        clear_push_to_talk_shortcut: bool,
+        #[arg(long = "clear-toggle-shortcut")]
+        clear_toggle_shortcut: bool,
         #[arg(long)]
         language: Option<String>,
     },
@@ -284,13 +302,15 @@ where
 fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
     match action {
         ProfileAction::List => {
-            println!("{:<16} {:<20} {:<28} LANGUAGE", "ID", "NAME", "HOTKEY");
+            println!("{:<16} {:<20} {:<28} {:<28} {:<28} LANGUAGE", "ID", "NAME", "LEGACY", "PUSH-TO-TALK", "TOGGLE");
             for profile in settings::store::load().resolved_hotkey_profiles() {
                 println!(
-                    "{:<16} {:<20} {:<28} {}",
+                    "{:<16} {:<20} {:<28} {:<28} {:<28} {}",
                     profile.id,
                     profile.name,
                     profile.shortcut,
+                    profile.push_to_talk_shortcut.as_deref().unwrap_or("-"),
+                    profile.toggle_shortcut.as_deref().unwrap_or("-"),
                     format_language(profile.language)
                 );
             }
@@ -300,10 +320,31 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             id,
             name,
             hotkey,
+            push_to_talk_shortcut,
+            toggle_shortcut,
+            clear_push_to_talk_shortcut,
+            clear_toggle_shortcut,
             language,
         } => {
             let language = parse_enum_value::<Language>(&language, "language")?;
-            let hotkey_warning = bare_extended_hotkey_warning(&hotkey);
+            if clear_push_to_talk_shortcut || clear_toggle_shortcut {
+                return Err(DictationError::SettingsError(
+                    "Clear shortcut options are only valid when updating a profile".to_string(),
+                ));
+            }
+            let shortcut = hotkey
+                .or_else(|| push_to_talk_shortcut.clone())
+                .or_else(|| toggle_shortcut.clone())
+                .ok_or_else(|| {
+                    DictationError::SettingsError(
+                        "Specify --hotkey or at least one explicit shortcut".to_string(),
+                    )
+                })?;
+            let hotkey_warnings = [
+                bare_extended_hotkey_warning(&shortcut),
+                push_to_talk_shortcut.as_deref().and_then(bare_extended_hotkey_warning),
+                toggle_shortcut.as_deref().and_then(bare_extended_hotkey_warning),
+            ];
             let mut profiles = settings::store::load().resolved_hotkey_profiles();
             if profiles.iter().any(|profile| profile.id == id) {
                 return Err(DictationError::SettingsError(format!(
@@ -313,12 +354,14 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             profiles.push(HotkeyProfile {
                 id: id.clone(),
                 name,
-                shortcut: hotkey,
+                shortcut,
                 language,
+                push_to_talk_shortcut,
+                toggle_shortcut,
             });
             persist_profiles(profiles)?;
             eprintln!("Created profile {id}");
-            if let Some(warning) = hotkey_warning {
+            for warning in hotkey_warnings.into_iter().flatten().collect::<std::collections::HashSet<_>>() {
                 eprintln!("Warning: {warning}");
             }
             Ok(())
@@ -327,14 +370,29 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
             id,
             name,
             hotkey,
+            push_to_talk_shortcut,
+            toggle_shortcut,
+            clear_push_to_talk_shortcut,
+            clear_toggle_shortcut,
             language,
         } => {
-            if name.is_none() && hotkey.is_none() && language.is_none() {
+            if name.is_none()
+                && hotkey.is_none()
+                && push_to_talk_shortcut.is_none()
+                && toggle_shortcut.is_none()
+                && !clear_push_to_talk_shortcut
+                && !clear_toggle_shortcut
+                && language.is_none()
+            {
                 return Err(DictationError::SettingsError(
-                    "Specify at least one of --name, --hotkey, or --language".to_string(),
+                    "Specify at least one profile field or shortcut option".to_string(),
                 ));
             }
-            let hotkey_warning = hotkey.as_deref().and_then(bare_extended_hotkey_warning);
+            let hotkey_warnings = [
+                hotkey.as_deref().and_then(bare_extended_hotkey_warning),
+                push_to_talk_shortcut.as_deref().and_then(bare_extended_hotkey_warning),
+                toggle_shortcut.as_deref().and_then(bare_extended_hotkey_warning),
+            ];
             let language = language
                 .as_deref()
                 .map(|value| parse_enum_value::<Language>(value, "language"))
@@ -348,14 +406,26 @@ fn cmd_profiles(action: ProfileAction) -> Result<(), DictationError> {
                 profile.name = name;
             }
             if let Some(hotkey) = hotkey {
-                profile.shortcut = hotkey;
+                profile.set_primary_shortcut(hotkey);
+            }
+            if clear_push_to_talk_shortcut {
+                profile.push_to_talk_shortcut = None;
+            }
+            if clear_toggle_shortcut {
+                profile.toggle_shortcut = None;
+            }
+            if let Some(shortcut) = push_to_talk_shortcut {
+                profile.push_to_talk_shortcut = Some(shortcut);
+            }
+            if let Some(shortcut) = toggle_shortcut {
+                profile.toggle_shortcut = Some(shortcut);
             }
             if let Some(language) = language {
                 profile.language = language;
             }
             persist_profiles(profiles)?;
             eprintln!("Updated profile {id}");
-            if let Some(warning) = hotkey_warning {
+            for warning in hotkey_warnings.into_iter().flatten().collect::<std::collections::HashSet<_>>() {
                 eprintln!("Warning: {warning}");
             }
             Ok(())
@@ -943,6 +1013,8 @@ mod tests {
             name: "Default".to_string(),
             shortcut: settings.hotkey.clone(),
             language: Language::Swedish,
+            push_to_talk_shortcut: None,
+            toggle_shortcut: None,
         }];
         settings
             .profile_glossaries
@@ -967,6 +1039,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "Option+Space".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };
@@ -1081,6 +1155,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "Option+Space".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };

--- a/src-tauri/crates/sagascript-cli/src/lib.rs
+++ b/src-tauri/crates/sagascript-cli/src/lib.rs
@@ -1310,13 +1310,68 @@ mod tests {
         ]).unwrap();
         match cli.command.unwrap() {
             Command::Config(args) => match args.action {
-                config::ConfigAction::Profiles { action: config::ProfileAction::Create { id, name, hotkey, language } } => {
+                config::ConfigAction::Profiles { action: config::ProfileAction::Create { id, name, hotkey, language, .. } } => {
                     assert_eq!(id, "swedish");
                     assert_eq!(name, "Swedish");
-                    assert_eq!(hotkey, "Option+Space");
+                    assert_eq!(hotkey.as_deref(), Some("Option+Space"));
                     assert_eq!(language, "sv");
                 }
                 _ => panic!("expected profile create"),
+            },
+            _ => panic!("expected Config"),
+        }
+    }
+
+    #[test]
+    fn parse_config_profile_add_explicit_shortcuts() {
+        let cli = Cli::try_parse_from([
+            "sagascript", "config", "profiles", "add", "swedish",
+            "--name", "Swedish", "--push-to-talk-shortcut", "Control+Shift+P",
+            "--toggle-shortcut", "Control+Shift+T", "--language", "sv",
+        ]).unwrap();
+        match cli.command.unwrap() {
+            Command::Config(args) => match args.action {
+                config::ConfigAction::Profiles {
+                    action: config::ProfileAction::Create {
+                        id,
+                        hotkey,
+                        push_to_talk_shortcut,
+                        toggle_shortcut,
+                        ..
+                    },
+                } => {
+                    assert_eq!(id, "swedish");
+                    assert!(hotkey.is_none());
+                    assert_eq!(push_to_talk_shortcut.as_deref(), Some("Control+Shift+P"));
+                    assert_eq!(toggle_shortcut.as_deref(), Some("Control+Shift+T"));
+                }
+                _ => panic!("expected profile add"),
+            },
+            _ => panic!("expected Config"),
+        }
+    }
+
+    #[test]
+    fn parse_config_profile_set_clear_explicit_shortcuts() {
+        let cli = Cli::try_parse_from([
+            "sagascript", "config", "profiles", "set", "swedish",
+            "--clear-push-to-talk-shortcut", "--clear-toggle-shortcut",
+        ]).unwrap();
+        match cli.command.unwrap() {
+            Command::Config(args) => match args.action {
+                config::ConfigAction::Profiles {
+                    action: config::ProfileAction::Update {
+                        id,
+                        clear_push_to_talk_shortcut,
+                        clear_toggle_shortcut,
+                        ..
+                    },
+                } => {
+                    assert_eq!(id, "swedish");
+                    assert!(clear_push_to_talk_shortcut);
+                    assert!(clear_toggle_shortcut);
+                }
+                _ => panic!("expected profile set"),
             },
             _ => panic!("expected Config"),
         }

--- a/src-tauri/crates/sagascript-cli/src/transcribe.rs
+++ b/src-tauri/crates/sagascript-cli/src/transcribe.rs
@@ -2724,12 +2724,16 @@ mod tests {
                     name: "Swedish".to_string(),
                     shortcut: "F13".to_string(),
                     language: Language::Swedish,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
                 HotkeyProfile {
                     id: "english".to_string(),
                     name: "English".to_string(),
                     shortcut: "F14".to_string(),
                     language: Language::English,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
             ],
             ..Default::default()
@@ -2757,6 +2761,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "F13".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };
@@ -2789,6 +2795,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "F13".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };

--- a/src-tauri/crates/sagascript-core/src/settings/manager.rs
+++ b/src-tauri/crates/sagascript-core/src/settings/manager.rs
@@ -525,6 +525,10 @@ pub struct HotkeyProfile {
     pub name: String,
     pub shortcut: String,
     pub language: Language,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub push_to_talk_shortcut: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub toggle_shortcut: Option<String>,
 }
 
 impl HotkeyProfile {
@@ -534,7 +538,20 @@ impl HotkeyProfile {
             name: "Default".to_string(),
             shortcut,
             language,
+            push_to_talk_shortcut: None,
+            toggle_shortcut: None,
         }
+    }
+
+    /// Update the compatibility shortcut and whichever explicit binding is
+    /// primary for this profile.
+    pub fn set_primary_shortcut(&mut self, shortcut: String) {
+        if self.push_to_talk_shortcut.is_some() {
+            self.push_to_talk_shortcut = Some(shortcut.clone());
+        } else if self.toggle_shortcut.is_some() {
+            self.toggle_shortcut = Some(shortcut.clone());
+        }
+        self.shortcut = shortcut;
     }
 }
 
@@ -660,14 +677,40 @@ impl Settings {
         }
     }
 
+    /// Return the profile bindings that should be registered at runtime.
+    /// Explicit push-to-talk/toggle bindings replace the legacy binding for a
+    /// profile. Presenter mode intentionally keeps the legacy one-binding
+    /// behavior for compatibility with its finish/cancel routing.
+    pub fn resolved_hotkey_bindings(&self) -> Vec<(HotkeyProfile, String, HotkeyMode)> {
+        self.resolved_hotkey_profiles()
+            .into_iter()
+            .flat_map(|profile| {
+                if self.hotkey_mode == HotkeyMode::Presenter {
+                    return vec![(profile.clone(), profile.shortcut.clone(), HotkeyMode::Presenter)];
+                }
+                let mut bindings = Vec::with_capacity(2);
+                if let Some(shortcut) = &profile.push_to_talk_shortcut {
+                    bindings.push((profile.clone(), shortcut.clone(), HotkeyMode::PushToTalk));
+                }
+                if let Some(shortcut) = &profile.toggle_shortcut {
+                    bindings.push((profile.clone(), shortcut.clone(), HotkeyMode::Toggle));
+                }
+                if bindings.is_empty() {
+                    bindings.push((profile.clone(), profile.shortcut.clone(), self.hotkey_mode));
+                }
+                bindings
+            })
+            .collect()
+    }
+
     /// Return all shortcuts that the active hotkey mode may register.
     /// Presenter finish/cancel shortcuts are intentionally omitted from the
     /// ordinary modes so opting into presenter behavior is explicit.
     pub fn resolved_shortcuts(&self) -> Vec<String> {
         let mut shortcuts = self
-            .resolved_hotkey_profiles()
+            .resolved_hotkey_bindings()
             .into_iter()
-            .map(|profile| profile.shortcut)
+            .map(|(_, shortcut, _)| shortcut)
             .collect::<Vec<_>>();
         if self.hotkey_mode == HotkeyMode::Presenter {
             shortcuts.push(self.presenter.finish_shortcut.clone());
@@ -702,9 +745,26 @@ impl Settings {
                 return Err(format!("Profile '{}' name must be 40 characters or fewer", profile.id));
             }
             validate_hotkey(&profile.shortcut)?;
-            let canonical = canonical_hotkey(&profile.shortcut)?;
-            if !shortcuts.insert(canonical) {
-                return Err(format!("Duplicate hotkey '{}'", profile.shortcut));
+            let has_explicit_bindings = profile.push_to_talk_shortcut.is_some() || profile.toggle_shortcut.is_some();
+            let active_shortcuts = if has_explicit_bindings {
+                profile
+                    .push_to_talk_shortcut
+                    .iter()
+                    .chain(profile.toggle_shortcut.iter())
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+            } else {
+                vec![profile.shortcut.as_str()]
+            };
+            for shortcut in active_shortcuts {
+                if shortcut.trim().is_empty() {
+                    return Err(format!("Profile '{}' has an empty hotkey", profile.id));
+                }
+                validate_hotkey(shortcut)?;
+                let canonical = canonical_hotkey(shortcut)?;
+                if !shortcuts.insert(canonical) {
+                    return Err(format!("Duplicate hotkey '{}'", shortcut));
+                }
             }
         }
         Ok(())
@@ -717,11 +777,15 @@ impl Settings {
         let profiles = self.resolved_hotkey_profiles();
         Self::validate_hotkey_profiles(&profiles)?;
         self.presenter.validate()?;
+        let mut shortcuts = self
+            .resolved_hotkey_bindings()
+            .into_iter()
+            .map(|(_, shortcut, _)| canonical_hotkey(&shortcut))
+            .collect::<Result<HashSet<_>, _>>()?;
+        if shortcuts.len() != self.resolved_hotkey_bindings().len() {
+            return Err("Duplicate hotkey bindings".to_string());
+        }
         if self.hotkey_mode == HotkeyMode::Presenter {
-            let mut shortcuts = profiles
-                .iter()
-                .map(|profile| canonical_hotkey(&profile.shortcut))
-                .collect::<Result<HashSet<_>, _>>()?;
             let finish = canonical_hotkey(&self.presenter.finish_shortcut)?;
             if !shortcuts.insert(finish) {
                 return Err("Presenter finish shortcut conflicts with a profile shortcut".to_string());
@@ -753,6 +817,16 @@ impl Settings {
     }
 
     pub fn replace_hotkey_profiles(&mut self, profiles: Vec<HotkeyProfile>) -> Result<(), String> {
+        let mut profiles = profiles;
+        for profile in &mut profiles {
+            if let Some(shortcut) = profile
+                .push_to_talk_shortcut
+                .as_ref()
+                .or(profile.toggle_shortcut.as_ref())
+            {
+                profile.shortcut = shortcut.clone();
+            }
+        }
         Self::validate_hotkey_profiles(&profiles)?;
         let current_profiles = self.resolved_hotkey_profiles();
         if let Some(profile) = profiles.iter().find(|profile| {
@@ -800,9 +874,10 @@ impl Settings {
 
     pub fn hotkey_profile_for_shortcut(&self, shortcut: &str) -> Option<HotkeyProfile> {
         let target = canonical_hotkey(shortcut).ok()?;
-        self.resolved_hotkey_profiles()
+        self.resolved_hotkey_bindings()
             .into_iter()
-            .find(|profile| canonical_hotkey(&profile.shortcut).ok().as_deref() == Some(target.as_str()))
+            .find(|(_, binding, _)| canonical_hotkey(binding).ok().as_deref() == Some(target.as_str()))
+            .map(|(profile, _, _)| profile)
     }
 
     pub fn set_legacy_language(&mut self, language: Language) -> Result<(), String> {
@@ -837,7 +912,7 @@ impl Settings {
         let mut candidate = self.clone();
         candidate.hotkey = shortcut.clone();
         if let Some(profile) = candidate.hotkey_profiles.iter_mut().find(|profile| profile.id == "default") {
-            profile.shortcut = shortcut;
+            profile.set_primary_shortcut(shortcut);
         }
         candidate.validate_shortcut_configuration()?;
         self.hotkey = candidate.hotkey;
@@ -1445,12 +1520,16 @@ mod tests {
                     name: "Swedish".to_string(),
                     shortcut: "Control+Shift+Space".to_string(),
                     language: Language::Swedish,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
                 HotkeyProfile {
                     id: "english".to_string(),
                     name: "English".to_string(),
                     shortcut: "Control+Option+Space".to_string(),
                     language: Language::English,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
             ],
             ..Default::default()
@@ -1483,12 +1562,16 @@ mod tests {
                     name: "Swedish".to_string(),
                     shortcut: "Control+Shift+Space".to_string(),
                     language: Language::Swedish,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
                 HotkeyProfile {
                     id: "english".to_string(),
                     name: "English".to_string(),
                     shortcut: "Control+Option+Space".to_string(),
                     language: Language::English,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
             ],
             ..Default::default()
@@ -1513,6 +1596,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "Control+Shift+Space".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };
@@ -1582,6 +1667,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "Control+Shift+Space".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };
@@ -1629,6 +1716,8 @@ mod tests {
                     name: "Reused".to_string(),
                     shortcut: "Control+Option+Space".to_string(),
                     language: Language::English,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
             ])
             .unwrap_err();
@@ -1658,6 +1747,8 @@ mod tests {
                     name: "Reused".to_string(),
                     shortcut: "Control+Option+Space".to_string(),
                     language: Language::English,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
             ])
             .unwrap();
@@ -1736,6 +1827,8 @@ mod tests {
                 name: "Swedish".to_string(),
                 shortcut: "Control+Shift+Space".to_string(),
                 language: Language::Swedish,
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
             }],
             ..Default::default()
         };
@@ -1805,6 +1898,8 @@ mod tests {
             name: id.to_string(),
             shortcut: shortcut.to_string(),
             language,
+            push_to_talk_shortcut: None,
+            toggle_shortcut: None,
         }
     }
 
@@ -1837,6 +1932,106 @@ mod tests {
             loaded.hotkey_profile_for_shortcut("Alt+Space").unwrap().id,
             "swedish"
         );
+    }
+
+    #[test]
+    fn legacy_profile_binding_uses_global_push_or_toggle_mode() {
+        let mut settings = Settings::default();
+        settings
+            .replace_hotkey_profiles(vec![profile("default", "Control+Shift+A", Language::English)])
+            .unwrap();
+
+        settings.hotkey_mode = HotkeyMode::PushToTalk;
+        assert_eq!(settings.resolved_hotkey_bindings()[0].1, "Control+Shift+A");
+        assert_eq!(settings.resolved_hotkey_bindings()[0].2, HotkeyMode::PushToTalk);
+
+        settings.hotkey_mode = HotkeyMode::Toggle;
+        assert_eq!(settings.resolved_hotkey_bindings()[0].2, HotkeyMode::Toggle);
+    }
+
+    #[test]
+    fn explicit_profile_bindings_resolve_both_modes_independent_of_global_mode() {
+        let mut explicit = profile("default", "Control+Shift+A", Language::English);
+        explicit.push_to_talk_shortcut = Some("Control+Shift+P".to_string());
+        explicit.toggle_shortcut = Some("Control+Shift+T".to_string());
+        let mut settings = Settings {
+            hotkey_mode: HotkeyMode::Toggle,
+            ..Settings::default()
+        };
+        settings.replace_hotkey_profiles(vec![explicit]).unwrap();
+
+        let bindings = settings.resolved_hotkey_bindings();
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(bindings[0].1, "Control+Shift+P");
+        assert_eq!(bindings[0].2, HotkeyMode::PushToTalk);
+        assert_eq!(bindings[1].1, "Control+Shift+T");
+        assert_eq!(bindings[1].2, HotkeyMode::Toggle);
+        assert_eq!(settings.resolved_shortcuts(), vec!["Control+Shift+P", "Control+Shift+T"]);
+        assert_eq!(settings.hotkey_profile_for_shortcut("control+shift+t").unwrap().id, "default");
+        assert_eq!(settings.hotkey_profiles[0].shortcut, "Control+Shift+P");
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let loaded: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.hotkey_profiles, settings.hotkey_profiles);
+        assert!(json.contains("push_to_talk_shortcut"));
+        assert!(json.contains("toggle_shortcut"));
+    }
+
+    #[test]
+    fn explicit_profile_bindings_reject_empty_or_canonical_duplicates() {
+        let mut empty = profile("default", "Control+Shift+E", Language::English);
+        empty.push_to_talk_shortcut = Some("  ".to_string());
+        assert!(Settings::validate_hotkey_profiles(&[empty]).is_err());
+
+        let mut first = profile("first", "Control+Shift+F", Language::English);
+        first.push_to_talk_shortcut = Some("Option+Shift+A".to_string());
+        let mut second = profile("second", "Control+Shift+G", Language::Swedish);
+        second.toggle_shortcut = Some("shift+alt+KeyA".to_string());
+        assert!(Settings::validate_hotkey_profiles(&[first, second]).is_err());
+    }
+
+    #[test]
+    fn explicit_bindings_allow_an_additional_modifier() {
+        let mut first = profile("first", "Control+Shift+P", Language::English);
+        first.push_to_talk_shortcut = Some("Control+Shift+A".to_string());
+        let mut second = profile("second", "Control+Shift+Q", Language::Swedish);
+        second.push_to_talk_shortcut = Some("Control+Option+Shift+A".to_string());
+        assert!(Settings::validate_hotkey_profiles(&[first, second]).is_ok());
+    }
+
+    #[test]
+    fn presenter_binding_ignores_explicit_shortcuts() {
+        let mut explicit = profile("default", "Control+Shift+P", Language::English);
+        explicit.push_to_talk_shortcut = Some("Control+Shift+Q".to_string());
+        explicit.toggle_shortcut = Some("Control+Shift+R".to_string());
+        let mut settings = Settings {
+            hotkey_mode: HotkeyMode::Presenter,
+            ..Settings::default()
+        };
+        settings.replace_hotkey_profiles(vec![explicit]).unwrap();
+
+        let bindings = settings.resolved_hotkey_bindings();
+        assert_eq!(bindings, vec![(settings.hotkey_profiles[0].clone(), "Control+Shift+Q".to_string(), HotkeyMode::Presenter)]);
+        assert_eq!(settings.resolved_shortcuts()[0], "Control+Shift+Q");
+    }
+
+    #[test]
+    fn legacy_hotkey_update_tracks_explicit_primary_binding() {
+        let mut push_to_talk = profile("default", "Control+Shift+P", Language::English);
+        push_to_talk.push_to_talk_shortcut = Some("Control+Shift+Q".to_string());
+        let mut settings = Settings::default();
+        settings.replace_hotkey_profiles(vec![push_to_talk]).unwrap();
+        settings.try_set_legacy_hotkey("Control+Shift+R".to_string()).unwrap();
+        assert_eq!(settings.hotkey, "Control+Shift+R");
+        assert_eq!(settings.hotkey_profiles[0].shortcut, "Control+Shift+R");
+        assert_eq!(settings.hotkey_profiles[0].push_to_talk_shortcut.as_deref(), Some("Control+Shift+R"));
+
+        let mut toggle = profile("default", "Control+Shift+P", Language::English);
+        toggle.toggle_shortcut = Some("Control+Shift+Q".to_string());
+        let mut settings = Settings::default();
+        settings.replace_hotkey_profiles(vec![toggle]).unwrap();
+        settings.try_set_legacy_hotkey("Control+Shift+R".to_string()).unwrap();
+        assert_eq!(settings.hotkey_profiles[0].toggle_shortcut.as_deref(), Some("Control+Shift+R"));
     }
 
     #[test]

--- a/src-tauri/src/app_controller.rs
+++ b/src-tauri/src/app_controller.rs
@@ -76,6 +76,12 @@ pub struct AppController {
     model_ready: bool,
     active_hotkey_profile: Option<HotkeyProfile>,
     active_hotkey_mode: Option<HotkeyMode>,
+    /// Canonical shortcut that initiated the active recording.  The profile's
+    /// legacy shortcut is not sufficient once one profile may expose both a
+    /// PTT and a toggle binding.
+    active_hotkey_shortcut: Option<String>,
+    toggle_stop_requested: bool,
+    toggle_key_down: bool,
     presenter_owned: bool,
     recording_generation: u64,
     hotkey_configuration_changing: bool,
@@ -110,6 +116,9 @@ impl AppController {
             model_ready: false,
             active_hotkey_profile: None,
             active_hotkey_mode: None,
+            active_hotkey_shortcut: None,
+            toggle_stop_requested: false,
+            toggle_key_down: false,
             presenter_owned: false,
             recording_generation: 0,
             hotkey_configuration_changing: false,
@@ -196,32 +205,66 @@ impl AppController {
         &mut self,
         profile: HotkeyProfile,
     ) -> Result<HotkeyDownResult, DictationError> {
+        let mode = self.session_hotkey_mode();
+        let shortcut = profile.shortcut.clone();
+        self.handle_hotkey_down_for_binding(profile, mode, &shortcut)
+    }
+
+    /// Handle a press for a resolved per-shortcut binding.
+    ///
+    /// The mode is deliberately supplied by the binding instead of read from
+    /// current settings.  This lets one profile expose both PTT and toggle
+    /// shortcuts, and freezes the initiating mode/shortcut for the recording's
+    /// lifetime.  A toggle stop is accepted only for the same profile and the
+    /// same initiating toggle shortcut; a PTT binding can never stop it.
+    pub fn handle_hotkey_down_for_binding(
+        &mut self,
+        profile: HotkeyProfile,
+        mode: HotkeyMode,
+        shortcut: &str,
+    ) -> Result<HotkeyDownResult, DictationError> {
         info!("Hotkey DOWN");
 
-        match self.session_hotkey_mode() {
+        match mode {
             HotkeyMode::PushToTalk => {
                 // Only report StartedRecording if we actually started. Holding
                 // PTT while a prior utterance is still Transcribing must be a
                 // no-op — otherwise the overlay/tray shows a recording that
                 // never happened and never hides (finding 1).
-                if self.start_recording_for_profile(profile)? {
+                if self.start_recording_for_binding(profile, mode, shortcut)? {
                     Ok(HotkeyDownResult::StartedRecording)
                 } else {
                     Ok(HotkeyDownResult::NoOp)
                 }
             }
             HotkeyMode::Toggle => {
+                // Keep the no-argument test/compatibility helper's legacy
+                // behavior when it models a recording without the frozen
+                // binding metadata that real starts always populate.
+                let legacy_toggle_recording = self.active_hotkey_mode.is_none()
+                    && self.active_hotkey_profile.is_none()
+                    && self.active_hotkey_shortcut.is_none();
                 if self.state.is_recording()
                     && !self.training_recording
+                    && (self.active_hotkey_mode == Some(HotkeyMode::Toggle)
+                        || legacy_toggle_recording)
+                    && !self.toggle_stop_requested
+                    && !self.toggle_key_down
                     && self
                         .active_hotkey_profile
                         .as_ref()
                         .map(|active| active.id == profile.id)
                         .unwrap_or(true)
+                    && (legacy_toggle_recording || self.active_shortcut_matches(shortcut))
                 {
+                    // Global shortcut backends can deliver duplicate Pressed
+                    // notifications while a key is held.  Latch the first
+                    // accepted stop until the terminal transition clears it.
+                    self.toggle_stop_requested = true;
                     Ok(HotkeyDownResult::StopRecording)
                 } else if self.state == AppState::Idle {
-                    if self.start_recording_for_profile(profile)? {
+                    if self.start_recording_for_binding(profile, mode, shortcut)? {
+                        self.toggle_key_down = true;
                         Ok(HotkeyDownResult::StartedRecording)
                     } else {
                         Ok(HotkeyDownResult::NoOp)
@@ -233,7 +276,7 @@ impl AppController {
             HotkeyMode::Presenter => {
                 // Atomic Start is never a toggle. Finish has its own action;
                 // repeated Start, training and in-flight transcription are no-ops.
-                if self.start_recording_for_profile(profile)? {
+                if self.start_recording_for_binding(profile, mode, shortcut)? {
                     Ok(HotkeyDownResult::StartedRecording)
                 } else {
                     Ok(HotkeyDownResult::NoOp)
@@ -271,6 +314,7 @@ impl AppController {
     pub fn use_safe_fallback_lifecycle(&mut self) {
         if self.state.is_recording() && !self.training_recording {
             self.active_hotkey_mode = Some(HotkeyMode::PushToTalk);
+            self.active_hotkey_shortcut = canonical_hotkey(crate::SAFE_FALLBACK_HOTKEY).ok();
             if let Some(profile) = &mut self.active_hotkey_profile {
                 profile.shortcut = crate::SAFE_FALLBACK_HOTKEY.to_string();
             }
@@ -313,13 +357,28 @@ impl AppController {
 
     pub fn should_stop_profile_on_key_up(&self, shortcut: &str) -> bool {
         self.should_stop_on_key_up()
-            && self
-                .active_hotkey_profile
-                .as_ref()
-                .and_then(|active| {
-                    Some(canonical_hotkey(&active.shortcut).ok()? == canonical_hotkey(shortcut).ok()?)
-                })
-                .unwrap_or(false)
+            && self.active_shortcut_matches(shortcut)
+    }
+
+    /// Record the physical release edge for toggle bindings.  Toggle presses
+    /// are edge-triggered: a repeated Pressed notification while the key is
+    /// still held must not be mistaken for the second user press.
+    pub fn note_hotkey_release(&mut self, shortcut: &str) {
+        if self.active_hotkey_mode == Some(HotkeyMode::Toggle)
+            && self.active_shortcut_matches(shortcut)
+        {
+            self.toggle_key_down = false;
+        }
+    }
+
+    fn active_shortcut_matches(&self, shortcut: &str) -> bool {
+        let active = self
+            .active_hotkey_shortcut
+            .as_deref()
+            .or_else(|| self.active_hotkey_profile.as_ref().map(|profile| profile.shortcut.as_str()));
+        active
+            .and_then(|active| Some(canonical_hotkey(active).ok()? == canonical_hotkey(shortcut).ok()?))
+            .unwrap_or(false)
     }
 
     /// Start audio recording.
@@ -346,6 +405,17 @@ impl AppController {
         self.start_recording_for_profile_with_capture(profile, |audio| audio.start_capture())
     }
 
+    fn start_recording_for_binding(
+        &mut self,
+        profile: HotkeyProfile,
+        mode: HotkeyMode,
+        shortcut: &str,
+    ) -> Result<bool, DictationError> {
+        self.start_recording_for_binding_with_capture(profile, mode, shortcut, |audio| {
+            audio.start_capture()
+        })
+    }
+
     /// Start recording using the supplied capture operation.
     ///
     /// The injected capture operation keeps the startup transition testable
@@ -355,6 +425,21 @@ impl AppController {
     fn start_recording_for_profile_with_capture<F>(
         &mut self,
         profile: HotkeyProfile,
+        start_capture: F,
+    ) -> Result<bool, DictationError>
+    where
+        F: FnOnce(&mut AudioCaptureService) -> Result<(), DictationError>,
+    {
+        let mode = self.settings.hotkey_mode;
+        let shortcut = profile.shortcut.clone();
+        self.start_recording_for_binding_with_capture(profile, mode, &shortcut, start_capture)
+    }
+
+    fn start_recording_for_binding_with_capture<F>(
+        &mut self,
+        profile: HotkeyProfile,
+        mode: HotkeyMode,
+        shortcut: &str,
         start_capture: F,
     ) -> Result<bool, DictationError>
     where
@@ -401,7 +486,10 @@ impl AppController {
         );
         self.active_hotkey_profile = Some(profile);
         self.recording_generation = next_generation;
-        self.active_hotkey_mode = Some(self.settings.hotkey_mode);
+        self.active_hotkey_mode = Some(mode);
+        self.active_hotkey_shortcut = canonical_hotkey(shortcut).ok();
+        self.toggle_stop_requested = false;
+        self.toggle_key_down = false;
         self.presenter_owned = false;
         self.training_recording = false;
         self.state = AppState::Recording;
@@ -538,6 +626,9 @@ impl AppController {
         self.audio.clear_last_captured();
         self.state = AppState::Idle;
         self.active_hotkey_profile = None;
+        self.active_hotkey_shortcut = None;
+        self.toggle_stop_requested = false;
+        self.toggle_key_down = false;
         self.training_recording = false;
         self.logging.end_dictation_session();
     }
@@ -550,6 +641,9 @@ impl AppController {
         self.audio.clear_last_captured();
         self.state = AppState::Idle;
         self.active_hotkey_profile = None;
+        self.active_hotkey_shortcut = None;
+        self.toggle_stop_requested = false;
+        self.toggle_key_down = false;
         self.training_recording = false;
         self.logging.log(
             "info",
@@ -576,6 +670,9 @@ impl AppController {
         self.last_error = Some(error.to_string());
         self.state = AppState::Idle;
         self.active_hotkey_profile = None;
+        self.active_hotkey_shortcut = None;
+        self.toggle_stop_requested = false;
+        self.toggle_key_down = false;
         self.training_recording = false;
         self.logging.end_dictation_session();
     }
@@ -622,6 +719,9 @@ impl AppController {
         self.state = AppState::Idle;
         self.active_hotkey_profile = None;
         self.active_hotkey_mode = None;
+        self.active_hotkey_shortcut = None;
+        self.toggle_stop_requested = false;
+        self.toggle_key_down = false;
         self.training_recording = false;
         self.logging.end_dictation_session();
     }
@@ -1218,8 +1318,8 @@ mod tests {
     fn active_profile_freezes_language_and_release_identity() {
         let mut ctrl = default_controller();
         let profiles = vec![
-            HotkeyProfile { id: "default".into(), name: "English".into(), shortcut: "Control+Shift+E".into(), language: sagascript_core::settings::Language::English },
-            HotkeyProfile { id: "swedish".into(), name: "Swedish".into(), shortcut: "Option+Space".into(), language: sagascript_core::settings::Language::Swedish },
+            HotkeyProfile { id: "default".into(), name: "English".into(), shortcut: "Control+Shift+E".into(), language: sagascript_core::settings::Language::English, push_to_talk_shortcut: None, toggle_shortcut: None },
+            HotkeyProfile { id: "swedish".into(), name: "Swedish".into(), shortcut: "Option+Space".into(), language: sagascript_core::settings::Language::Swedish, push_to_talk_shortcut: None, toggle_shortcut: None },
         ];
         ctrl.settings_mut().replace_hotkey_profiles(profiles.clone()).unwrap();
         ctrl.settings_mut().hotkey_mode = HotkeyMode::PushToTalk;
@@ -1236,10 +1336,67 @@ mod tests {
         let mut ctrl = default_controller();
         ctrl.settings_mut().hotkey_mode = HotkeyMode::Toggle;
         ctrl.state = AppState::Recording;
-        ctrl.active_hotkey_profile = Some(HotkeyProfile { id: "english".into(), name: "English".into(), shortcut: "Control+Shift+E".into(), language: sagascript_core::settings::Language::English });
-        let swedish = HotkeyProfile { id: "swedish".into(), name: "Swedish".into(), shortcut: "Option+Space".into(), language: sagascript_core::settings::Language::Swedish };
+        ctrl.active_hotkey_profile = Some(HotkeyProfile { id: "english".into(), name: "English".into(), shortcut: "Control+Shift+E".into(), language: sagascript_core::settings::Language::English, push_to_talk_shortcut: None, toggle_shortcut: None });
+        let swedish = HotkeyProfile { id: "swedish".into(), name: "Swedish".into(), shortcut: "Option+Space".into(), language: sagascript_core::settings::Language::Swedish, push_to_talk_shortcut: None, toggle_shortcut: None };
 
         assert_eq!(ctrl.handle_hotkey_down_for_profile(swedish).unwrap(), HotkeyDownResult::NoOp);
+    }
+
+    #[test]
+    fn explicit_ptt_and_toggle_bindings_do_not_stop_each_other() {
+        let mut ctrl = default_controller();
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_profile = Some(profile.clone());
+        ctrl.active_hotkey_mode = Some(HotkeyMode::PushToTalk);
+        ctrl.active_hotkey_shortcut = canonical_hotkey("Super+S").ok();
+
+        assert_eq!(
+            ctrl.handle_hotkey_down_for_binding(profile, HotkeyMode::Toggle, "Super+Shift+S")
+                .unwrap(),
+            HotkeyDownResult::NoOp
+        );
+    }
+
+    #[test]
+    fn toggle_requires_release_edge_and_latches_stop_request() {
+        let mut ctrl = default_controller();
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_profile = Some(profile.clone());
+        ctrl.active_hotkey_mode = Some(HotkeyMode::Toggle);
+        ctrl.active_hotkey_shortcut = canonical_hotkey("Super+S").ok();
+        ctrl.toggle_key_down = true;
+
+        assert_eq!(
+            ctrl.handle_hotkey_down_for_binding(profile.clone(), HotkeyMode::Toggle, "Super+S")
+                .unwrap(),
+            HotkeyDownResult::NoOp
+        );
+        ctrl.note_hotkey_release("Super+S");
+        assert_eq!(
+            ctrl.handle_hotkey_down_for_binding(profile.clone(), HotkeyMode::Toggle, "Super+S")
+                .unwrap(),
+            HotkeyDownResult::StopRecording
+        );
+        assert_eq!(
+            ctrl.handle_hotkey_down_for_binding(profile, HotkeyMode::Toggle, "Super+S")
+                .unwrap(),
+            HotkeyDownResult::NoOp
+        );
+    }
+
+    #[test]
+    fn ptt_release_uses_frozen_binding_shortcut() {
+        let mut ctrl = default_controller();
+        let profile = ctrl.settings().resolved_hotkey_profiles()[0].clone();
+        ctrl.state = AppState::Recording;
+        ctrl.active_hotkey_profile = Some(profile);
+        ctrl.active_hotkey_mode = Some(HotkeyMode::PushToTalk);
+        ctrl.active_hotkey_shortcut = canonical_hotkey("Super+S").ok();
+
+        assert!(ctrl.should_stop_profile_on_key_up("Super+S"));
+        assert!(!ctrl.should_stop_profile_on_key_up("Control+Shift+Space"));
     }
 
     #[test]
@@ -1253,12 +1410,16 @@ mod tests {
                     name: "Swedish".into(),
                     shortcut: "Control+Shift+Space".into(),
                     language: sagascript_core::settings::Language::Swedish,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
                 HotkeyProfile {
                     id: "english".into(),
                     name: "English".into(),
                     shortcut: "Alt+E".into(),
                     language: sagascript_core::settings::Language::English,
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                 },
             ],
             ..Default::default()

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -153,12 +153,16 @@ mod glossary_options_tests {
                     id: "svenska".to_string(),
                     name: "Svenska".to_string(),
                     shortcut: "Control+Shift+Space".to_string(),
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                     language: Language::Swedish,
                 },
                 HotkeyProfile {
                     id: "english".to_string(),
                     name: "English".to_string(),
                     shortcut: "Control+Option+Space".to_string(),
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                     language: Language::English,
                 },
             ],
@@ -226,18 +230,24 @@ mod glossary_options_tests {
                     id: "swedish".into(),
                     name: "Swedish".into(),
                     shortcut: "Super+S".into(),
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                     language: Language::Swedish,
                 },
                 HotkeyProfile {
                     id: "english".into(),
                     name: "English".into(),
                     shortcut: "Super+E".into(),
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                     language: Language::English,
                 },
                 HotkeyProfile {
                     id: "automatic".into(),
                     name: "Automatic".into(),
                     shortcut: "Super+A".into(),
+                    push_to_talk_shortcut: None,
+                    toggle_shortcut: None,
                     language: Language::Auto,
                 },
             ],
@@ -522,7 +532,7 @@ pub async fn set_hotkey(
         .iter()
         .position(|profile| profile.id == "default")
         .unwrap_or(0);
-    profiles[profile_index].shortcut = shortcut;
+    profiles[profile_index].set_primary_shortcut(shortcut);
     set_hotkey_profiles(app, controller, health, profiles).await
 }
 
@@ -1483,6 +1493,8 @@ mod dictionary_compare_and_set_tests {
                 id: "english".to_string(),
                 name: "English".to_string(),
                 shortcut: "Option+Space".to_string(),
+                push_to_talk_shortcut: None,
+                toggle_shortcut: None,
                 language: Language::English,
             }],
             ..Settings::default()

--- a/src-tauri/src/hotkey/configuration.rs
+++ b/src-tauri/src/hotkey/configuration.rs
@@ -78,4 +78,33 @@ mod tests {
         assert!(HotkeyChange::Presenter(config).prepare(&settings).is_err());
         assert!(HotkeyChange::Profiles(Vec::new()).prepare(&settings).is_err());
     }
+
+    #[test]
+    fn dual_binding_profile_change_registers_and_persists_both_shortcuts() {
+        let settings = Settings::default();
+        let mut profiles = settings.resolved_hotkey_profiles();
+        profiles[0].push_to_talk_shortcut = Some("Super+S".into());
+        profiles[0].toggle_shortcut = Some("Super+Shift+S".into());
+        let change = HotkeyChange::Profiles(profiles);
+        let registered = change.prepare(&settings).unwrap().resolved_shortcuts();
+        assert_eq!(registered, vec!["Super+S", "Super+Shift+S"]);
+        let mut fresh = settings;
+        fresh.show_overlay = false;
+        change.apply_registered(&mut fresh, &registered).unwrap();
+        assert!(!fresh.show_overlay);
+        assert_eq!(fresh.hotkey, "Super+S");
+        assert_eq!(fresh.resolved_hotkey_bindings().len(), 2);
+    }
+
+    #[test]
+    fn incomplete_dual_binding_registration_cannot_be_persisted() {
+        let settings = Settings::default();
+        let mut profiles = settings.resolved_hotkey_profiles();
+        profiles[0].push_to_talk_shortcut = Some("Super+S".into());
+        profiles[0].toggle_shortcut = Some("Super+Shift+S".into());
+        let change = HotkeyChange::Profiles(profiles);
+        let mut fresh = settings.clone();
+        assert!(change.apply_registered(&mut fresh, &["Super+S".into()]).is_err());
+        assert_eq!(fresh.resolved_hotkey_profiles(), settings.resolved_hotkey_profiles());
+    }
 }

--- a/src-tauri/src/hotkey/presenter_routing.rs
+++ b/src-tauri/src/hotkey/presenter_routing.rs
@@ -66,6 +66,8 @@ mod tests {
             name: id.to_string(),
             shortcut: shortcut.to_string(),
             language,
+            push_to_talk_shortcut: None,
+            toggle_shortcut: None,
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -57,6 +57,7 @@ use app_controller::{AppController, HotkeyDownResult, StopRecordingOutcome};
 use commands::{SharedController, SharedWhisper};
 use sagascript_core::settings::HotkeyProfile;
 use sagascript_core::settings::HotkeyMode;
+use sagascript_core::settings::canonical_hotkey;
 #[cfg(test)]
 use sagascript_core::settings::{validate_hotkey, Language};
 use sagascript_core::transcription::{
@@ -458,15 +459,24 @@ fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::Ba
             }
             let (result, active_profile) = {
                 let mut c = ctrl.lock().unwrap();
-                let profile = c
+                let binding = c
                     .settings()
-                    .hotkey_profile_for_shortcut(shortcut)
-                    .or_else(|| {
-                        safe_fallback
-                            .then(|| c.settings().resolved_hotkey_profiles()[0].clone())
+                    .resolved_hotkey_bindings()
+                    .into_iter()
+                    .find(|(_, configured, _)| {
+                        canonical_hotkey(configured).ok() == canonical_hotkey(shortcut).ok()
                     });
-                let result = match profile {
-                    Some(profile) => match c.handle_hotkey_down_for_profile(profile) {
+                let result = match binding {
+                    Some((profile, configured_shortcut, mode)) => {
+                        // A failed operational configuration always uses the
+                        // dedicated fallback as PTT, even if the persisted
+                        // shortcut happens to be an explicit toggle binding.
+                        let (mode, shortcut) = if safe_fallback {
+                            (HotkeyMode::PushToTalk, SAFE_FALLBACK_HOTKEY)
+                        } else {
+                            (mode, configured_shortcut.as_str())
+                        };
+                        match c.handle_hotkey_down_for_binding(profile, mode, shortcut) {
                         Ok(result) => {
                             if safe_fallback && result == HotkeyDownResult::StartedRecording {
                                 c.use_safe_fallback_lifecycle();
@@ -478,7 +488,28 @@ fn handle_hotkey_event(app: &tauri::AppHandle, shortcut: &str, state: hotkey::Ba
                             let _ = app.emit(events::event::ERROR, error.to_string());
                             HotkeyDownResult::NoOp
                         }
-                    },
+                        }
+                    }
+                    None if safe_fallback => {
+                        let profile = c.settings().resolved_hotkey_profiles()[0].clone();
+                        match c.handle_hotkey_down_for_binding(
+                            profile,
+                            HotkeyMode::PushToTalk,
+                            SAFE_FALLBACK_HOTKEY,
+                        ) {
+                            Ok(result) => {
+                                if result == HotkeyDownResult::StartedRecording {
+                                    c.use_safe_fallback_lifecycle();
+                                }
+                                result
+                            }
+                            Err(error) => {
+                                error!("Hotkey down error: {error}");
+                                let _ = app.emit(events::event::ERROR, error.to_string());
+                                HotkeyDownResult::NoOp
+                            }
+                        }
+                    }
                     None => {
                         warn!("Ignoring unconfigured shortcut event: {shortcut}");
                         HotkeyDownResult::NoOp
@@ -1526,8 +1557,10 @@ fn handle_hotkey_release(
     shortcut: &str,
 ) {
     let should_stop = {
-        let c = ctrl.lock().unwrap();
-        c.should_stop_profile_on_key_up(shortcut)
+        let mut c = ctrl.lock().unwrap();
+        let should_stop = c.should_stop_profile_on_key_up(shortcut);
+        c.note_hotkey_release(shortcut);
+        should_stop
     };
 
     if !should_stop {
@@ -2784,6 +2817,8 @@ mod tests {
             name: "Svenska".to_string(),
             shortcut: "Super+Shift+S".to_string(),
             language: Language::Swedish,
+            push_to_talk_shortcut: None,
+            toggle_shortcut: None,
         };
 
         assert_eq!(
@@ -2803,6 +2838,8 @@ mod tests {
             name: "English".to_string(),
             shortcut: "Control+Alt+Space".to_string(),
             language: Language::English,
+            push_to_talk_shortcut: None,
+            toggle_shortcut: None,
         };
 
         assert_eq!(

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -64,6 +64,13 @@
     supportedBareFunctionKeyRange,
     tauriKeyName,
   } from "./hotkey.js";
+  import {
+    allProfileShortcutValues,
+    displayProfileShortcut,
+    profileShortcutValues,
+    profileWithShortcut,
+    suggestedProfileShortcuts,
+  } from "./profile-shortcuts.js";
 
   let settings: Settings | null = $state(null);
   let buildInfo: BuildInfo | null = $state(null);
@@ -93,6 +100,13 @@
 
   // Hotkey recorder state
   let recordingProfileId: string | null = $state(null);
+  type ExplicitShortcutSlot = "push_to_talk_shortcut" | "toggle_shortcut";
+  type ShortcutSlot = ExplicitShortcutSlot | "presenter_shortcut";
+  const shortcutControls: { slot: ExplicitShortcutSlot; label: string }[] = [
+    { slot: "push_to_talk_shortcut", label: "Push to talk" },
+    { slot: "toggle_shortcut", label: "Toggle" },
+  ];
+  let recordingShortcutSlot: ShortcutSlot | null = $state(null);
   let hotkeyCaptureGeneration = 0;
   let draftProfileId: string | null = $state(null);
   let hotkeyError: string = $state("");
@@ -107,7 +121,7 @@
   let hotkeyStatusError: string = $state("");
 
   $effect(() => {
-    if (recordingProfileId && hotkeyRecorderEl) hotkeyRecorderEl.focus();
+    if (recordingProfileId && recordingShortcutSlot && hotkeyRecorderEl) hotkeyRecorderEl.focus();
   });
 
   // Dictate test state
@@ -544,6 +558,17 @@
 
   async function onHotkeyModeChange(e: Event) {
     const value = (e.target as HTMLSelectElement).value as HotkeyMode;
+    // Freeze legacy routing before leaving ordinary mode, including across
+    // restarts while Presenter is selected. This does not change its bindings.
+    if (value === "presenter" && settings && settings.hotkey_mode !== "presenter") {
+      const mode = settings.hotkey_mode;
+      const profiles = settings.hotkey_profiles.map((profile) =>
+        profile.push_to_talk_shortcut || profile.toggle_shortcut
+          ? profile
+          : profileWithShortcut(profile, mode === "toggle" ? "toggle_shortcut" : "push_to_talk_shortcut", profile.shortcut, mode)
+      );
+      if (!(await applySetting(() => setHotkeyProfiles(profiles)))) return;
+    }
     await applySetting(() => setHotkeyMode(value));
   }
 
@@ -608,7 +633,7 @@
     if (!settings) return false;
     const shortcuts = [
       settings.hotkey,
-      ...settings.hotkey_profiles.map((profile) => profile.shortcut),
+      ...allProfileShortcutValues(settings.hotkey_profiles, settings.hotkey_mode),
     ];
     return shortcuts.some((shortcut) => canUseBareHotkey(shortcut, platform));
   }
@@ -1201,13 +1226,14 @@
     return formatShortcutDisplay(shortcut, platform);
   }
 
-  function beginHotkeyCapture(profileId: string) {
+  function beginHotkeyCapture(profileId: string, slot: ShortcutSlot) {
     hotkeyCaptureGeneration += 1;
     recordingProfileId = profileId;
+    recordingShortcutSlot = slot;
     hotkeyError = "";
   }
 
-  async function onHotkeyKeydown(e: KeyboardEvent, profileId: string) {
+  async function onHotkeyKeydown(e: KeyboardEvent, profileId: string, slot: ShortcutSlot) {
     const captureGeneration = hotkeyCaptureGeneration;
     e.preventDefault();
     e.stopPropagation();
@@ -1216,6 +1242,7 @@
     if (e.key === "Escape") {
       hotkeyCaptureGeneration += 1;
       recordingProfileId = null;
+      recordingShortcutSlot = null;
       hotkeyError = "";
       return;
     }
@@ -1279,19 +1306,45 @@
     const shortcut = parts.join("+");
     hotkeyError = "";
 
-    if (!settings) return;
-    const profiles = settings.hotkey_profiles.map((profile) =>
-      profile.id === profileId ? { ...profile, shortcut } : profile
+    const currentSettings = settings;
+    if (!currentSettings) return;
+    const profiles = currentSettings.hotkey_profiles.map((profile) =>
+      profile.id === profileId
+        ? slot === "presenter_shortcut"
+          ? profile.push_to_talk_shortcut || profile.toggle_shortcut
+            ? profileWithShortcut(profile, profile.push_to_talk_shortcut ? "push_to_talk_shortcut" : "toggle_shortcut", shortcut, "presenter")
+            : { ...profile, shortcut }
+          : profileWithShortcut(profile, slot, shortcut, currentSettings.hotkey_mode)
+        : profile
     );
     setHotkeyProfiles(profiles)
       .then(async () => {
         recordingProfileId = null;
+        recordingShortcutSlot = null;
         draftProfileId = null;
         settings = await getSettings();
+        await refreshProfileModels(settings.hotkey_profiles);
       })
       .catch((err: any) => {
         hotkeyError = typeof err === "string" ? err : err.message || "Failed to set hotkey";
       });
+  }
+
+  async function clearProfileShortcut(profileId: string, slot: ExplicitShortcutSlot) {
+    const currentSettings = settings;
+    if (!currentSettings) return;
+    const profile = currentSettings.hotkey_profiles.find((candidate) => candidate.id === profileId);
+    if (!profile || !profile.push_to_talk_shortcut || !profile.toggle_shortcut) return;
+    const profiles = currentSettings.hotkey_profiles.map((candidate) =>
+      candidate.id === profileId ? profileWithShortcut(candidate, slot, null, currentSettings.hotkey_mode) : candidate
+    );
+    if (profileId === draftProfileId) {
+      settings = { ...currentSettings, hotkey_profiles: profiles };
+      await refreshProfileModels(profiles);
+      return;
+    }
+    const saved = await applySetting(() => setHotkeyProfiles(profiles));
+    if (!saved && settingsError) hotkeyError = settingsError;
   }
 
   async function updateProfile(profileId: string, changes: Partial<HotkeyProfile>) {
@@ -1314,15 +1367,20 @@
       settings.hotkey_profiles.some((profile) => profile.id === `profile-${suffix}`)
       || Object.hasOwn(settings.profile_glossaries, `profile-${suffix}`)
     ) suffix += 1;
+    const suggested = suggestedProfileShortcuts(
+      settings.hotkey_profiles,
+      settings.hotkey,
+      platform,
+    );
     const profile: HotkeyProfile = {
       id: `profile-${suffix}`,
       name: `Profile ${suffix}`,
-      shortcut: "Control+Option+Shift+F12",
+      ...suggested,
       language: settings.language === "sv" ? "en" : "sv",
     };
     settings = { ...settings, hotkey_profiles: [...settings.hotkey_profiles, profile] };
     draftProfileId = profile.id;
-    beginHotkeyCapture(profile.id);
+    beginHotkeyCapture(profile.id, "push_to_talk_shortcut");
     void refreshProfileModels(settings.hotkey_profiles);
   }
 
@@ -1332,6 +1390,7 @@
       settings = { ...settings, hotkey_profiles: settings.hotkey_profiles.filter((profile) => profile.id !== profileId) };
       draftProfileId = null;
       recordingProfileId = null;
+      recordingShortcutSlot = null;
       return;
     }
     await applySetting(() =>
@@ -1347,6 +1406,12 @@
       case "en": return "English";
       default: return "Auto-detect";
     }
+  }
+
+  function presenterProfileShortcuts(): string[] {
+    return settings
+      ? settings.hotkey_profiles.flatMap((profile) => profileShortcutValues(profile, "presenter"))
+      : [];
   }
 
 </script>
@@ -1411,24 +1476,61 @@
                   <option value="auto">Auto-detect</option>
                 </select>
               </div>
-              <div class="profile-row">
-                {#if recordingProfileId === profile.id}
-                  <button
-                    class="hotkey-recorder recording"
-                    bind:this={hotkeyRecorderEl}
-                    onkeydown={(event) => onHotkeyKeydown(event, profile.id)}
-                    onblur={() => { recordingProfileId = null; hotkeyError = ""; }}
-                  >Press shortcut...</button>
-                {:else}
-                  <button
-                    class="hotkey-recorder"
-                    onclick={() => beginHotkeyCapture(profile.id)}
-                  >{formatHotkeyDisplay(profile.shortcut)}</button>
-                {/if}
-                {#if settings.hotkey_profiles.length > 1}
-                  <button class="profile-remove" aria-label={`Remove ${profile.name}`} onclick={() => removeProfile(profile.id)}>Remove</button>
-                {/if}
-              </div>
+              {#if settings.hotkey_mode === "presenter"}
+                <div class="presenter-start-control">
+                  <span class="shortcut-label">Presenter start</span>
+                  {#if recordingProfileId === profile.id && recordingShortcutSlot === "presenter_shortcut"}
+                    <button
+                      class="hotkey-recorder recording"
+                      bind:this={hotkeyRecorderEl}
+                      aria-label={`${profile.name} Presenter start shortcut`}
+                      onkeydown={(event) => onHotkeyKeydown(event, profile.id, "presenter_shortcut")}
+                      onblur={() => { recordingProfileId = null; recordingShortcutSlot = null; hotkeyError = ""; }}
+                    >Press shortcut...</button>
+                  {:else}
+                    <button
+                      class="hotkey-recorder"
+                      aria-label={`${profile.name} Presenter start shortcut`}
+                      onclick={() => beginHotkeyCapture(profile.id, "presenter_shortcut")}
+                    >{formatHotkeyDisplay(profile.shortcut)}</button>
+                  {/if}
+                  <div class="hotkey-hint">Presenter uses this one start shortcut. Push-to-talk and Toggle bindings are configured in Profile shortcuts mode.</div>
+                </div>
+              {:else}
+                <div class="shortcut-grid">
+                  {#each shortcutControls as shortcutControl}
+                    <div class="shortcut-control">
+                      <span class="shortcut-label">{shortcutControl.label}</span>
+                      {#if recordingProfileId === profile.id && recordingShortcutSlot === shortcutControl.slot}
+                        <button
+                          class="hotkey-recorder recording"
+                          bind:this={hotkeyRecorderEl}
+                          aria-label={`${profile.name} ${shortcutControl.label} shortcut`}
+                          onkeydown={(event) => onHotkeyKeydown(event, profile.id, shortcutControl.slot)}
+                          onblur={() => { recordingProfileId = null; recordingShortcutSlot = null; hotkeyError = ""; }}
+                        >Press shortcut...</button>
+                      {:else}
+                        <button
+                          class="hotkey-recorder"
+                          aria-label={`${profile.name} ${shortcutControl.label} shortcut`}
+                          onclick={() => beginHotkeyCapture(profile.id, shortcutControl.slot)}
+                        >{formatHotkeyDisplay(displayProfileShortcut(profile, shortcutControl.slot, settings.hotkey_mode) || "Not set")}</button>
+                      {/if}
+                      {#if profile.push_to_talk_shortcut && profile.toggle_shortcut}
+                        <button
+                          type="button"
+                          class="shortcut-clear"
+                          aria-label={`Clear ${shortcutControl.label} shortcut for ${profile.name}`}
+                          onclick={() => clearProfileShortcut(profile.id, shortcutControl.slot)}
+                        >Clear</button>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+              {#if settings.hotkey_profiles.length > 1}
+                <button class="profile-remove" aria-label={`Remove ${profile.name}`} onclick={() => removeProfile(profile.id)}>Remove</button>
+              {/if}
               {#if profileModels[profile.id]}
                 <div class="profile-engine" class:missing={!profileModels[profile.id].downloaded}>
                   <span>
@@ -1462,23 +1564,23 @@
             </div>
           {/if}
           <div class="hotkey-hint">
-            Each shortcut selects its language. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission: macOS sends keyboard events to Sagascript, which immediately ignores everything except bare F13–F24 and never stores or sends them.{/if}
+            Push to talk starts while held; Toggle starts and stops with each press. They are independent and either or both may be configured. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission: macOS sends keyboard events to Sagascript, which immediately ignores everything except bare F13–F24 and never stores or sends them.{/if}
           </div>
         </div>
 
         <div class="field">
-          <label for="hotkey-mode">Shortcut behavior</label>
+          <label for="hotkey-mode">Dictation behavior</label>
           <select id="hotkey-mode" value={settings.hotkey_mode} onchange={onHotkeyModeChange}>
-            <option value="push">Push-to-talk</option>
-            <option value="toggle">Toggle</option>
+            <option value={settings.hotkey_mode === "toggle" ? "toggle" : "push"}>Profile shortcuts</option>
             <option value="presenter">Presenter</option>
           </select>
+          <div class="hotkey-hint">Presenter is a separate opt-in mode with finish/cancel controls; it does not replace the per-profile push-to-talk and toggle bindings.</div>
         </div>
 
         {#if settings.hotkey_mode === "presenter"}
           <PresenterSettings
             config={settings.presenter}
-            profileShortcuts={settings.hotkey_profiles.map((profile) => profile.shortcut)}
+            profileShortcuts={presenterProfileShortcuts()}
             {platform}
             onSave={onPresenterSave}
           />
@@ -2086,8 +2188,44 @@
     flex: 1 1 48%;
   }
 
-  .profile-row .hotkey-recorder {
-    flex: 1;
+  .shortcut-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    align-items: end;
+  }
+
+  .shortcut-control {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .shortcut-label {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .shortcut-clear {
+    align-self: flex-start;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 11px;
+    padding: 0;
+  }
+
+  .shortcut-clear:hover {
+    color: var(--text);
+  }
+
+  @media (max-width: 520px) {
+    .shortcut-grid {
+      grid-template-columns: 1fr;
+    }
   }
 
   .profile-engine {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -17,6 +17,8 @@ export interface HotkeyProfile {
   name: string;
   shortcut: string;
   language: Language;
+  push_to_talk_shortcut?: string | null;
+  toggle_shortcut?: string | null;
 }
 
 export interface WhisperModel {

--- a/src/lib/profile-shortcuts.js
+++ b/src/lib/profile-shortcuts.js
@@ -1,0 +1,178 @@
+/**
+ * Helpers for the two independent dictation bindings on a hotkey profile.
+ * Keep the legacy `shortcut` field in the payload: older settings use it
+ * when neither explicit binding is present, and the backend keeps it as the
+ * compatibility/default value.
+ */
+
+/** @type {Record<string, string>} */
+const MODIFIER_ALIASES = {
+  control: "control",
+  ctrl: "control",
+  alt: "alt",
+  option: "alt",
+  super: "super",
+  command: "super",
+  cmd: "super",
+  meta: "super",
+  shift: "shift",
+};
+
+/** @type {Record<string, string>} */
+const KEY_ALIASES = {
+  up: "arrowup",
+  down: "arrowdown",
+  left: "arrowleft",
+  right: "arrowright",
+  esc: "escape",
+};
+
+/**
+ * @typedef {object} ShortcutProfile
+ * @property {string} id
+ * @property {string} name
+ * @property {string} shortcut
+ * @property {"en"|"sv"|"no"|"fi"|"auto"} language
+ * @property {string|null|undefined} [push_to_talk_shortcut]
+ * @property {string|null|undefined} [toggle_shortcut]
+ */
+
+/**
+ * @param {string|null|undefined} shortcut
+ * @param {string} [platform]
+ * @returns {string}
+ */
+export function canonicalShortcut(shortcut, platform = "macos") {
+  if (typeof shortcut !== "string") return "";
+  const tokens = shortcut.split("+").map((token) => token.trim().toLowerCase()).filter(Boolean);
+  if (tokens.length === 0) return "";
+  const keyToken = tokens[tokens.length - 1];
+  const modifiers = [...new Set(tokens.slice(0, -1).map((token) => {
+    if (["commandorcontrol", "commandorctrl", "cmdorctrl", "cmdorcontrol"].includes(token)) {
+      return platform === "macos" ? "super" : "control";
+    }
+    return MODIFIER_ALIASES[token] ?? token;
+  }))].sort();
+  const key = KEY_ALIASES[keyToken]
+    ?? (keyToken.length === 1 && /^[a-z]$/.test(keyToken) ? `key${keyToken}` : null)
+    ?? (keyToken.length === 1 && /^[0-9]$/.test(keyToken) ? `digit${keyToken}` : keyToken);
+  return [...modifiers, key].join("+");
+}
+
+/** @param {unknown} value @returns {string} */
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+/**
+ * @param {ShortcutProfile} profile
+ * @param {"push_to_talk_shortcut"|"toggle_shortcut"} slot
+ * @param {"push"|"toggle"|"presenter"} hotkeyMode
+ * @returns {string}
+ */
+export function displayProfileShortcut(profile, slot, hotkeyMode) {
+  const explicit = nonEmpty(profile[slot]);
+  if (explicit) return explicit;
+  const hasAnyExplicitBinding = nonEmpty(profile.push_to_talk_shortcut) || nonEmpty(profile.toggle_shortcut);
+  if (hasAnyExplicitBinding) return "";
+  // Legacy settings are shown in the slot selected by the old global mode,
+  // but this read-only migration view must not manufacture explicit fields.
+  if (hotkeyMode === slotPrefixToMode(slot) || (hotkeyMode === "presenter" && slot === "push_to_talk_shortcut")) {
+    return nonEmpty(profile.shortcut);
+  }
+  return "";
+}
+
+/**
+ * @param {"push_to_talk_shortcut"|"toggle_shortcut"} slot
+ * @returns {"push"|"toggle"}
+ */
+function slotPrefixToMode(slot) {
+  return slot === "push_to_talk_shortcut" ? "push" : "toggle";
+}
+
+/**
+ * Return the bindings that should be considered when checking registration
+ * health and Presenter collisions. Explicit bindings replace legacy shortcut
+ * routing for that profile; a profile with neither remains legacy-compatible.
+ *
+ * @param {ShortcutProfile} profile
+ * @param {"push"|"toggle"|"presenter"} hotkeyMode
+ * @returns {string[]}
+ */
+export function profileShortcutValues(profile, hotkeyMode = "push") {
+  const push = nonEmpty(profile.push_to_talk_shortcut);
+  const toggle = nonEmpty(profile.toggle_shortcut);
+  const legacy = nonEmpty(profile.shortcut);
+  if (hotkeyMode === "presenter") return legacy ? [legacy] : [];
+  if (push || toggle) return [push, toggle].filter(Boolean);
+  return legacy ? [legacy] : [];
+}
+
+/** @param {ShortcutProfile[]} profiles @param {"push"|"toggle"|"presenter"} hotkeyMode @returns {string[]} */
+export function allProfileShortcutValues(profiles, hotkeyMode = "push") {
+  return profiles.flatMap((profile) => profileShortcutValues(profile, hotkeyMode));
+}
+
+/**
+ * @param {ShortcutProfile} profile
+ * @param {"push_to_talk_shortcut"|"toggle_shortcut"} slot
+ * @param {string|null|undefined} value
+ * @param {"push"|"toggle"|"presenter"} [hotkeyMode]
+ * @returns {ShortcutProfile}
+ */
+export function profileWithShortcut(profile, slot, value, hotkeyMode = "push") {
+  const next = {
+    ...profile,
+    push_to_talk_shortcut: nonEmpty(profile.push_to_talk_shortcut) || null,
+    toggle_shortcut: nonEmpty(profile.toggle_shortcut) || null,
+    [slot]: nonEmpty(value) || null,
+  };
+  const hasAnyExplicitBinding = nonEmpty(profile.push_to_talk_shortcut) || nonEmpty(profile.toggle_shortcut);
+  const legacySlot = hotkeyMode === "toggle" ? "toggle_shortcut" : "push_to_talk_shortcut";
+  if (!hasAnyExplicitBinding && nonEmpty(profile.shortcut) && legacySlot !== slot) {
+    next[legacySlot] = profile.shortcut;
+  }
+  const push = nonEmpty(next.push_to_talk_shortcut);
+  const toggle = nonEmpty(next.toggle_shortcut);
+  // The backend retains this compatibility field and synchronizes it to the
+  // first explicit binding. An empty value is intentionally left for backend
+  // validation when the user clears both fields.
+  next.shortcut = push || toggle || "";
+  return next;
+}
+
+/**
+ * Pick the first unused pair of friendly defaults. Existing customized
+ * profile shortcuts, including legacy values, are treated as occupied.
+ *
+ * @param {ShortcutProfile[]} profiles
+ * @param {string} legacyShortcut
+ * @param {string} platform
+ * @returns {{push_to_talk_shortcut: string|null, toggle_shortcut: string|null, shortcut: string}}
+ */
+export function suggestedProfileShortcuts(profiles, legacyShortcut, platform) {
+  const occupied = new Set([
+    ...profiles.flatMap((profile) => [profile.shortcut, profile.push_to_talk_shortcut, profile.toggle_shortcut]),
+    legacyShortcut,
+  ].map((shortcut) => canonicalShortcut(shortcut, platform)).filter(Boolean));
+  const pttCandidates = platform === "macos"
+    ? ["Super+S", "Super+E"]
+    : ["Control+S", "Control+E"];
+  const toggleCandidates = platform === "macos"
+    ? ["Shift+Super+S", "Shift+Super+E"]
+    : ["Control+Shift+S", "Control+Shift+E"];
+  /** @param {string[]} candidates @param {Set<string>} [reserved] */
+  const pick = (candidates, reserved = new Set()) => candidates.find((candidate) => {
+    const canonical = canonicalShortcut(candidate, platform);
+    return !occupied.has(canonical) && !reserved.has(canonical);
+  }) ?? "";
+  const ptt = pick(pttCandidates);
+  const reserved = new Set(ptt ? [canonicalShortcut(ptt, platform)] : []);
+  const toggle = pick(toggleCandidates, reserved);
+  return {
+    push_to_talk_shortcut: ptt || null,
+    toggle_shortcut: toggle || null,
+    shortcut: ptt || toggle,
+  };
+}


### PR DESCRIPTION
## Summary

- Allow simultaneous push-to-talk and toggle shortcuts per language profile, in both the desktop UI and CLI.
- Preserve legacy shortcut settings; freeze recording ownership to the initiating shortcut, profile and mode. Ignore unrelated shortcuts and toggle key-repeat events.
- Keep Presenter separate and preserve legacy toggle behavior through Presenter transitions.
- Support Cmd+S / Cmd+E for PTT and Shift+Cmd+S / Shift+Cmd+E for toggle. Existing user settings and programmable devices are not automatically changed.

## Verification

- Rust workspace: 956 tests passed; workspace check and warnings-denied clippy passed.
- Lean CLI build passed; isolated CLI settings smoke configured all four requested bindings.
- Frontend: 147 tests passed, one platform-specific skip; svelte-check zero errors/warnings; production build passed.
- Isolated Chromium UI tests passed: legacy migration, independent bindings, Presenter toggle preservation, last-binding Clear visibility and third-profile PTT-only save. Screenshots visually inspected. Native global shortcut hardware testing remains for the test build.

## Independent review

Claude Fable 5.1 approved the final scoped diff (commit a2ac7367ec8c8e306df6c0b868e27ad7ec9c83f7) in read-only mode. Initial findings about empty optional slots, sole-binding clearing and Presenter legacy-toggle preservation were fixed and covered by regression tests.

Conductor verified the two review questions against source: short recordings defer stop asynchronously rather than rejecting it (`main.rs`), and `get_settings` resolves an empty legacy profile list (`commands.rs`). Non-blocking follow-ups remain: Presenter Add language needs a second click to capture; converting a legacy single key directly between modes is awkward; suggested keys may collide with Presenter controls (backend safely rejects); combined legacy/explicit CLI options use explicit precedence. Existing global Cmd+S/E interception is intentional per owner request.

No personal audio, credentials, user settings or downloaded model data were included in the review.
