### PR TITLE
docs: explain Bluetooth microphone dictation limitations

### DIFF
--- a/scripts/test-release-surface.mjs
+++ b/scripts/test-release-surface.mjs
@@ -273,6 +273,17 @@ test("product page explains the complete privacy boundary without implying fixed
   assert.match(sitePageSource, /View source on GitHub/);
 });
 
+test("product page gives Bluetooth microphone guidance", () => {
+  const bluetoothGuidance = sitePageSource
+    .match(/<p className="microphone-note">([\s\S]*?)<\/p>/)?.[1]
+    ?.replace(/\s+/g, " ")
+    .trim();
+  assert.equal(
+    bluetoothGuidance,
+    "Bluetooth headset microphones may give less reliable dictation, especially with fast speech. If words are missed, try a built-in microphone, if available, or a wired microphone.",
+  );
+});
+
 test("app and website use the exact canonical single-S geometry", () => {
   const canonicalPath = brandMarkSource.match(/<path\s+d="([^"]+)"/)?.[1];
   assert.ok(canonicalPath, "Canonical S path is missing");

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -31,6 +31,11 @@ export default function Home() {
             <a className="button secondary" href={sourceUrl}>View source on GitHub <span aria-hidden="true">↗</span></a>
           </div>
           <p className="requirements">Apple silicon · macOS 13 or later · Local processing</p>
+          <p className="microphone-note">
+            Bluetooth headset microphones may give less reliable dictation,
+            especially with fast speech. If words are missed, try
+            a built-in microphone, if available, or a wired microphone.
+          </p>
         </div>
 
         <figure className="product-shot">


### PR DESCRIPTION
## Summary

Closes #218.

- Add a visible, cautious Bluetooth headset microphone limitation note below the product-page download requirements.
- Suggest a built-in microphone, if available, or a wired microphone when words are missed.
- Add an exact-copy regression guard that tolerates JSX whitespace reflow.

No audio tuning, automatic device detection, application changes, permissions, dependencies, workflows, hosting changes, or version changes. Production site deployment is separate; this PR does not establish that the live site has changed.

## Verification

- Red/green regression test; release-surface suite: 22/22 passed.
- Frontend suite: 139 passed, one Windows-only test skipped on macOS; Svelte check: zero errors/warnings.
- Release identity and license checks passed.
- Site production build and lint passed.
- Isolated Playwright checks at 1440px desktop and 390px mobile: warning/privacy visible, warning 16px, no horizontal overflow or page errors. Both screenshots inspected by conductor.
- `git diff --check` passed.

## Independent review

Claude Fable 5.1 reviewed the scoped change read-only and found no blocking issues. Implemented its precision improvement for Macs without a built-in microphone and whitespace-robust test suggestion. Existing body typography and early visible placement are intentional; no unverified Bluetooth causal explanation was added. Final review of exact head `653aff682aedaa0c65b1c26f241bb5d8adf3a31b` found no blocking issues; disposition is recorded in https://github.com/Magnus-Gille/sagascript/pull/219#issuecomment-5575941902.

Implementation and bounded verification helpers: Luna xhigh. Conductor owns final validation and merge; no CI bypass.
