### PR TITLE
Run CI validation and native builds in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+# Keep source/line backtraces for CI failures without full variable/type debug
+# information in every dependency and PDB. Release profiles are unchanged.
+# rust-cache includes CARGO_* environment variables in its compatibility key.
+env:
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+
 jobs:
   check-macos:
     runs-on: macos-14
@@ -146,7 +153,7 @@ jobs:
       # release.yml, so skipping bundling here removes duplicate work without
       # weakening native macOS coverage.
       - name: Build native release binary (no installer)
-        run: npx tauri build --no-bundle
+        run: npx tauri build --config scripts/tauri-ci-prebuilt.json --no-bundle
 
       - name: Verify native release binary
         run: |
@@ -400,7 +407,7 @@ jobs:
       # release.yml, so skipping bundling here removes duplicate work without
       # weakening native Windows coverage.
       - name: Build native release binary (no installer)
-        run: npx tauri build --no-bundle
+        run: npx tauri build --config scripts/tauri-ci-prebuilt.json --no-bundle
 
       - name: Verify native release binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: macos-14
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -78,6 +77,8 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
+      # Separate invocations preserve the core no-features build; combining
+      # package flags would unify features with the CLI defaults.
       - name: Cargo test (sagascript-core, no features)
         working-directory: src-tauri
         run: cargo test -p sagascript-core
@@ -94,6 +95,8 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
 
+      # Core defaults to no features. CLI defaults already include diarization
+      # and are covered above; core needs this explicit feature matrix.
       - name: Cargo check (sagascript-core, diarization)
         working-directory: src-tauri
         run: cargo check -p sagascript-core --features diarization
@@ -108,11 +111,11 @@ jobs:
 
       - name: Svelte check
         run: npx svelte-check --tsconfig ./tsconfig.json
+
   build-macos:
     runs-on: macos-14
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -123,8 +126,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -151,6 +152,7 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+
       # PR validation needs the native release binary for the smoke tests, not
       # an installer. Full packaging, signing and notarization remain gated in
       # release.yml, so skipping bundling here removes duplicate work without
@@ -340,7 +342,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -390,6 +391,8 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
+      # Separate invocations preserve the core no-features build; combining
+      # package flags would unify features with the CLI defaults.
       - name: Cargo test (sagascript-core, no features)
         working-directory: src-tauri
         run: cargo test -p sagascript-core
@@ -405,18 +408,16 @@ jobs:
       - name: Cargo clippy (sagascript-cli)
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
+
   build-windows:
     runs-on: windows-latest
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -443,6 +444,7 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+
       # PR validation needs the native release binary for the smoke tests, not
       # an installer. Full packaging, signing and notarization remain gated in
       # release.yml, so skipping bundling here removes duplicate work without
@@ -510,6 +512,7 @@ jobs:
           findstr /C:"text" json_output.txt
           findstr /C:"duration_seconds" json_output.txt
           findstr /C:"language" json_output.txt
+
   check-windows:
     needs: [test-windows, build-windows]
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ env:
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
-  check-macos:
+  test-macos:
     runs-on: macos-14
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -50,27 +51,11 @@ jobs:
           node-version: 20
           cache: npm
 
-      # Per-crate fingerprints shared across branches (#178): the previous
-      # `actions/cache` over `src-tauri/target` keyed on `Cargo.lock` forced a
-      # cold multi-GB rebuild (plus minutes of save/restore) on any lockfile
-      # change. rust-cache prunes before upload and stays warm across branches.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
-          shared-key: sagascript-ci
-
-      # Tier-2 smokes re-download `nb-whisper-tiny` every run (#178). The key
-      # tracks model-definition sources; restore-keys plus idempotent
-      # `download-model` (skips artifacts already at the expected size) cover
-      # all other cases.
-      - name: Cache downloaded models
-        uses: actions/cache@v5
-        with:
-          path: ~/Library/Application Support/Sagascript/Models
-          key: macos-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
-          restore-keys: |
-            macos-models-
+          shared-key: sagascript-ci-checks
 
       - name: Install npm dependencies
         run: npm ci
@@ -93,10 +78,6 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
-      # Workspace members. Bare cargo commands above cover only the root (app)
-      # package; these cover sagascript-core and sagascript-cli explicitly.
-      # NOTE: core is tested in its own invocation so its no-features build is
-      # exercised — combining -p flags would unify features across packages.
       - name: Cargo test (sagascript-core, no features)
         working-directory: src-tauri
         run: cargo test -p sagascript-core
@@ -113,14 +94,6 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
 
-      # `diarization` feature coverage (#68): core defaults to no features, so
-      # these explicit invocations compile/test/lint its ~1,771 lines of
-      # speaker diarization code. The CLI defaults already include diarization
-      # and are covered by the package commands above. All diarization unit
-      # tests are pure (math/serialization/clustering logic) — none load an
-      # ONNX model file at runtime, so this layer needs no downloaded artifacts.
-      # The macOS model-backed smoke tests below are also release-critical and
-      # fail the job on inference regressions.
       - name: Cargo check (sagascript-core, diarization)
         working-directory: src-tauri
         run: cargo check -p sagascript-core --features diarization
@@ -135,11 +108,54 @@ jobs:
 
       - name: Svelte check
         run: npx svelte-check --tsconfig ./tsconfig.json
+  build-macos:
+    runs-on: macos-14
 
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select evaluation Python runtime
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: src-tauri
+          shared-key: sagascript-ci-native
+
+      - name: Cache downloaded models
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Application Support/Sagascript/Models
+          key: macos-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
+          restore-keys: |
+            macos-models-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
       # PR validation needs the native release binary for the smoke tests, not
       # an installer. Full packaging, signing and notarization remain gated in
       # release.yml, so skipping bundling here removes duplicate work without
       # weakening native macOS coverage.
+
       - name: Build native release binary (no installer)
         run: npx tauri build --config scripts/tauri-ci-prebuilt.json --no-bundle
 
@@ -199,6 +215,19 @@ jobs:
           $BINARY transcribe --json --language no --model nb-whisper-tiny \
             test-audio/norwegian-short-3s.mp3 > "$STDOUT" 2> "$STDERR"
           python3 scripts/verify-json-cli-streams.py "$STDOUT" "$STDERR"
+
+  check-macos:
+    needs: [test-macos, build-macos]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    env:
+      TEST_RESULT: ${{ needs.test-macos.result }}
+      BUILD_RESULT: ${{ needs.build-macos.result }}
+    steps:
+      - name: Assert macOS CI lanes passed
+        run: |
+          test "$TEST_RESULT" = success
+          test "$BUILD_RESULT" = success
 
   check-linux:
     runs-on: ubuntu-24.04
@@ -307,10 +336,11 @@ jobs:
           fi
           echo "OK: no cpal/ALSA in batch-only tree"
 
-  check-windows:
+  test-windows:
     runs-on: windows-latest
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -333,23 +363,11 @@ jobs:
           node-version: 20
           cache: npm
 
-      # Same rust-cache scheme as the macOS job (#178); the shared key spans
-      # branches while rust-cache keeps OS/target entries separate.
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
-          shared-key: sagascript-ci
-
-      # Tier-2 smokes re-download `nb-whisper-tiny` every run (#178). Same
-      # scheme as macOS; `%APPDATA%` is `~\AppData\Roaming` on the runner.
-      - name: Cache downloaded models
-        uses: actions/cache@v5
-        with:
-          path: ~\AppData\Roaming\Sagascript\Models
-          key: windows-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
-          restore-keys: |
-            windows-models-
+          shared-key: sagascript-ci-checks
 
       - name: Test Windows build identity gates
         run: node --test scripts/test-ci-build-identity.mjs scripts/test-windows-release-identity.mjs scripts/test-windows-package-workflow.mjs
@@ -372,8 +390,6 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
-      # Workspace members (see the macOS job for why these are separate
-      # invocations: combined -p flags would unify features across packages).
       - name: Cargo test (sagascript-core, no features)
         working-directory: src-tauri
         run: cargo test -p sagascript-core
@@ -389,11 +405,49 @@ jobs:
       - name: Cargo clippy (sagascript-cli)
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
+  build-windows:
+    runs-on: windows-latest
 
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: src-tauri
+          shared-key: sagascript-ci-native
+
+      - name: Cache downloaded models
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Roaming\Sagascript\Models
+          key: windows-models-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
+          restore-keys: |
+            windows-models-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
       # PR validation needs the native release binary for the smoke tests, not
       # an installer. Full packaging, signing and notarization remain gated in
       # release.yml, so skipping bundling here removes duplicate work without
       # weakening native Windows coverage.
+
       - name: Build native release binary (no installer)
         run: npx tauri build --config scripts/tauri-ci-prebuilt.json --no-bundle
 
@@ -456,3 +510,15 @@ jobs:
           findstr /C:"text" json_output.txt
           findstr /C:"duration_seconds" json_output.txt
           findstr /C:"language" json_output.txt
+  check-windows:
+    needs: [test-windows, build-windows]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    env:
+      TEST_RESULT: ${{ needs.test-windows.result }}
+      BUILD_RESULT: ${{ needs.build-windows.result }}
+    steps:
+      - name: Assert Windows CI lanes passed
+        run: |
+          test "$TEST_RESULT" = success
+          test "$BUILD_RESULT" = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,37 +113,25 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -p sagascript-cli --all-targets -- -D warnings
 
-      # `diarization` feature coverage (#68): gates ~1,771 lines of speaker
-      # diarization code (crates/sagascript-core/src/diarization/) and its
-      # CLI wiring (--diarize / --diarize-threshold in sagascript-cli) that
-      # otherwise never compile in CI. All diarization unit tests are pure
-      # (math/serialization/clustering logic) — none load an ONNX model file
-      # at runtime, so this layer needs no downloaded artifacts. The macOS
-      # model-backed smoke tests below are also release-critical and fail the
-      # job on inference regressions.
+      # `diarization` feature coverage (#68): core defaults to no features, so
+      # these explicit invocations compile/test/lint its ~1,771 lines of
+      # speaker diarization code. The CLI defaults already include diarization
+      # and are covered by the package commands above. All diarization unit
+      # tests are pure (math/serialization/clustering logic) — none load an
+      # ONNX model file at runtime, so this layer needs no downloaded artifacts.
+      # The macOS model-backed smoke tests below are also release-critical and
+      # fail the job on inference regressions.
       - name: Cargo check (sagascript-core, diarization)
         working-directory: src-tauri
         run: cargo check -p sagascript-core --features diarization
-
-      - name: Cargo check (sagascript-cli, diarization)
-        working-directory: src-tauri
-        run: cargo check -p sagascript-cli --features diarization
 
       - name: Cargo test (sagascript-core, diarization)
         working-directory: src-tauri
         run: cargo test -p sagascript-core --features diarization
 
-      - name: Cargo test (sagascript-cli, diarization)
-        working-directory: src-tauri
-        run: cargo test -p sagascript-cli --features diarization
-
       - name: Cargo clippy (sagascript-core, diarization)
         working-directory: src-tauri
         run: cargo clippy -p sagascript-core --features diarization --all-targets -- -D warnings
-
-      - name: Cargo clippy (sagascript-cli, diarization)
-        working-directory: src-tauri
-        run: cargo clippy -p sagascript-cli --features diarization --all-targets -- -D warnings
 
       - name: Svelte check
         run: npx svelte-check --tsconfig ./tsconfig.json

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           : "${APPLE_SIGNING_IDENTITY:?APPLE_SIGNING_IDENTITY secret is required}"
           : "${APPLE_API_ISSUER:?APPLE_API_ISSUER secret is required}"
-          npx tauri build --target aarch64-apple-darwin
+          npx tauri build --config scripts/tauri-ci-prebuilt.json --target aarch64-apple-darwin
 
       - name: Notarize and staple disk image
         env:

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Build unsigned internal installers
         env:
           CARGO_LOG: cargo::core::compiler::fingerprint=info
-        run: npx tauri build --config scripts/tauri-ci-prebuilt.json --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }}
+        run: npx tauri build --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }} --config scripts/tauri-ci-prebuilt.json
 
       - name: Verify packaged x64 inference CPU policy
         if: matrix.architecture == 'x64'

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -85,6 +85,10 @@ jobs:
           "CMAKE_ASM_COMPILER=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_C_COMPILER_TARGET=aarch64-pc-windows-msvc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CMAKE_CXX_COMPILER_TARGET=aarch64-pc-windows-msvc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          # Pinned Whisper's SVE implementation includes Linux-only headers.
+          # Keep other native ARM features; bypass only SVE/SME positive probes.
+          $policy = (Resolve-Path -LiteralPath 'scripts/cmake/windows-arm64-native.cmake').Path.Replace('\', '/')
+          "CMAKE_PROJECT_INCLUDE=$policy" >> $env:GITHUB_ENV
 
       - name: Configure portable x64 inference baseline
         if: matrix.architecture == 'x64'
@@ -124,7 +128,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
-          shared-key: windows-package-${{ matrix.architecture }}-${{ steps.windows-image.outputs.image_os }}-${{ steps.windows-image.outputs.image_version }}-${{ hashFiles('.github/workflows/windows-package.yml', 'scripts/cmake/windows-x64-portable.cmake', 'scripts/verify-windows-x64-cpu-policy.ps1') }}
+          shared-key: windows-package-${{ matrix.architecture }}-${{ steps.windows-image.outputs.image_os }}-${{ steps.windows-image.outputs.image_version }}-${{ hashFiles('.github/workflows/windows-package.yml', 'scripts/cmake/windows-x64-portable.cmake', 'scripts/cmake/windows-arm64-native.cmake', 'scripts/verify-windows-x64-cpu-policy.ps1') }}
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -191,6 +191,10 @@ jobs:
         shell: pwsh
         run: ./scripts/verify-windows-x64-cpu-policy.ps1 -TargetRoot src-tauri/target -PolicyFile scripts/cmake/windows-x64-portable.cmake
 
+      - name: Verify debug ARM64 native CPU flags
+        if: matrix.architecture == 'arm64'
+        run: node scripts/report-windows-arm64-native.mjs src-tauri/target
+
       - name: Verify source before release CLI build
         run: node scripts/ci-build-identity.mjs --verify
 
@@ -270,6 +274,10 @@ jobs:
         if: matrix.architecture == 'x64'
         shell: pwsh
         run: ./scripts/verify-windows-x64-cpu-policy.ps1 -TargetRoot src-tauri/target -PolicyFile scripts/cmake/windows-x64-portable.cmake
+
+      - name: Verify packaged ARM64 native CPU flags
+        if: matrix.architecture == 'arm64'
+        run: node scripts/report-windows-arm64-native.mjs src-tauri/target
 
       - name: Verify source after installer build
         run: node scripts/ci-build-identity.mjs --verify

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -20,6 +20,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+# Keep source/line backtraces for CI failures without full variable/type debug
+# information in every dependency and PDB. Release profiles are unchanged.
+# rust-cache includes CARGO_* environment variables in its compatibility key.
+env:
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+
 jobs:
   build-windows-candidate:
     name: Build Windows ${{ matrix.architecture }} candidate
@@ -169,6 +176,8 @@ jobs:
         run: node scripts/ci-build-identity.mjs --verify
 
       - name: Gate real Windows transcription
+        env:
+          CARGO_LOG: cargo::core::compiler::fingerprint=info
         shell: pwsh
         run: |
           cargo build --release -p sagascript-cli --manifest-path src-tauri/Cargo.toml --target ${{ matrix.rust_target }}
@@ -234,7 +243,9 @@ jobs:
         run: node scripts/ci-build-identity.mjs --verify
 
       - name: Build unsigned internal installers
-        run: npx tauri build --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }}
+        env:
+          CARGO_LOG: cargo::core::compiler::fingerprint=info
+        run: npx tauri build --config scripts/tauri-ci-prebuilt.json --ci --bundles nsis,msi --no-sign --target ${{ matrix.rust_target }}
 
       - name: Verify packaged x64 inference CPU policy
         if: matrix.architecture == 'x64'

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -132,6 +132,21 @@ jobs:
           node-version: 20
           cache: npm
 
+      # Keep the candidate's larger model set under its own primary key. A
+      # regular CI cache may restore the Norwegian smoke model, but the
+      # candidate run must still save its additional base.en artifact.
+      # `download-model` verifies every restored file against the immutable
+      # manifest before using it; this path contains models only, never app
+      # settings or logs.
+      - name: Cache downloaded models
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Roaming\Sagascript\Models
+          key: windows-models-package-${{ matrix.architecture }}-${{ hashFiles('src-tauri/crates/sagascript-core/src/settings/manager.rs', 'src-tauri/crates/sagascript-core/src/transcription/model.rs', 'src-tauri/crates/sagascript-core/src/diarization/model.rs') }}
+          restore-keys: |
+            windows-models-package-${{ matrix.architecture }}-
+            windows-models-
+
       - name: Pin validated Windows build identity
         run: node scripts/ci-build-identity.mjs --initialize
 

--- a/docs/ci-performance/baseline-2026-09-08.json
+++ b/docs/ci-performance/baseline-2026-09-08.json
@@ -1,0 +1,1364 @@
+{
+  "schemaVersion": 1,
+  "window": {
+    "from": "2026-09-06T08:20:44Z",
+    "through": "2026-09-08T09:44:00Z"
+  },
+  "selection": "Latest 100 repository runs; completed CI, Windows Package Candidate, Test Build, Release only. Latest job attempts as observed.",
+  "method": {
+    "elapsed": "max(job.completed_at) minus run.created_at",
+    "p50": "median",
+    "p90": "nearest rank",
+    "latencyPopulation": "successful runs only, mixed events/revisions/cache states/attempts",
+    "initiallyInProgressExcluded": [
+      34211620052
+    ]
+  },
+  "outcomes": {
+    "CI": {
+      "success": 39,
+      "failure": 2
+    },
+    "Release": {
+      "success": 1
+    },
+    "Windows Package Candidate": {
+      "cancelled": 4,
+      "success": 20,
+      "failure": 2
+    },
+    "Test Build": {
+      "success": 9
+    }
+  },
+  "workflows": {
+    "CI": {
+      "n": 39,
+      "p50_s": 618.0,
+      "p90_s": 729.0,
+      "min_s": 468.0,
+      "max_s": 1666.0
+    },
+    "Release": {
+      "n": 1,
+      "p50_s": 1067.0,
+      "p90_s": 1067.0,
+      "min_s": 1067.0,
+      "max_s": 1067.0
+    },
+    "Test Build": {
+      "n": 9,
+      "p50_s": 499.0,
+      "p90_s": 616.0,
+      "min_s": 291.0,
+      "max_s": 616.0
+    },
+    "Windows Package Candidate": {
+      "n": 20,
+      "p50_s": 1864.0,
+      "p90_s": 2171.0,
+      "min_s": 816.0,
+      "max_s": 2260.0
+    }
+  },
+  "successfulRunLedger": [
+    {
+      "run": 34211619966,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "e4bc2172078d8da02ee2e11b58a3bd0854817e91",
+      "seconds": 746.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 420.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 150.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 742.0
+        }
+      ]
+    },
+    {
+      "run": 34209086662,
+      "workflow": "Release",
+      "event": "push",
+      "sha": "1aba32242845340304e94e4c0e2b3540b81a2064",
+      "seconds": 1067.0,
+      "jobs": [
+        {
+          "name": "quality-gate",
+          "seconds": 578.0
+        },
+        {
+          "name": "build-macos",
+          "seconds": 458.0
+        },
+        {
+          "name": "publish-release",
+          "seconds": 11.0
+        }
+      ]
+    },
+    {
+      "run": 34206976204,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "122766517d8c7036cd8099efc8a264653429bcbd",
+      "seconds": 670.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 122.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 389.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 666.0
+        }
+      ]
+    },
+    {
+      "run": 34206945641,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "1aba32242845340304e94e4c0e2b3540b81a2064",
+      "seconds": 532.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 523.0
+        }
+      ]
+    },
+    {
+      "run": 34204997034,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "5123df4d901bfa4776f56e854f5c4a81c555288f",
+      "seconds": 655.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 176.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 550.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 651.0
+        }
+      ]
+    },
+    {
+      "run": 34204996987,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "5123df4d901bfa4776f56e854f5c4a81c555288f",
+      "seconds": 1012.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1008.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 908.0
+        }
+      ]
+    },
+    {
+      "run": 34204224613,
+      "workflow": "Windows Package Candidate",
+      "event": "workflow_dispatch",
+      "sha": "1aba32242845340304e94e4c0e2b3540b81a2064",
+      "seconds": 2096.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1544.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 2092.0
+        }
+      ]
+    },
+    {
+      "run": 34203274653,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "deedf96d860bc224bef80e5e34277bc8cd598ce5",
+      "seconds": 607.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 102.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 602.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 420.0
+        }
+      ]
+    },
+    {
+      "run": 34201979049,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "13f8a42b07c24a833cd59507dc5420f6f3d4ab3e",
+      "seconds": 642.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 363.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 158.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 638.0
+        }
+      ]
+    },
+    {
+      "run": 34201501326,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "7d937023562d45e66b2c3e82db09aa566b367770",
+      "seconds": 658.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 456.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 652.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 158.0
+        }
+      ]
+    },
+    {
+      "run": 34201501297,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "7d937023562d45e66b2c3e82db09aa566b367770",
+      "seconds": 2190.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 2186.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1572.0
+        }
+      ]
+    },
+    {
+      "run": 34198151269,
+      "workflow": "Windows Package Candidate",
+      "event": "workflow_dispatch",
+      "sha": "e4db9c6137b73c710826a21f5792ab5d31c4a798",
+      "seconds": 2171.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1471.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 2166.0
+        }
+      ]
+    },
+    {
+      "run": 34167344037,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "9e76c364de3ac17b2c3f56478644458779a39eec",
+      "seconds": 592.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 375.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 123.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 589.0
+        }
+      ]
+    },
+    {
+      "run": 34166555593,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "83bfc33c7711e628311105ae49e72ef9571f294d",
+      "seconds": 614.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 403.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 610.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 95.0
+        }
+      ]
+    },
+    {
+      "run": 34166488458,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "f281bf466c7351acfe1a6fa959f3dc7b656d7ca0",
+      "seconds": 630.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 105.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 543.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 627.0
+        }
+      ]
+    },
+    {
+      "run": 34164464479,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "653aff682aedaa0c65b1c26f241bb5d8adf3a31b",
+      "seconds": 530.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 114.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 526.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 445.0
+        }
+      ]
+    },
+    {
+      "run": 34164464363,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "653aff682aedaa0c65b1c26f241bb5d8adf3a31b",
+      "seconds": 1996.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1992.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1366.0
+        }
+      ]
+    },
+    {
+      "run": 34160445004,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "e4db9c6137b73c710826a21f5792ab5d31c4a798",
+      "seconds": 500.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 491.0
+        }
+      ]
+    },
+    {
+      "run": 34159205851,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "e4db9c6137b73c710826a21f5792ab5d31c4a798",
+      "seconds": 624.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 121.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 355.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 619.0
+        }
+      ]
+    },
+    {
+      "run": 34157025149,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "72c8fd8705f6c08cf4f6788a30372b95446a86ee",
+      "seconds": 1938.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1425.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1934.0
+        }
+      ]
+    },
+    {
+      "run": 34157025144,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "72c8fd8705f6c08cf4f6788a30372b95446a86ee",
+      "seconds": 508.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 505.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 117.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 390.0
+        }
+      ]
+    },
+    {
+      "run": 34122142331,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "c6f1046c4a1a2bb1c886f613cdb09850df29f32a",
+      "seconds": 616.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 605.0
+        }
+      ]
+    },
+    {
+      "run": 34120406896,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "c6f1046c4a1a2bb1c886f613cdb09850df29f32a",
+      "seconds": 646.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 336.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 642.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 99.0
+        }
+      ]
+    },
+    {
+      "run": 34117314379,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "a2ac7367ec8c8e306df6c0b868e27ad7ec9c83f7",
+      "seconds": 2095.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 2091.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1458.0
+        }
+      ]
+    },
+    {
+      "run": 34117314372,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "a2ac7367ec8c8e306df6c0b868e27ad7ec9c83f7",
+      "seconds": 680.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 677.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 121.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 399.0
+        }
+      ]
+    },
+    {
+      "run": 34110041596,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "3a75bee4c98f4e31e96ab107f04f9656c38bdd96",
+      "seconds": 634.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 252.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 386.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 630.0
+        }
+      ]
+    },
+    {
+      "run": 34105133106,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "c50f6613c1b694ef787350228e2e2891f0320286",
+      "seconds": 1084.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1080.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 892.0
+        }
+      ]
+    },
+    {
+      "run": 34105133008,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "c50f6613c1b694ef787350228e2e2891f0320286",
+      "seconds": 597.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 321.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 99.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 591.0
+        }
+      ]
+    },
+    {
+      "run": 34105127095,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "c50f6613c1b694ef787350228e2e2891f0320286",
+      "seconds": 541.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 532.0
+        }
+      ]
+    },
+    {
+      "run": 34102324573,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "3fc68078cd8f4726c4ba47a3a19c817b1651df59",
+      "seconds": 499.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 489.0
+        }
+      ]
+    },
+    {
+      "run": 34102223763,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "3fc68078cd8f4726c4ba47a3a19c817b1651df59",
+      "seconds": 1790.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1426.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1786.0
+        }
+      ]
+    },
+    {
+      "run": 34102223694,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "3fc68078cd8f4726c4ba47a3a19c817b1651df59",
+      "seconds": 533.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 101.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 384.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 527.0
+        }
+      ]
+    },
+    {
+      "run": 34092448629,
+      "workflow": "Windows Package Candidate",
+      "event": "workflow_dispatch",
+      "sha": "c001ef1cf6b0889ee884485eb4ad0cc6348ca70b",
+      "seconds": 1959.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1437.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1955.0
+        }
+      ]
+    },
+    {
+      "run": 34092447406,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "c001ef1cf6b0889ee884485eb4ad0cc6348ca70b",
+      "seconds": 499.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 488.0
+        }
+      ]
+    },
+    {
+      "run": 34092373805,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "c001ef1cf6b0889ee884485eb4ad0cc6348ca70b",
+      "seconds": 612.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 609.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 351.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 99.0
+        }
+      ]
+    },
+    {
+      "run": 34089490400,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "d7ff86c2f3dd70a4694f46f883ba003ed62bdf82",
+      "seconds": 613.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 420.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 125.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 607.0
+        }
+      ]
+    },
+    {
+      "run": 34089490046,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "d7ff86c2f3dd70a4694f46f883ba003ed62bdf82",
+      "seconds": 2260.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 2249.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1446.0
+        }
+      ]
+    },
+    {
+      "run": 34088638019,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "417f6ca9e88bf20c9e8f9365407723dd513060b2",
+      "seconds": 709.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 117.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 609.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 400.0
+        }
+      ]
+    },
+    {
+      "run": 34085960973,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "26df47407cfeb0489af7934b7393104be287240c",
+      "seconds": 611.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 361.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 608.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 124.0
+        }
+      ]
+    },
+    {
+      "run": 34059971109,
+      "workflow": "Windows Package Candidate",
+      "event": "workflow_dispatch",
+      "sha": "09493451cc11e2344d227c5798366fb4eab27d7d",
+      "seconds": 1505.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1501.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1432.0
+        }
+      ]
+    },
+    {
+      "run": 34059969412,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "09493451cc11e2344d227c5798366fb4eab27d7d",
+      "seconds": 390.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 381.0
+        }
+      ]
+    },
+    {
+      "run": 34059941334,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "09493451cc11e2344d227c5798366fb4eab27d7d",
+      "seconds": 585.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 581.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 433.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 139.0
+        }
+      ]
+    },
+    {
+      "run": 34059343158,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "9b1b9f7231a0c7fe9e8166bde5afbfa1e6565aee",
+      "seconds": 622.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 110.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 619.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 334.0
+        }
+      ]
+    },
+    {
+      "run": 34058770962,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "f81c6b9676801ad71735b94c4e8b3fc907c8ce68",
+      "seconds": 618.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 614.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 400.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 162.0
+        }
+      ]
+    },
+    {
+      "run": 34055841527,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "8f464d28d4d53d773a7863a5e14f5ffb255f0c81",
+      "seconds": 594.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 117.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 445.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 589.0
+        }
+      ]
+    },
+    {
+      "run": 34053600453,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "68178b45ad067c6401d43a30413022c36d47be5f",
+      "seconds": 1545.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1542.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1465.0
+        }
+      ]
+    },
+    {
+      "run": 34053600448,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "68178b45ad067c6401d43a30413022c36d47be5f",
+      "seconds": 666.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 98.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 342.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 663.0
+        }
+      ]
+    },
+    {
+      "run": 34053312881,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "ffa1ba3c296a5bfa4f23eff2628be047f21f6e4d",
+      "seconds": 586.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 582.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 343.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 107.0
+        }
+      ]
+    },
+    {
+      "run": 34051290652,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "6701036c37a8341a90b26fdab5a95cc96ec87923",
+      "seconds": 2134.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1476.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 2119.0
+        }
+      ]
+    },
+    {
+      "run": 34051290649,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "6701036c37a8341a90b26fdab5a95cc96ec87923",
+      "seconds": 607.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 604.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 111.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 354.0
+        }
+      ]
+    },
+    {
+      "run": 34050208171,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "aa5eb24adedfd86d7a91203339ef1967fa611de4",
+      "seconds": 587.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 320.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 148.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 583.0
+        }
+      ]
+    },
+    {
+      "run": 34047258974,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "3a23068790d5656754218a211b01180db4b3172e",
+      "seconds": 1666.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 437.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 1024.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 1662.0
+        }
+      ]
+    },
+    {
+      "run": 34045760979,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "b55fe61a8a3114da7bf12f562d5a48cf0ec19730",
+      "seconds": 763.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 375.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 623.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 139.0
+        }
+      ]
+    },
+    {
+      "run": 34045760976,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "b55fe61a8a3114da7bf12f562d5a48cf0ec19730",
+      "seconds": 1589.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1182.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1439.0
+        }
+      ]
+    },
+    {
+      "run": 34044931114,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "24f77dfc991f31a75e682d06124bac3fd7757325",
+      "seconds": 729.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 163.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 375.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 573.0
+        }
+      ]
+    },
+    {
+      "run": 34043640213,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "197e8fc2e21101686041d22df1e37f594020fdd7",
+      "seconds": 671.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 142.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 667.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 491.0
+        }
+      ]
+    },
+    {
+      "run": 34025123374,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "cae6c59d780e3e2265a9885f16b5ac3ace006ef8",
+      "seconds": 1020.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1017.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 815.0
+        }
+      ]
+    },
+    {
+      "run": 34025123365,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "cae6c59d780e3e2265a9885f16b5ac3ace006ef8",
+      "seconds": 603.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 143.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 600.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 365.0
+        }
+      ]
+    },
+    {
+      "run": 34024234830,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "ae644530cd029a207da28e15b3d782f5139d96f5",
+      "seconds": 602.0,
+      "jobs": [
+        {
+          "name": "check-linux",
+          "seconds": 164.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 468.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 598.0
+        }
+      ]
+    },
+    {
+      "run": 34024234800,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "ae644530cd029a207da28e15b3d782f5139d96f5",
+      "seconds": 816.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 812.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 800.0
+        }
+      ]
+    },
+    {
+      "run": 34024021044,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "0b514fed95f190a616c161f6800fe298fd2f59c4",
+      "seconds": 468.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 365.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 162.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 465.0
+        }
+      ]
+    },
+    {
+      "run": 34023378069,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "e855258ab307f2a1ec3543e96081689d6129b525",
+      "seconds": 657.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 363.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 653.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 150.0
+        }
+      ]
+    },
+    {
+      "run": 34022984597,
+      "workflow": "Windows Package Candidate",
+      "event": "workflow_dispatch",
+      "sha": "882e4f4be448368cc445ae45a0aa706f19a8bebe",
+      "seconds": 1458.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1454.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 762.0
+        }
+      ]
+    },
+    {
+      "run": 34022983714,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "882e4f4be448368cc445ae45a0aa706f19a8bebe",
+      "seconds": 291.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 282.0
+        }
+      ]
+    },
+    {
+      "run": 34022909720,
+      "workflow": "CI",
+      "event": "push",
+      "sha": "882e4f4be448368cc445ae45a0aa706f19a8bebe",
+      "seconds": 521.0,
+      "jobs": [
+        {
+          "name": "check-macos",
+          "seconds": 459.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 143.0
+        },
+        {
+          "name": "check-windows",
+          "seconds": 518.0
+        }
+      ]
+    },
+    {
+      "run": 34022455753,
+      "workflow": "CI",
+      "event": "pull_request",
+      "sha": "dc108d8b0635b29423bb6aab0b98c610531a52ac",
+      "seconds": 625.0,
+      "jobs": [
+        {
+          "name": "check-windows",
+          "seconds": 621.0
+        },
+        {
+          "name": "check-linux",
+          "seconds": 154.0
+        },
+        {
+          "name": "check-macos",
+          "seconds": 284.0
+        }
+      ]
+    },
+    {
+      "run": 34021727764,
+      "workflow": "Windows Package Candidate",
+      "event": "workflow_dispatch",
+      "sha": "69b0118399bf73c74ff812dbf608a8a57e171ea5",
+      "seconds": 1952.0,
+      "jobs": [
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1945.0
+        },
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1425.0
+        }
+      ]
+    },
+    {
+      "run": 34021726711,
+      "workflow": "Test Build",
+      "event": "workflow_dispatch",
+      "sha": "69b0118399bf73c74ff812dbf608a8a57e171ea5",
+      "seconds": 448.0,
+      "jobs": [
+        {
+          "name": "build-macos-test",
+          "seconds": 440.0
+        }
+      ]
+    },
+    {
+      "run": 34021588070,
+      "workflow": "Windows Package Candidate",
+      "event": "pull_request",
+      "sha": "e7355d53c6c23f99c04aa3cb9643eeccf7bfe313",
+      "seconds": 1440.0,
+      "jobs": [
+        {
+          "name": "Build Windows arm64 candidate",
+          "seconds": 1416.0
+        },
+        {
+          "name": "Build Windows x64 candidate",
+          "seconds": 1435.0
+        }
+      ]
+    }
+  ],
+  "observedDate": "2026-09-08"
+}

--- a/docs/ci-performance/cohort-measurement.md
+++ b/docs/ci-performance/cohort-measurement.md
@@ -1,0 +1,101 @@
+# Comparing CI performance
+
+Issue [#178](https://github.com/Magnus-Gille/sagascript/issues/178) targets a large
+reduction in CI and build waiting. Measurement can proceed alongside application
+implementation: the reporting commands below read saved JSON and do not start
+builds, download models, change caches, or modify workflows.
+
+## Capture and report
+
+Use Node.js and the existing authenticated GitHub CLI. Save explicit run attempts
+so later reruns cannot silently change the evidence. For example, these commands
+read two existing runs; they do not dispatch or retry them:
+
+```sh
+gh run view 34204997034 --attempt 1 --repo Magnus-Gille/sagascript \
+  --json databaseId,headSha,workflowName,event,attempt,status,conclusion,createdAt,jobs \
+  > /tmp/sagascript-ci-run-a.json
+gh run view 34201979049 --attempt 1 --repo Magnus-Gille/sagascript \
+  --json databaseId,headSha,workflowName,event,attempt,status,conclusion,createdAt,jobs \
+  > /tmp/sagascript-ci-run-b.json
+jq -s '.' /tmp/sagascript-ci-run-a.json /tmp/sagascript-ci-run-b.json \
+  > /tmp/sagascript-ci-sample.json
+node scripts/ci-cohort-timings.mjs < /tmp/sagascript-ci-sample.json \
+  > /tmp/sagascript-ci-report.json
+```
+
+Select the full comparison window before collecting runs. Include failures,
+cancellations, and in-progress runs, not just the fastest green runs. Archive the
+input JSON together with the report. Repeat the same selection procedure after
+each optimization, retaining the commit SHA and run/attempt identity.
+
+The existing single-run command remains available:
+
+```sh
+gh run view 34204997034 --attempt 1 --repo Magnus-Gille/sagascript \
+  --json databaseId,headSha,jobs | node scripts/ci-run-timings.mjs
+```
+
+## Meaning of the measurements
+
+- **Elapsed:** run creation to the final job completion, including initial wait,
+  gaps between dependent jobs, and post-job cleanup.
+- **Initial wait:** run creation to the first job start. This does not measure
+  every job's scheduling delay.
+- **Wall:** first job start to final job completion; the existing single-run
+  reporter uses this definition.
+- **Runner:** sum of job durations, including jobs that execute in parallel.
+  This is raw time, not billed cost.
+- **p50 / p90:** median / nearest-rank 90th percentile, in seconds. Reports retain
+  sample size and range. Small samples are descriptive, not evidence of stable
+  tail performance.
+
+Cohorts separate workflow, event, and attempt. Only completed successful runs
+with complete required timing data contribute latency samples. Missing data is
+excluded explicitly, not converted to zero. Failed/cancelled outcomes remain
+counted. Job statistics use successful jobs; step statistics use successful steps
+within those jobs and retain the job name, step number, and step name so matrix
+architectures are not pooled. Job and step medians are independent distributions:
+adding them does not reconstruct the median workflow's critical path.
+
+Run creation precedes later retries, so elapsed time for attempt 2+ includes the
+intervening delay. Keep those cohorts separate; do not describe their elapsed
+metric as the retry's execution duration. Use wall/runner time for that question.
+
+The reporter cannot establish compiler cache hits, runner image changes, toolchain
+versions, or a split between compilation, linking, downloads, and notarization
+inside one step. Record that evidence separately. Do not rename a combined
+build/sign/notarize step as pure compilation or treat a short cache step as proof
+of a hit. Compare matched runner/architecture, workflow revision, feature/profile,
+and warm/cold conditions before attributing a speedup to a change.
+
+## September 8 reference
+
+[The baseline JSON](baseline-2026-09-08.json) preserves the earlier issue snapshot's
+workflow statistics, successful run IDs/SHAs, per-run job durations, and outcome
+counts. It is an archival summary, not the full raw input to the new CLI. Its
+mixed-event/mixed-attempt values should not be equated with individual cohorts.
+Full job/step metadata can be read from the linked GitHub run IDs while retained;
+the raw capture used for local validation lives outside the repository.
+
+| Workflow | Successes | Median | p90 | Median target |
+|---|---:|---:|---:|---:|
+| CI | 39 | 10m18s | 12m09s | 5m |
+| Windows Package Candidate | 20 | 31m04s | 36m11s | 15m |
+| Signed macOS Test Build | 9 | 8m19s | 10m16s | 5m |
+| Release | 1 | 17m47s observed | insufficient sample | 10m provisional |
+
+These are observations from September 6–8, 2026, after earlier caching work.
+They do not prove a warm-cache baseline. The full acceptance criteria remain in
+#178. Implementation of this reporter alone does not improve build speed or
+satisfy those criteria.
+
+## Local checks
+
+```sh
+node --test scripts/test-ci-run-timings.mjs scripts/test-ci-cohort-timings.mjs
+```
+
+The existing `scripts/run-frontend-tests.mjs` discovers the new test file
+automatically. No package manifest, dependency, CI trigger, signing, publication,
+or application changes are required for the reporting tool.

--- a/docs/ci-performance/optimization-2026-09-08.md
+++ b/docs/ci-performance/optimization-2026-09-08.md
@@ -51,7 +51,14 @@ passed all three platforms. New debug-profile cache fingerprints required cold
 builds: macOS took 1,185 seconds, Windows 1,643 seconds, and Linux 503 seconds.
 These are not comparable to the warm baseline and are not claimed as gains.
 The parallel split introduces separate cache namespaces and also requires an
-initial population before warm measurements.
+initial population before warm measurements. Its first attempt at
+`cebb0b13c4288294afae80b18cae941cc9d7547e` passed both native build jobs, but
+validation failed because a Python workflow fixture still expected the old job
+names. The final aggregation jobs correctly failed too. The fixture now checks
+the three validation jobs and retains the Python-version and ordering assertions.
+Local verification after this correction passed all 127 Python tests and 185
+frontend tests (one additional test is skipped), plus workflow actionlint.
+The failed workflow is excluded from successful latency comparisons.
 
 The first Windows candidate attempt at `15113c01b8a626c2f59c06c939a4f17a27459a19`
 failed before native compilation: a newly added test expected LF but the Windows
@@ -63,8 +70,14 @@ A separate code-generation parallelism experiment compares release builds with
 one and sixteen codegen units while retaining optimization level 3 and thin LTO.
 An initial offline attempt failed to link ONNX Runtime and is excluded from all
 performance comparisons. Successful local CLI builds took 75.76 seconds with one
-codegen unit and 90.16 seconds with sixteen. This first comparison did not show
-an improvement; the existing release setting is retained.
+codegen unit and 90.16 seconds with sixteen. Sixteen units were 19% slower for this CLI build. A controlled app experiment,
+with workspace crates cleaned and dependency artifacts retained between builds,
+used order 1 → 16 → 16 → 1: 95.03, 73.56, 75.86, and 108.22 seconds. The means
+were 101.63 versus 74.71 seconds, a 26.5% local improvement, but the app binary
+grew from 43,777,296 to 49,891,488 bytes (14%). These trials used the same older
+source revision, not the final CI patch; runtime parity was not benchmarked.
+The mixed CLI/app results and binary growth do not justify changing the global
+release setting, which remains one codegen unit.
 
 The larger acceptance cohorts in #178 remain necessary before claiming stable
 median/tail targets or closing the issue. Signed macOS and production release
@@ -96,5 +109,7 @@ final performance assessment. Bounded tasks used native Luna agents:
 | Model cache implementation | gpt-5.6-luna / high | Cache contract and Windows workflow tests, actionlint | pass |
 | CLI duplicate-gate removal | gpt-5.6-luna / xhigh | Feature coverage test, actionlint | partial: Windows line-ending failure corrected after native CI |
 | LF/CRLF regression correction | gpt-5.6-luna / high | Both line-ending fixtures pass; conductor reran | pass |
-| Parallel validation/native lanes | gpt-5.6-luna / high | Gate parity, actionlint, full suite; conductor expanded all 16 aggregate cases and retained smoke failure policy | pass |
-| Release code-generation experiment | gpt-5.6-luna / xhigh | Successful CLI paired builds; controlled app experiment in progress | partial: CLI setting rejected as slower |
+| Parallel validation/native lanes | gpt-5.6-luna / high | Gate parity, actionlint, frontend suite; conductor expanded all 16 aggregate cases and retained smoke failure policy | partial: missed Python workflow fixture corrected after CI |
+| Python workflow fixture correction | gpt-5.6-luna / high | Red/green regression, 127 Python tests and frontend suite rerun by conductor | pass |
+| Release code-generation experiment | gpt-5.6-luna / xhigh | Paired CLI builds and four controlled app builds; logs and sizes inspected by conductor | pass: measured tradeoff, setting retained |
+| Follow-up rebuild diagnosis | gpt-5.6-luna / xhigh | Historical Cargo logs and source inspection | partial: stale worktree context corrected; exact invalidation cause remains unproven |

--- a/docs/ci-performance/optimization-2026-09-08.md
+++ b/docs/ci-performance/optimization-2026-09-08.md
@@ -140,6 +140,14 @@ both architecture packages, and the existing transcription gates before merge;
 its result is recorded in PR #226. This compatibility correction is not claimed
 as a compilation or inference speed improvement.
 
+Successful Cargo logs hide CMake output, so ARM64 candidates additionally inspect
+the generated Ninja compiler flags after debug and installer compilation. The
+check prints each selected cache and unique `-mcpu` settings, rejects missing or
+SVE/SME-enabled evidence, and requires explicit `native+...+nosve+nosme` flags.
+The preceding exact-head CI run [34230248675](https://github.com/Magnus-Gille/sagascript/actions/runs/34230248675)
+passed all seven jobs in 8m40s (24m03s summed runner time); this verification run
+does not replace the original cached comparison above.
+
 Merging this PR activates the main-push CI workflow. Windows candidates remain
 PR/manual-triggered, signed macOS test builds remain manual, and application
 releases remain tag-triggered. No application release is needed for these CI
@@ -165,3 +173,4 @@ final performance assessment. Bounded tasks used native Luna agents:
 | ARM64 image diagnosis | gpt-5.6-luna / xhigh | Pinned CMake/header source and old/new compiler logs checked | pass |
 | ARM64 regression tests | gpt-5.6-luna / high | Red/green CMake tests; conductor corrected native flag name and strengthened diagnostics/module coverage | partial |
 | Cleanup inventory and evidence archive | gpt-5.6-luna / high | Clean status, patch-ID equivalence, source/copy SHA-256 checks repeated by conductor | pass |
+| ARM64 generated-build evidence | gpt-5.6-luna / high | Realistic Ninja fixtures and workflow regression tests; conductor corrected actual flag format and per-flag validation | partial |

--- a/docs/ci-performance/optimization-2026-09-08.md
+++ b/docs/ci-performance/optimization-2026-09-08.md
@@ -1,7 +1,7 @@
 # CI optimization experiment — September 8, 2026
 
 Tracking: [issue #178](https://github.com/Magnus-Gille/sagascript/issues/178),
-[draft PR #226](https://github.com/Magnus-Gille/sagascript/pull/226).
+[PR #226](https://github.com/Magnus-Gille/sagascript/pull/226).
 
 ## Baseline and changes
 
@@ -97,6 +97,54 @@ as runner-cost tradeoffs. The conductor also added explicit assertions that
 macOS checks remain blocking and only the two existing Windows smoke exceptions
 remain nonblocking.
 
+## Cached comparison and merge review
+
+The nearest main control, [34216174578 attempt 1](https://github.com/Magnus-Gille/sagascript/actions/runs/34216174578/attempts/1),
+used `b661415f6db99e64bad95cfdd766e7c359733b1a`. The corrected cached PR repeat,
+[34224809046 attempt 2](https://github.com/Magnus-Gille/sagascript/actions/runs/34224809046/attempts/2),
+used `fcd1599f840f4005c97416c076538d8ad71eaaf5` and passed all seven jobs.
+
+| Metric | Main control | Cached PR repeat |
+|---|---:|---:|
+| First job start to last job end | 10m58s | 8m01s |
+| Summed runner time | 18m55s | 23m24s |
+| macOS native build step | 2m15s | 3m12s |
+| Windows native build step | 5m08s | 5m39s |
+
+This is **26.9% less waiting** and **23.7% more runner time**. Native compilation
+itself did not get faster. Summed runner time is not billed cost. This single
+cached comparison is not a stable percentile result: triggers differ (main push
+versus PR rerun), although application Rust source and these three runner images
+were unchanged. The corrected first attempt passed in 15m31s with cold validation
+caches. Issue #178 remains open for faster compilation, packaging, lower runner
+time, and the larger acceptance cohorts.
+
+The [unsigned candidate repeat](https://github.com/Magnus-Gille/sagascript/actions/runs/34224809050)
+passed x64 in 18m51s, versus 16m48s at a different older application revision;
+this does not establish a packaging gain. ARM64 failed after the image changed
+from `20260830.155.1` (Clang 20.1.6) to `20260906.161.1` (Clang 22.1.8).
+Both ARM attempts missed their image-scoped Rust cache. The new native probe
+selected SVE, which makes pinned `whisper-rs-sys` 0.14.1 include Linux-only
+`sys/prctl.h` on Windows. The preceding cold candidate
+[34221630681](https://github.com/Magnus-Gille/sagascript/actions/runs/34221630681)
+passed both architectures. The image compatibility failure is not a timing sample.
+
+The merge-review correction adds a Windows ARM64-only CMake hook that forces
+only the pinned SVE/SME positive probe caches off. It preserves native tuning and
+dotprod/i8mm probes, and lets upstream test the corresponding disabling flags.
+The hook has Windows/ARM64/pointer-size guards and participates in the native
+cache key. Regression tests exercise the actual CMake source-run check module
+and reject wrong targets. Dependency updates must re-audit these internal probe
+names. The native candidate run must confirm `+nosve+nosme` in generated flags,
+both architecture packages, and the existing transcription gates before merge;
+its result is recorded in PR #226. This compatibility correction is not claimed
+as a compilation or inference speed improvement.
+
+Merging this PR activates the main-push CI workflow. Windows candidates remain
+PR/manual-triggered, signed macOS test builds remain manual, and application
+releases remain tag-triggered. No application release is needed for these CI
+changes. Reverting the PR restores the prior workflow and tooling behavior.
+
 ## Delegated work
 
 The conductor integrates changes, checks results, and owns publication and the
@@ -113,3 +161,7 @@ final performance assessment. Bounded tasks used native Luna agents:
 | Python workflow fixture correction | gpt-5.6-luna / high | Red/green regression, 127 Python tests and frontend suite rerun by conductor | pass |
 | Release code-generation experiment | gpt-5.6-luna / xhigh | Paired CLI builds and four controlled app builds; logs and sizes inspected by conductor | pass: measured tradeoff, setting retained |
 | Follow-up rebuild diagnosis | gpt-5.6-luna / xhigh | Historical Cargo logs and source inspection | partial: stale worktree context corrected; exact invalidation cause remains unproven |
+| Merge review: gate parity and frontend reuse | gpt-5.6-luna / high | Focused tests plus conductor inspection; fresh independent Claude Sonnet 5 review | pass |
+| ARM64 image diagnosis | gpt-5.6-luna / xhigh | Pinned CMake/header source and old/new compiler logs checked | pass |
+| ARM64 regression tests | gpt-5.6-luna / high | Red/green CMake tests; conductor corrected native flag name and strengthened diagnostics/module coverage | partial |
+| Cleanup inventory and evidence archive | gpt-5.6-luna / high | Clean status, patch-ID equivalence, source/copy SHA-256 checks repeated by conductor | pass |

--- a/docs/ci-performance/optimization-2026-09-08.md
+++ b/docs/ci-performance/optimization-2026-09-08.md
@@ -1,0 +1,100 @@
+# CI optimization experiment — September 8, 2026
+
+Tracking: [issue #178](https://github.com/Magnus-Gille/sagascript/issues/178),
+[draft PR #226](https://github.com/Magnus-Gille/sagascript/pull/226).
+
+## Baseline and changes
+
+The archived [baseline](baseline-2026-09-08.json) contains 39 successful CI runs
+(median 618 seconds) and 20 successful Windows candidate runs (median 1,864
+seconds). These mixed cohorts include different cache conditions and revisions;
+they are context, not a matched control for attributing a percentage improvement.
+
+The nearest main revision is `b661415f6db99e64bad95cfdd766e7c359733b1a`.
+[CI run 34216174578](https://github.com/Magnus-Gille/sagascript/actions/runs/34216174578)
+took 351 seconds on macOS and 658 seconds on Windows. Native build steps took
+135 and 308 seconds respectively (Cargo itself reported 132 and 301 seconds).
+The macOS native step rebuilt the three workspace crates. Windows additionally
+rebuilt `ort-sys` and `ort`; a cache hit does not imply no compilation.
+
+The proposed changes preserve the existing native, inference, architecture,
+unsigned-installer, and source-identity gates:
+
+- Retain source-line backtraces while reducing development/test debug information
+  to `line-tables-only`. Release optimization remains unchanged by this setting.
+- Reuse the frontend built earlier in each job. Validate its title and content
+  hash against build metadata before Tauri embeds it; fail on missing or changed
+  output. Normal local frontend builds still regenerate output and metadata.
+- Remove three redundant macOS CLI diarization commands. CLI default features
+  already include diarization; default CLI tests/all-target Clippy and the
+  separate core feature matrix remain. Those commands cost 14 seconds in the
+  nearest main run (approximately 15 seconds in the broader baseline).
+- Cache Windows candidate model files, retaining manifest verification and both
+  inference gates. Earlier downloads took only 3–5 seconds, so this is a small
+  improvement rather than the main performance opportunity.
+- Run macOS and Windows validation alongside native release builds. Separate
+  caches keep development/test dependencies apart from release dependencies.
+  Final jobs retain the existing `check-macos` and `check-windows` status names
+  and require both lanes to succeed, including failure/cancellation/skip cases.
+  This trades duplicated runner setup for a shorter critical path; measure total
+  runner time as well as elapsed time.
+- Add offline cohort reporting and Cargo fingerprint diagnostics for measuring
+  subsequent changes and explaining rebuilds.
+
+Local frontend timing was approximately 0.58 seconds for Vite versus 0.03 seconds
+for reuse validation. This measures one local invocation, not total CI latency.
+
+## Verification and limitations
+
+The initial unsplit native CI run at `15113c01b8a626c2f59c06c939a4f17a27459a19`
+passed all three platforms. New debug-profile cache fingerprints required cold
+builds: macOS took 1,185 seconds, Windows 1,643 seconds, and Linux 503 seconds.
+These are not comparable to the warm baseline and are not claimed as gains.
+The parallel split introduces separate cache namespaces and also requires an
+initial population before warm measurements.
+
+The first Windows candidate attempt at `15113c01b8a626c2f59c06c939a4f17a27459a19`
+failed before native compilation: a newly added test expected LF but the Windows
+workflow checkout used CRLF. The correction parameterizes the test for both line
+endings without weakening its feature assertions. Failed attempts remain part
+of the experiment record; their short durations are not speed improvements.
+
+A separate code-generation parallelism experiment compares release builds with
+one and sixteen codegen units while retaining optimization level 3 and thin LTO.
+An initial offline attempt failed to link ONNX Runtime and is excluded from all
+performance comparisons. Successful local CLI builds took 75.76 seconds with one
+codegen unit and 90.16 seconds with sixteen. This first comparison did not show
+an improvement; the existing release setting is retained.
+
+The larger acceptance cohorts in #178 remain necessary before claiming stable
+median/tail targets or closing the issue. Signed macOS and production release
+workflows have not been dispatched for this experiment. Native run results and
+subsequent attempt comparisons are recorded in PR #226. Compare workflow elapsed
+time across the split, not old versus new `check-macos`/`check-windows` job
+durations: those names become short aggregation jobs. Compare native build steps
+against the new `build-macos`/`build-windows` lanes explicitly.
+
+The initial independent review used Claude Sonnet 5 in read-only mode. Its only
+medium concern was missing context for the signed macOS frontend-build ordering:
+source inspection confirmed `Build fresh frontend` precedes the Tauri reuse step.
+The review found no confirmed defect. A separate Claude Sonnet 5 review of the parallel-job change found no blockers
+after deterministic checks passed. It confirmed gate parity and fail-closed
+aggregation, and highlighted duplicated setup and loss of sequential fail-fast
+as runner-cost tradeoffs. The conductor also added explicit assertions that
+macOS checks remain blocking and only the two existing Windows smoke exceptions
+remain nonblocking.
+
+## Delegated work
+
+The conductor integrates changes, checks results, and owns publication and the
+final performance assessment. Bounded tasks used native Luna agents:
+
+| Task | Model / effort | Checks | Usefulness |
+|---|---|---|---|
+| Historical timing and log analysis | gpt-5.6-luna / high | Raw run/step arithmetic cross-checked | pass |
+| Frontend reuse implementation | gpt-5.6-luna / high | Focused tests, full frontend suite, build and hash validation | partial: schema corrected and metadata test strengthened during integration |
+| Model cache implementation | gpt-5.6-luna / high | Cache contract and Windows workflow tests, actionlint | pass |
+| CLI duplicate-gate removal | gpt-5.6-luna / xhigh | Feature coverage test, actionlint | partial: Windows line-ending failure corrected after native CI |
+| LF/CRLF regression correction | gpt-5.6-luna / high | Both line-ending fixtures pass; conductor reran | pass |
+| Parallel validation/native lanes | gpt-5.6-luna / high | Gate parity, actionlint, full suite; conductor expanded all 16 aggregate cases and retained smoke failure policy | pass |
+| Release code-generation experiment | gpt-5.6-luna / xhigh | Successful CLI paired builds; controlled app experiment in progress | partial: CLI setting rejected as slower |

--- a/scripts/build-frontend.mjs
+++ b/scripts/build-frontend.mjs
@@ -1,27 +1,14 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const dist = join(root, "dist");
 const vite = join(root, "node_modules", "vite", "bin", "vite.js");
 
-// Tauri embeds dist at Rust compile time. Removing it first prevents obsolete
-// hashed assets from surviving an incremental build.
-rmSync(dist, { recursive: true, force: true });
-execFileSync(process.execPath, [vite, "build"], { cwd: root, stdio: "inherit" });
-
-const indexPath = join(dist, "index.html");
-if (!existsSync(indexPath)) {
-  throw new Error("Vite completed without producing dist/index.html");
-}
-if (!readFileSync(indexPath, "utf8").includes("<title>Sagascript Settings</title>")) {
-  throw new Error("dist/index.html does not contain the current Sagascript title");
-}
-
-function addTree(hash, path, relative = "") {
+export function addTree(hash, path, relative = "") {
   for (const name of readdirSync(path).sort()) {
     const absolute = join(path, name);
     const child = join(relative, name);
@@ -35,12 +22,59 @@ function addTree(hash, path, relative = "") {
   }
 }
 
-const hash = createHash("sha256");
-addTree(hash, dist);
-const frontendHash = hash.digest("hex");
-// build.rs watches this ignored file. A changed frontend content hash forces
-// Cargo/Tauri to regenerate the embedded asset context even with target/ cached.
-writeFileSync(
-  join(root, "src-tauri", "build-meta.env"),
-  `SAGASCRIPT_FRONTEND_HASH=${frontendHash}\n`,
-);
+export function hashFrontendTree(distPath) {
+  const hash = createHash("sha256");
+  addTree(hash, distPath);
+  return hash.digest("hex");
+}
+
+export function validateFrontendOutput(distPath) {
+  const indexPath = join(distPath, "index.html");
+  if (!existsSync(indexPath)) {
+    throw new Error("Vite output is missing dist/index.html");
+  }
+  if (!readFileSync(indexPath, "utf8").includes("<title>Sagascript Settings</title>")) {
+    throw new Error("dist/index.html does not contain the current Sagascript title");
+  }
+}
+
+export function validateFrontend({ distPath, metadataPath }) {
+  validateFrontendOutput(distPath);
+
+  if (!existsSync(metadataPath)) {
+    throw new Error("Frontend metadata is missing src-tauri/build-meta.env");
+  }
+  const metadata = readFileSync(metadataPath, "utf8");
+  const match = /^SAGASCRIPT_FRONTEND_HASH=([0-9a-f]{64})\n?$/.exec(metadata);
+  if (!match) {
+    throw new Error("Frontend metadata contains an invalid SAGASCRIPT_FRONTEND_HASH");
+  }
+
+  const actualHash = hashFrontendTree(distPath);
+  if (actualHash !== match[1]) {
+    throw new Error(
+      `Frontend output hash ${actualHash} does not match build metadata ${match[1]}`,
+    );
+  }
+  return actualHash;
+}
+
+function buildFrontend() {
+  // Tauri embeds dist at Rust compile time. Removing it first prevents obsolete
+  // hashed assets from surviving an incremental build.
+  rmSync(dist, { recursive: true, force: true });
+  execFileSync(process.execPath, [vite, "build"], { cwd: root, stdio: "inherit" });
+
+  validateFrontendOutput(dist);
+  const frontendHash = hashFrontendTree(dist);
+  // build.rs watches this ignored file. A changed frontend content hash forces
+  // Cargo/Tauri to regenerate the embedded asset context even with target/ cached.
+  writeFileSync(
+    join(root, "src-tauri", "build-meta.env"),
+    `SAGASCRIPT_FRONTEND_HASH=${frontendHash}\n`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  buildFrontend();
+}

--- a/scripts/ci-cohort-timings.mjs
+++ b/scripts/ci-cohort-timings.mjs
@@ -1,0 +1,249 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+import { summarizeRun } from "./ci-run-timings.mjs";
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${label} must be a non-empty string`);
+  return value;
+}
+
+function requiredId(value, label) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function optionalAttempt(value, label) {
+  if (value === undefined || value === null || value === "") return null;
+  return requiredId(value, label);
+}
+
+function parseTimestamp(value, label) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") throw new TypeError(`${label} must be an ISO timestamp or null`);
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) throw new TypeError(`${label} is not a valid timestamp: ${value}`);
+  return milliseconds;
+}
+
+function interval(start, end, label) {
+  if (start === null || end === null) return null;
+  const seconds = (end - start) / 1000;
+  if (seconds < 0) throw new RangeError(`${label} has a negative interval`);
+  return seconds;
+}
+
+function nearestRank(values, percentile) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const rank = Math.max(1, Math.ceil(percentile * sorted.length));
+  return sorted[rank - 1];
+}
+
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function stats(values) {
+  if (values.length === 0) return { n: 0, p50: null, p90: null, min: null, max: null };
+  return {
+    n: values.length,
+    p50: median(values),
+    p90: nearestRank(values, 0.9),
+    min: Math.min(...values),
+    max: Math.max(...values),
+  };
+}
+
+function aggregate(valuesByName) {
+  return [...valuesByName.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, values]) => ({ name, ...stats(values) }));
+}
+
+function validateRun(run, index) {
+  const label = `runs[${index}]`;
+  if (run === null || typeof run !== "object" || Array.isArray(run)) throw new TypeError(`${label} must be an object`);
+  for (const key of ["databaseId", "headSha", "workflowName", "event", "status", "conclusion", "jobs"]) {
+    if (!hasOwn(run, key)) throw new TypeError(`${label}.${key} is required`);
+  }
+  const id = requiredId(run.databaseId, `${label}.databaseId`);
+  const workflowName = requiredString(run.workflowName, `${label}.workflowName`);
+  const event = requiredString(run.event, `${label}.event`);
+  const status = requiredString(run.status, `${label}.status`);
+  if (run.conclusion !== null && typeof run.conclusion !== "string") {
+    throw new TypeError(`${label}.conclusion must be a string or null`);
+  }
+  if (status === "completed" && (run.conclusion === null || run.conclusion.length === 0)) {
+    throw new TypeError(`${label}.conclusion is required for completed runs`);
+  }
+  const attempt = optionalAttempt(run.attempt, `${label}.attempt`);
+  const createdMilliseconds = parseTimestamp(run.createdAt, `${label}.createdAt`);
+  let normalizedRun;
+  try {
+    normalizedRun = summarizeRun(run);
+  } catch (error) {
+    throw new Error(`${label}: ${error.message}`, { cause: error });
+  }
+  const jobs = normalizedRun.jobs;
+  const jobStarts = jobs.map((job) => parseTimestamp(run.jobs.find((candidate) => candidate.databaseId === job.id)?.startedAt, `${label}.jobs[${job.id}].startedAt`));
+  const jobEnds = jobs.map((job) => parseTimestamp(run.jobs.find((candidate) => candidate.databaseId === job.id)?.completedAt, `${label}.jobs[${job.id}].completedAt`));
+  const completeTiming = createdMilliseconds !== null && jobs.length > 0 && jobs.every((job, position) => (
+    job.durationSeconds !== null && jobStarts[position] !== null && jobEnds[position] !== null
+  ));
+  const initialWaitSeconds = completeTiming ? interval(createdMilliseconds, Math.min(...jobStarts), `${label}.createdAt→first job`) : null;
+  const elapsedSeconds = completeTiming ? interval(createdMilliseconds, Math.max(...jobEnds), `${label}.createdAt→last job`) : null;
+  const eligible = status === "completed" && run.conclusion === "success" && completeTiming;
+  return {
+    id,
+    attempt,
+    workflowName,
+    event,
+    headSha: requiredString(run.headSha, `${label}.headSha`),
+    status,
+    conclusion: run.conclusion,
+    createdAt: run.createdAt === undefined || run.createdAt === null ? null : requiredString(run.createdAt, `${label}.createdAt`),
+    eligible,
+    incomplete: status === "completed" && run.conclusion === "success" && !completeTiming,
+    reason: eligible ? null : (status === "completed" && run.conclusion === "success" ? "incomplete-timing" : "unsuccessful"),
+    normalizedRun,
+    initialWaitSeconds,
+    elapsedSeconds,
+  };
+}
+
+function addOutcome(counts, run) {
+  counts.total += 1;
+  if (run.status !== "completed") counts.inProgress += 1;
+  if (run.conclusion === "success") counts.success += 1;
+  else if (run.conclusion === null) counts.noConclusion += 1;
+  const outcome = run.conclusion ?? "none";
+  counts.outcomes[outcome] = (Object.prototype.hasOwnProperty.call(counts.outcomes, outcome) ? counts.outcomes[outcome] : 0) + 1;
+  if (run.incomplete) counts.incomplete += 1;
+  if (run.eligible) counts.eligible += 1;
+}
+
+export function summarizeCohorts(runs) {
+  if (!Array.isArray(runs)) throw new TypeError("stdin JSON must be an array of workflow runs");
+  if (runs.length === 0) throw new Error("stdin JSON array is empty");
+  const cohorts = new Map();
+  const seen = new Set();
+  for (let index = 0; index < runs.length; index += 1) {
+    const run = validateRun(runs[index], index);
+    const identity = `${run.id}/${run.attempt === null ? "null" : run.attempt}`;
+    if (seen.has(identity)) throw new Error(`duplicate run databaseId/attempt ${identity}`);
+    seen.add(identity);
+    const key = `${run.workflowName}\u0000${run.event}\u0000${run.attempt === null ? "null" : run.attempt}`;
+    if (!cohorts.has(key)) {
+      cohorts.set(key, {
+        workflowName: run.workflowName,
+        event: run.event,
+        attempt: run.attempt,
+        ledger: [],
+        counts: { total: 0, eligible: 0, incomplete: 0, success: 0, inProgress: 0, noConclusion: 0, outcomes: Object.create(null) },
+        metricValues: { elapsedSeconds: [], initialWaitSeconds: [], wallSeconds: [], runnerSeconds: [] },
+        jobValues: new Map(),
+        stepValues: new Map(),
+      });
+    }
+    const cohort = cohorts.get(key);
+    addOutcome(cohort.counts, run);
+    cohort.ledger.push({
+      id: run.id,
+      attempt: run.attempt,
+      headSha: run.headSha,
+      status: run.status,
+      conclusion: run.conclusion,
+      createdAt: run.createdAt,
+      eligible: run.eligible,
+      incomplete: run.incomplete,
+      reason: run.reason,
+      elapsedSeconds: run.elapsedSeconds,
+      initialWaitSeconds: run.initialWaitSeconds,
+      wallSeconds: run.normalizedRun.wallSeconds,
+      runnerSeconds: run.normalizedRun.runnerSeconds,
+    });
+    if (!run.eligible) continue;
+    cohort.metricValues.elapsedSeconds.push(run.elapsedSeconds);
+    cohort.metricValues.initialWaitSeconds.push(run.initialWaitSeconds);
+    cohort.metricValues.wallSeconds.push(run.normalizedRun.wallSeconds);
+    cohort.metricValues.runnerSeconds.push(run.normalizedRun.runnerSeconds);
+    for (const job of run.normalizedRun.jobs) {
+      if (job.conclusion !== "success" || job.durationSeconds === null) continue;
+      const jobName = job.name ?? String(job.id);
+      if (!cohort.jobValues.has(jobName)) cohort.jobValues.set(jobName, []);
+      cohort.jobValues.get(jobName).push(job.durationSeconds);
+      for (const step of job.steps) {
+        if (step.conclusion !== "success" || step.durationSeconds === null) continue;
+        const stepName = step.name ?? `step-${step.number}`;
+        const stepKey = `${jobName}\u0000${step.number}\u0000${stepName}`;
+        if (!cohort.stepValues.has(stepKey)) cohort.stepValues.set(stepKey, { jobName, name: stepName, number: step.number, values: [] });
+        cohort.stepValues.get(stepKey).values.push(step.durationSeconds);
+      }
+    }
+  }
+  return {
+    cohorts: [...cohorts.values()].map((cohort) => {
+      const metrics = Object.fromEntries(Object.entries(cohort.metricValues).map(([name, values]) => [name, stats(values)]));
+      cohort.ledger.sort((left, right) => left.id - right.id || (left.attempt ?? -1) - (right.attempt ?? -1));
+      return {
+        workflowName: cohort.workflowName,
+        event: cohort.event,
+        attempt: cohort.attempt,
+        ledger: cohort.ledger,
+        counts: { ...cohort.counts, outcomes: { ...cohort.counts.outcomes } },
+        elapsedSeconds: metrics.elapsedSeconds,
+        initialWaitSeconds: metrics.initialWaitSeconds,
+        wallSeconds: metrics.wallSeconds,
+        runnerSeconds: metrics.runnerSeconds,
+        jobs: aggregate(cohort.jobValues),
+        steps: [...cohort.stepValues.values()]
+          .sort((left, right) => left.jobName.localeCompare(right.jobName) || left.number - right.number || left.name.localeCompare(right.name))
+          .map(({ jobName, name, number, values }) => ({ jobName, name, number, ...stats(values) })),
+      };
+    }).sort((left, right) => left.workflowName.localeCompare(right.workflowName) || left.event.localeCompare(right.event) || (left.attempt ?? -1) - (right.attempt ?? -1)),
+  };
+}
+
+function isDirectEntry() {
+  if (!process.argv[1]) return false;
+  const invoked = pathToFileURL(resolve(process.argv[1])).href;
+  const module = pathToFileURL(fileURLToPath(import.meta.url)).href;
+  return invoked === module;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/ci-cohort-timings.mjs < runs.json\n\nRead a JSON array of GitHub workflow runs from stdin and group by workflowName, event, and attempt.\nBuild the array from gh run view RUN_ID --json databaseId,headSha,workflowName,event,attempt,status,conclusion,createdAt,jobs\n(or concatenate those objects from multiple gh run view calls). Required run fields: databaseId, headSha, workflowName, event,\nstatus, conclusion, jobs. attempt and timestamps may be null/missing; conclusion may be null while a run is in progress.\nSuccessful runs with incomplete timestamps stay in the ledger and counts but are excluded from latency aggregates.\np50 is the median; p90 uses nearest rank.\n`);
+}
+
+function main() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    printHelp();
+    return;
+  }
+  try {
+    const input = readFileSync(0, "utf8");
+    if (input.trim() === "") throw new Error("stdin JSON is empty");
+    let runs;
+    try {
+      runs = JSON.parse(input);
+    } catch (error) {
+      throw new Error(`stdin is not valid JSON: ${error.message}`);
+    }
+    process.stdout.write(`${JSON.stringify(summarizeCohorts(runs), null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`ci-cohort-timings: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectEntry()) main();

--- a/scripts/cmake/windows-arm64-native.cmake
+++ b/scripts/cmake/windows-arm64-native.cmake
@@ -1,0 +1,35 @@
+# Injected through CMAKE_PROJECT_INCLUDE by the unsigned Windows ARM64
+# candidate. Other CMake projects and all other workflow targets are unaffected.
+if(NOT PROJECT_NAME STREQUAL "whisper.cpp")
+  return()
+endif()
+
+string(TOLOWER "${CMAKE_SYSTEM_NAME}" _sagascript_system_name)
+if(NOT _sagascript_system_name STREQUAL "windows")
+  message(FATAL_ERROR
+    "Sagascript whisper.cpp ARM hook: CMAKE_SYSTEM_NAME must be Windows "
+    "(got '${CMAKE_SYSTEM_NAME}')")
+endif()
+
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _sagascript_processor)
+if(NOT _sagascript_processor STREQUAL "arm64"
+   AND NOT _sagascript_processor STREQUAL "aarch64")
+  message(FATAL_ERROR
+    "Sagascript whisper.cpp ARM hook requires an ARM64 or aarch64 target "
+    "(got '${CMAKE_SYSTEM_PROCESSOR}')")
+endif()
+
+if(DEFINED CMAKE_SIZEOF_VOID_P AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+  message(FATAL_ERROR
+    "Sagascript whisper.cpp ARM hook requires 8-byte pointers "
+    "(got '${CMAKE_SIZEOF_VOID_P}')")
+endif()
+
+# whisper-rs-sys 0.14.1 / Whisper 1.7.6 uses these cached source-run checks
+# in ggml/src/ggml-cpu/CMakeLists.txt. Its SVE implementation includes Linux's
+# sys/prctl.h, even when a Windows Clang probe reports success. Skip only the
+# positive SVE/SME probes: GGML still verifies +nosve/+nosme compiler support
+# and probes dotprod/i8mm normally. Keep GGML_NATIVE and other tuning unchanged.
+# These are pinned implementation details; re-audit them on dependency updates.
+set(GGML_MACHINE_SUPPORTS_sve OFF CACHE INTERNAL "SVE unavailable in Windows Whisper" FORCE)
+set(GGML_MACHINE_SUPPORTS_sme OFF CACHE INTERNAL "SME unavailable in Windows Whisper" FORCE)

--- a/scripts/dictation_eval/test_evaluate_cli.py
+++ b/scripts/dictation_eval/test_evaluate_cli.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
@@ -16,9 +17,13 @@ SCRIPT = Path(__file__).with_name("evaluate.py")
 class EvaluateCliTests(unittest.TestCase):
     def test_ci_selects_supported_python_before_all_evaluator_suites(self):
         workflow = SCRIPT.parents[2] / ".github" / "workflows" / "ci.yml"
-        source = workflow.read_text(encoding="utf-8")
-        for name in ("check-macos", "check-linux", "check-windows"):
-            job = source.split(f"  {name}:\n", 1)[1].split("\n  check-", 1)[0]
+        source = workflow.read_text(encoding="utf-8").replace("\r\n", "\n")
+        for name in ("test-macos", "check-linux", "test-windows"):
+            marker = f"  {name}:\n"
+            start = source.index(marker) + len(marker)
+            next_job = re.search(r"^  [A-Za-z0-9_-]+:\s*$", source[start:], re.MULTILINE)
+            end = start + next_job.start() if next_job else len(source)
+            job = source[start:end]
             setup = job.index("actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1")
             suite = job.index("Test offline dictation evaluation tooling")
             self.assertLess(setup, suite)

--- a/scripts/report-windows-arm64-native.mjs
+++ b/scripts/report-windows-arm64-native.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+const profiles = [
+  ["debug"],
+  ["release"],
+  ["aarch64-pc-windows-msvc", "debug"],
+  ["aarch64-pc-windows-msvc", "release"],
+];
+async function isDirectory(path) {
+  try {
+    const info = await lstat(path);
+    return info.isDirectory() && !info.isSymbolicLink();
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    return false;
+  }
+}
+async function isFile(path) {
+  try {
+    const info = await lstat(path);
+    return info.isFile() && !info.isSymbolicLink();
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    return false;
+  }
+}
+function cleanToken(token) {
+  return token.replace(/^["'`]+|["'`,;]+$/g, "");
+}
+async function isSafeDirectory(root, ...parts) {
+  let path = root;
+  for (const part of parts) {
+    path = join(path, part);
+    if (!(await isDirectory(path))) return false;
+  }
+  return true;
+}
+async function findCaches(targetRoot) {
+  const selected = [];
+  for (const profile of profiles) {
+    const profileRoot = join(targetRoot, ...profile, "build");
+    if (!(await isSafeDirectory(targetRoot, ...profile, "build"))) continue;
+    for (const crate of await readdir(profileRoot, { withFileTypes: true })) {
+      if (!crate.isDirectory() || crate.isSymbolicLink() || !crate.name.startsWith("whisper-rs-sys-")) {
+        continue;
+      }
+      const cmakeRoot = join(profileRoot, crate.name, "out", "build");
+      if (!(await isSafeDirectory(targetRoot, ...profile, "build", crate.name, "out", "build"))) continue;
+      const cachePath = join(cmakeRoot, "CMakeCache.txt");
+      if (!(await isFile(cachePath))) continue;
+      const cache = await readFile(cachePath, "utf8");
+      if (!cache.split(/\r?\n/).some((line) => line === "CMAKE_PROJECT_NAME:STATIC=whisper.cpp")) {
+        continue;
+      }
+      const ninjaPath = join(cmakeRoot, "build.ninja");
+      if (!(await isFile(ninjaPath))) {
+        throw new Error(`matching cache has no sibling build.ninja: ${cachePath}`);
+      }
+      selected.push({ cachePath, ninjaPath, ninja: await readFile(ninjaPath, "utf8") });
+    }
+  }
+  return selected;
+}
+function inspectNinja(ninja) {
+  const lines = ninja.split(/\r?\n/).filter((line) => /^\s*FLAGS\s*=/.test(line));
+  const tokens = lines.flatMap((line) => line.trim().split(/\s+/).flatMap((token) => token.split(",")));
+  const mcpu = [...new Set(tokens.map(cleanToken).filter((token) => /^-mcpu=/i.test(token)))].sort();
+  if (mcpu.length === 0) throw new Error("no actual -mcpu= flag in Ninja FLAGS lines");
+  for (const flag of mcpu) {
+    const components = flag.slice("-mcpu=".length).toLowerCase().split("+");
+    if (components[0] !== "native") {
+      throw new Error(`required +native base missing from -mcpu= flag '${flag}'`);
+    }
+    for (const feature of ["sve", "sme"]) {
+      if (components.some((component) => new RegExp(`^${feature}(?:[0-9-]|$)`).test(component))) {
+        throw new Error(`positive ${feature}/${feature}2 token in Ninja FLAGS lines`);
+      }
+    }
+    for (const component of ["nosve", "nosme"]) {
+      if (!components.includes(component)) {
+        throw new Error(`required +${component} component missing from -mcpu= flag '${flag}'`);
+      }
+    }
+  }
+  return mcpu;
+}
+async function main() {
+  if (process.argv.length !== 3) throw new Error("usage: report-windows-arm64-native.mjs TARGET_ROOT");
+  const targetRoot = resolve(process.argv[2]);
+  if (!(await isDirectory(targetRoot))) throw new Error(`target root is not a real directory: ${targetRoot}`);
+  const candidates = await findCaches(targetRoot);
+  if (candidates.length === 0) throw new Error(`no whisper.cpp CMake caches under ${targetRoot}`);
+  const allMcpu = new Set();
+  for (const candidate of candidates) {
+    for (const flag of inspectNinja(candidate.ninja)) allMcpu.add(flag);
+    console.log(`Evidence pass: ${candidate.cachePath}`);
+  }
+  console.log(`Unique -mcpu= flags: ${[...allMcpu].sort().join(", ")}`);
+}
+main().catch((error) => {
+  console.error(`ARM64 native evidence failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/reuse-frontend.mjs
+++ b/scripts/reuse-frontend.mjs
@@ -1,0 +1,16 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateFrontend } from "./build-frontend.mjs";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+try {
+  const frontendHash = validateFrontend({
+    distPath: join(root, "dist"),
+    metadataPath: join(root, "src-tauri", "build-meta.env"),
+  });
+  console.log(`Reusing verified frontend output (${frontendHash})`);
+} catch (error) {
+  console.error(`Cannot reuse frontend output: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/tauri-ci-prebuilt.json
+++ b/scripts/tauri-ci-prebuilt.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
+  "build": {
+    "beforeBuildCommand": "node scripts/reuse-frontend.mjs"
+  }
+}

--- a/scripts/tauri-ci-prebuilt.json
+++ b/scripts/tauri-ci-prebuilt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/nicerdicer/tauri-v2-schema/refs/heads/main/tauri.conf.schema.json",
+  "$schema": "https://schema.tauri.app/config/2",
   "build": {
     "beforeBuildCommand": "node scripts/reuse-frontend.mjs"
   }

--- a/scripts/test-ci-cli-feature-coverage.mjs
+++ b/scripts/test-ci-cli-feature-coverage.mjs
@@ -11,8 +11,8 @@ const [cliManifest, coreManifest, ciWorkflow] = await Promise.all([
 function macosWorkflowFor(workflow) {
   const normalized = workflow.replace(/\r\n/g, "\n");
   return normalized.slice(
-    normalized.indexOf("  check-macos:"),
-    normalized.indexOf("  check-linux:"),
+    normalized.indexOf("  test-macos:"),
+    normalized.indexOf("  build-macos:"),
   );
 }
 

--- a/scripts/test-ci-cli-feature-coverage.mjs
+++ b/scripts/test-ci-cli-feature-coverage.mjs
@@ -8,12 +8,16 @@ const [cliManifest, coreManifest, ciWorkflow] = await Promise.all([
   readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
 ]);
 
-const macosWorkflow = ciWorkflow.slice(
-  ciWorkflow.indexOf("  check-macos:"),
-  ciWorkflow.indexOf("  check-linux:"),
-);
+function macosWorkflowFor(workflow) {
+  const normalized = workflow.replace(/\r\n/g, "\n");
+  return normalized.slice(
+    normalized.indexOf("  check-macos:"),
+    normalized.indexOf("  check-linux:"),
+  );
+}
 
-test("macOS CI keeps CLI diarization in defaults and gates core explicitly", () => {
+function assertMacosDiarizationCoverage(workflow) {
+  const macosWorkflow = macosWorkflowFor(workflow);
   assert.match(
     cliManifest,
     /default\s*=\s*\[\s*"record"\s*,\s*"diarization"\s*\]/,
@@ -30,4 +34,13 @@ test("macOS CI keeps CLI diarization in defaults and gates core explicitly", () 
     3,
     "core check, test, and all-target clippy gates must remain separate",
   );
-});
+}
+
+for (const [label, lineEnding] of [
+  ["LF", "\n"],
+  ["CRLF", "\r\n"],
+]) {
+  test(`macOS CI keeps CLI diarization in defaults and gates core explicitly (${label})`, () => {
+    assertMacosDiarizationCoverage(ciWorkflow.replace(/\r?\n/g, lineEnding));
+  });
+}

--- a/scripts/test-ci-cli-feature-coverage.mjs
+++ b/scripts/test-ci-cli-feature-coverage.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const [cliManifest, coreManifest, ciWorkflow] = await Promise.all([
+  readFile(new URL("../src-tauri/crates/sagascript-cli/Cargo.toml", import.meta.url), "utf8"),
+  readFile(new URL("../src-tauri/crates/sagascript-core/Cargo.toml", import.meta.url), "utf8"),
+  readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
+]);
+
+const macosWorkflow = ciWorkflow.slice(
+  ciWorkflow.indexOf("  check-macos:"),
+  ciWorkflow.indexOf("  check-linux:"),
+);
+
+test("macOS CI keeps CLI diarization in defaults and gates core explicitly", () => {
+  assert.match(
+    cliManifest,
+    /default\s*=\s*\[\s*"record"\s*,\s*"diarization"\s*\]/,
+    "CLI default features must include diarization",
+  );
+  assert.match(coreManifest, /default\s*=\s*\[\s*\]/, "core must retain its no-feature default");
+
+  assert.match(macosWorkflow, /run: cargo test -p sagascript-cli\n/);
+  assert.match(macosWorkflow, /run: cargo clippy -p sagascript-cli --all-targets -- -D warnings\n/);
+  assert.doesNotMatch(macosWorkflow, /-p sagascript-cli --features diarization/);
+
+  assert.equal(
+    (macosWorkflow.match(/-p sagascript-core --features diarization/g) ?? []).length,
+    3,
+    "core check, test, and all-target clippy gates must remain separate",
+  );
+});

--- a/scripts/test-ci-cohort-timings.mjs
+++ b/scripts/test-ci-cohort-timings.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { summarizeCohorts } from "./ci-cohort-timings.mjs";
+
+const cli = fileURLToPath(new URL("./ci-cohort-timings.mjs", import.meta.url));
+const at = (seconds) => new Date(Date.parse("2026-09-05T00:00:00Z") + seconds * 1000).toISOString();
+
+function job(databaseId, start, end, name = `job-${databaseId}`, steps = []) {
+  return {
+    databaseId,
+    name,
+    status: "completed",
+    conclusion: "success",
+    startedAt: start === null ? null : at(start),
+    completedAt: end === null ? null : at(end),
+    steps,
+  };
+}
+
+function run(databaseId, start, end, overrides = {}) {
+  const jobStart = start === null || end === null ? start : Math.min(start + 2, end);
+  return {
+    databaseId,
+    headSha: `sha-${databaseId}`,
+    workflowName: "CI",
+    event: "push",
+    attempt: 1,
+    status: "completed",
+    conclusion: "success",
+    createdAt: start === null ? null : at(start),
+    jobs: [job(databaseId * 10, jobStart, end)],
+    ...overrides,
+  };
+}
+
+test("groups by workflow, event, and attempt and computes parallel timing", () => {
+  const result = summarizeCohorts([
+    run(1, 0, 10, {
+      jobs: [
+        job(11, 2, 10, "build", [{ number: 1, name: "compile", status: "completed", conclusion: "success", startedAt: at(3), completedAt: at(8) }]),
+        job(12, 4, 7, "test", [{ number: 1, name: "unit", status: "completed", conclusion: "skipped", startedAt: at(4), completedAt: at(6) }]),
+      ],
+    }),
+    run(2, 0, 20),
+  ]);
+  assert.equal(result.cohorts.length, 1);
+  const cohort = result.cohorts[0];
+  assert.deepEqual(cohort.counts, { total: 2, eligible: 2, incomplete: 0, success: 2, inProgress: 0, noConclusion: 0, outcomes: { success: 2 } });
+  assert.deepEqual(cohort.elapsedSeconds, { n: 2, p50: 15, p90: 20, min: 10, max: 20 });
+  assert.deepEqual(cohort.initialWaitSeconds, { n: 2, p50: 2, p90: 2, min: 2, max: 2 });
+  assert.deepEqual(cohort.wallSeconds, { n: 2, p50: 13, p90: 18, min: 8, max: 18 });
+  assert.deepEqual(cohort.runnerSeconds, { n: 2, p50: 14.5, p90: 18, min: 11, max: 18 });
+  assert.deepEqual(cohort.jobs.find((entry) => entry.name === "build"), { name: "build", n: 1, p50: 8, p90: 8, min: 8, max: 8 });
+  assert.deepEqual(cohort.steps.find((entry) => entry.name === "compile"), { jobName: "build", name: "compile", number: 1, n: 1, p50: 5, p90: 5, min: 5, max: 5 });
+  assert.equal(cohort.steps.find((entry) => entry.name === "unit"), undefined);
+});
+
+test("uses median for p50 and nearest rank for p90", () => {
+  const result = summarizeCohorts([run(1, 0, 1), run(2, 0, 3), run(3, 0, 9)]).cohorts[0];
+  assert.deepEqual(result.elapsedSeconds, { n: 3, p50: 3, p90: 9, min: 1, max: 9 });
+});
+
+test("keeps mixed outcomes and incomplete successes in the ledger", () => {
+  const result = summarizeCohorts([
+    run(1, 0, 4),
+    run(2, 0, 3, { conclusion: "failure" }),
+    run(3, 0, null, { status: "in_progress", conclusion: null }),
+    run(4, null, null),
+  ]).cohorts[0];
+  assert.deepEqual(result.counts, { total: 4, eligible: 1, incomplete: 1, success: 2, inProgress: 1, noConclusion: 1, outcomes: { failure: 1, none: 1, success: 2 } });
+  assert.equal(result.elapsedSeconds.n, 1);
+  assert.deepEqual(result.ledger.map(({ id, eligible, incomplete, reason }) => ({ id, eligible, incomplete, reason })), [
+    { id: 1, eligible: true, incomplete: false, reason: null },
+    { id: 2, eligible: false, incomplete: false, reason: "unsuccessful" },
+    { id: 3, eligible: false, incomplete: false, reason: "unsuccessful" },
+    { id: 4, eligible: false, incomplete: true, reason: "incomplete-timing" },
+  ]);
+});
+
+test("separates attempts and rejects duplicate run/attempt identities", () => {
+  const result = summarizeCohorts([run(1, 0, 1), run(2, 0, 2, { attempt: 2 })]);
+  assert.equal(result.cohorts.length, 2);
+  assert.throws(() => summarizeCohorts([run(1, 0, 1), run(1, 0, 2)]), /duplicate run databaseId\/attempt 1\/1/);
+  assert.equal(summarizeCohorts([run(1, 0, 1), run(1, 0, 2, { attempt: 2 })]).cohorts.length, 2);
+});
+
+test("keeps architecture-specific jobs and steps separate and splits workflow/event cohorts", () => {
+  const architectureRuns = [
+    run(10, 0, 8, {
+      jobs: [
+        job(101, 1, 8, "build-x64", [{ number: 1, name: "compile", status: "completed", conclusion: "success", startedAt: at(2), completedAt: at(7) }]),
+        job(102, 1, 6, "build-arm64", [{ number: 1, name: "compile", status: "completed", conclusion: "success", startedAt: at(2), completedAt: at(5) }]),
+      ],
+    }),
+    run(11, 0, 9, {
+      jobs: [
+        job(111, 1, 9, "build-x64", [{ number: 1, name: "compile", status: "completed", conclusion: "success", startedAt: at(2), completedAt: at(8) }]),
+        job(112, 1, 7, "build-arm64", [{ number: 1, name: "compile", status: "completed", conclusion: "success", startedAt: at(2), completedAt: at(6) }]),
+      ],
+    }),
+  ];
+  const sameCohort = summarizeCohorts(architectureRuns).cohorts[0];
+  assert.deepEqual(sameCohort.jobs.map(({ name }) => name), ["build-arm64", "build-x64"]);
+  assert.deepEqual(sameCohort.steps.map(({ jobName, name, number }) => ({ jobName, name, number })), [
+    { jobName: "build-arm64", name: "compile", number: 1 },
+    { jobName: "build-x64", name: "compile", number: 1 },
+  ]);
+  assert.deepEqual(sameCohort.steps.map(({ n }) => n), [2, 2]);
+
+  const split = summarizeCohorts([
+    ...architectureRuns,
+    run(12, 0, 2, { workflowName: "Release" }),
+    run(13, 0, 3, { event: "pull_request" }),
+  ]);
+  assert.equal(split.cohorts.length, 3);
+  assert.deepEqual(split.cohorts.map(({ workflowName, event }) => `${workflowName}/${event}`), ["CI/pull_request", "CI/push", "Release/push"]);
+});
+
+test("validates required semantics, malformed timestamps, and negative intervals", () => {
+  const missingEvent = run(1, 0, 1);
+  delete missingEvent.event;
+  assert.throws(() => summarizeCohorts([missingEvent]), /runs\[0\]\.event is required/);
+  const missingHeadSha = run(1, 0, 1);
+  delete missingHeadSha.headSha;
+  assert.throws(() => summarizeCohorts([missingHeadSha]), /runs\[0\]\.headSha is required/);
+  assert.throws(() => summarizeCohorts([run(1, 0, 1, { createdAt: "nope" })]), /runs\[0\]\.createdAt is not a valid timestamp/);
+  assert.throws(() => summarizeCohorts([run(1, 5, 1)]), /createdAt→first job has a negative interval/);
+  assert.throws(() => summarizeCohorts([run(1, 0, 1, { status: "completed", conclusion: null })]), /conclusion is required/);
+});
+
+test("counts arbitrary conclusions without colliding with object properties", () => {
+  const result = summarizeCohorts([run(1, 0, 1, { conclusion: "constructor" }), run(2, 0, 1, { conclusion: "__proto__" })]).cohorts[0];
+  assert.equal(result.counts.outcomes.constructor, 1);
+  assert.equal(result.counts.outcomes["__proto__"], 1);
+  assert.equal(result.counts.eligible, 0);
+  assert.equal(result.elapsedSeconds.n, 0);
+});
+
+test("CLI supports help, JSON output, and failures", () => {
+  const help = spawnSync(process.execPath, [cli, "--help"], { encoding: "utf8" });
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /Required run fields/);
+  const valid = spawnSync(process.execPath, [cli], { input: JSON.stringify([run(7, 0, 2)]), encoding: "utf8" });
+  assert.equal(valid.status, 0);
+  assert.equal(JSON.parse(valid.stdout).cohorts[0].ledger[0].id, 7);
+  for (const input of ["", "{bad", "{}", "[]"]) {
+    const failed = spawnSync(process.execPath, [cli], { input, encoding: "utf8" });
+    assert.equal(failed.status, 1);
+    assert.match(failed.stderr, /ci-cohort-timings:/);
+    assert.equal(failed.stdout, "");
+  }
+});

--- a/scripts/test-ci-parallel-gates.mjs
+++ b/scripts/test-ci-parallel-gates.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = (await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"))
+  .replace(/\r\n/g, "\n");
+
+function jobBlock(jobId) {
+  const start = workflow.indexOf(`  ${jobId}:`);
+  assert.notEqual(start, -1, `workflow must define ${jobId}`);
+  const remainder = workflow.slice(start);
+  const body = remainder.slice(remainder.indexOf("\n") + 1);
+  const nextJob = body.search(/^  [a-z][a-z0-9-]*:/m);
+  return remainder.slice(0, nextJob === -1 ? remainder.length : remainder.indexOf("\n") + 1 + nextJob);
+}
+
+function parseSteps(job) {
+  const lines = job.split("\n");
+  const starts = lines
+    .map((line, index) => (/^      - name: (.*)$/.exec(line) ? index : -1))
+    .filter((index) => index >= 0);
+  const result = new Map();
+
+  for (let i = 0; i < starts.length; i += 1) {
+    const start = starts[i];
+    const end = starts[i + 1] ?? lines.length;
+    const segment = lines.slice(start, end);
+    const name = /^      - name: (.*)$/.exec(segment[0])[1];
+    const runIndex = segment.findIndex((line) => /^        run:\s*/.test(line));
+    if (runIndex < 0) continue;
+
+    const runValue = segment[runIndex].replace(/^        run:\s*/, "");
+    let command;
+    if (runValue === "|" || runValue === ">" || runValue === ">-") {
+      command = segment
+        .slice(runIndex + 1)
+        .filter((line) => line.length === 0 || line.startsWith("          "))
+        .map((line) => line.replace(/^          /, ""))
+        .join("\n");
+    } else {
+      command = runValue;
+    }
+    result.set(name, command.trim());
+  }
+  return result;
+}
+
+function normalizeCommand(command) {
+  return command.replace(/\r\n/g, "\n").trim();
+}
+
+// These are the Cargo/native/smoke run bodies in the pre-split check-macos and
+// check-windows jobs at base 1ab1128. Keeping the fixture explicit makes a
+// dropped invocation fail this test even if the replacement workflow remains valid YAML.
+const BASELINE_GATES = {
+  macos: {
+    test: [
+      ["Cargo check", "cargo check"],
+      ["Cargo test", "cargo test"],
+      ["Cargo clippy", "cargo clippy -- -D warnings"],
+      ["Cargo test (sagascript-core, no features)", "cargo test -p sagascript-core"],
+      ["Cargo test (sagascript-cli)", "cargo test -p sagascript-cli"],
+      ["Cargo clippy (sagascript-core, no features)", "cargo clippy -p sagascript-core --all-targets -- -D warnings"],
+      ["Cargo clippy (sagascript-cli)", "cargo clippy -p sagascript-cli --all-targets -- -D warnings"],
+      ["Cargo check (sagascript-core, diarization)", "cargo check -p sagascript-core --features diarization"],
+      ["Cargo test (sagascript-core, diarization)", "cargo test -p sagascript-core --features diarization"],
+      ["Cargo clippy (sagascript-core, diarization)", "cargo clippy -p sagascript-core --features diarization --all-targets -- -D warnings"],
+    ],
+    build: [
+      ["Build native release binary (no installer)", "npx tauri build --config scripts/tauri-ci-prebuilt.json --no-bundle"],
+      ["Verify native release binary", "BINARY=src-tauri/target/release/sagascript\n[[ -x \"$BINARY\" ]]\nfile \"$BINARY\""],
+      ["Smoke test — help and version", "BINARY=src-tauri/target/release/sagascript\n$BINARY --help\n$BINARY transcribe --help\n$BINARY record --help"],
+      ["Smoke test — config management", "BINARY=src-tauri/target/release/sagascript\n$BINARY config list\n$BINARY config get language\n$BINARY config set language sv\n$BINARY config get language | grep -q sv\n$BINARY config reset language\n$BINARY config get language | grep -q en\n$BINARY config path"],
+      ["Smoke test — model listing and formats", "BINARY=src-tauri/target/release/sagascript\n$BINARY list-models\n$BINARY formats"],
+      ["Smoke test — shell completions", "BINARY=src-tauri/target/release/sagascript\n$BINARY completions zsh > /dev/null\n$BINARY completions bash > /dev/null"],
+      ["Smoke test — download model and transcribe", "BINARY=src-tauri/target/release/sagascript\n$BINARY download-model nb-whisper-tiny\nRESULT=$($BINARY transcribe --language no --model nb-whisper-tiny test-audio/norwegian-short-3s.mp3)\necho \"Transcription: $RESULT\"\necho \"$RESULT\" | grep -iq \"stortinget\""],
+      ["Smoke test — transcribe with JSON output", "BINARY=src-tauri/target/release/sagascript\nSTDOUT=\"$RUNNER_TEMP/transcription-smoke.json\"\nSTDERR=\"$RUNNER_TEMP/transcription-smoke.stderr\"\n$BINARY transcribe --json --language no --model nb-whisper-tiny \\\n  test-audio/norwegian-short-3s.mp3 > \"$STDOUT\" 2> \"$STDERR\"\npython3 scripts/verify-json-cli-streams.py \"$STDOUT\" \"$STDERR\""],
+    ],
+  },
+  windows: {
+    test: [
+      ["Cargo check", "cargo check"],
+      ["Cargo test", "cargo test"],
+      ["Cargo clippy", "cargo clippy -- -D warnings"],
+      ["Cargo test (sagascript-core, no features)", "cargo test -p sagascript-core"],
+      ["Cargo test (sagascript-cli)", "cargo test -p sagascript-cli"],
+      ["Cargo clippy (sagascript-core, no features)", "cargo clippy -p sagascript-core --all-targets -- -D warnings"],
+      ["Cargo clippy (sagascript-cli)", "cargo clippy -p sagascript-cli --all-targets -- -D warnings"],
+    ],
+    build: [
+      ["Build native release binary (no installer)", "npx tauri build --config scripts/tauri-ci-prebuilt.json --no-bundle"],
+      ["Verify native release binary", "$binary = \"src-tauri\\target\\release\\sagascript.exe\"\nif (-not (Test-Path -PathType Leaf $binary)) {\n  throw \"Missing native release binary: $binary\"\n}"],
+      ["Smoke test — help and version", "$env:BINARY = \"src-tauri\\target\\release\\sagascript.exe\"\n& $env:BINARY --help\n& $env:BINARY transcribe --help\n& $env:BINARY record --help"],
+      ["Smoke test — config management", "$env:BINARY = \"src-tauri\\target\\release\\sagascript.exe\"\n& $env:BINARY config list\n& $env:BINARY config get language\n& $env:BINARY config set language sv\n$result = & $env:BINARY config get language\nif ($result -notmatch \"sv\") { throw \"Expected 'sv'\" }\n& $env:BINARY config reset language\n$result = & $env:BINARY config get language\nif ($result -notmatch \"en\") { throw \"Expected 'en'\" }\n& $env:BINARY config path"],
+      ["Smoke test — model listing and formats", "$env:BINARY = \"src-tauri\\target\\release\\sagascript.exe\"\n& $env:BINARY list-models\n& $env:BINARY formats"],
+      ["Smoke test — shell completions", "$env:BINARY = \"src-tauri\\target\\release\\sagascript.exe\"\n& $env:BINARY completions powershell | Out-Null"],
+      ["Smoke test — download model and transcribe", "$env:BINARY = \"src-tauri\\target\\release\\sagascript.exe\"\n& $env:BINARY download-model nb-whisper-tiny\n$result = & $env:BINARY transcribe --language no --model nb-whisper-tiny test-audio/norwegian-short-3s.mp3\nWrite-Host \"Transcription: $result\"\nif ($result -notmatch \"(?i)stortinget\") { throw \"Expected 'stortinget' in output\" }"],
+      ["Smoke test — transcribe with JSON output", "set BINARY=src-tauri\\target\\release\\sagascript.exe\n%BINARY% transcribe --json --language no --model nb-whisper-tiny test-audio/norwegian-short-3s.mp3 > json_output.txt 2>nul\ntype json_output.txt\nfindstr /C:\"text\" json_output.txt\nfindstr /C:\"duration_seconds\" json_output.txt\nfindstr /C:\"language\" json_output.txt"],
+    ],
+  },
+};
+
+for (const [platform, jobIds] of Object.entries({
+  macos: { test: "test-macos", build: "build-macos" },
+  windows: { test: "test-windows", build: "build-windows" },
+})) {
+  for (const lane of ["test", "build"]) {
+    test(`${platform} ${lane} lane retains every baseline gate`, () => {
+      const commands = parseSteps(jobBlock(jobIds[lane]));
+      for (const [name, expected] of BASELINE_GATES[platform][lane]) {
+        assert.equal(
+          commands.get(name),
+          normalizeCommand(expected),
+          `${jobIds[lane]} must retain the baseline ${name} command`,
+        );
+      }
+    });
+  }
+}
+
+test("model caches are isolated to native lanes", () => {
+  assert.doesNotMatch(jobBlock("test-macos"), /name: Cache downloaded models/);
+  assert.doesNotMatch(jobBlock("test-windows"), /name: Cache downloaded models/);
+  assert.match(jobBlock("build-macos"), /name: Cache downloaded models/);
+  assert.match(jobBlock("build-windows"), /name: Cache downloaded models/);
+  assert.match(jobBlock("test-macos"), /shared-key: sagascript-ci-checks/);
+  assert.match(jobBlock("test-windows"), /shared-key: sagascript-ci-checks/);
+  assert.match(jobBlock("build-macos"), /shared-key: sagascript-ci-native/);
+  assert.match(jobBlock("build-windows"), /shared-key: sagascript-ci-native/);
+});
+
+function aggregator(jobId, expectedNeeds, testResultName, buildResultName) {
+  const block = jobBlock(jobId);
+  const needs = /^    needs: \[([^\]]+)\]$/m.exec(block)?.[1]
+    .split(",")
+    .map((value) => value.trim());
+  assert.deepEqual(needs, expectedNeeds, `${jobId} must wait for both platform lanes`);
+  assert.match(block, /^    if: \$\{\{ always\(\) \}\}$/m);
+  assert.match(block, new RegExp(`TEST_RESULT: \\\$\\{\\{ needs\\.${testResultName}\\.result \\\}\\}`));
+  assert.match(block, new RegExp(`BUILD_RESULT: \\\$\\{\\{ needs\\.${buildResultName}\\.result \\\}\\}`));
+  const run = parseSteps(block).get(jobId === "check-macos" ? "Assert macOS CI lanes passed" : "Assert Windows CI lanes passed");
+  assert.match(run, /test "\$TEST_RESULT" = success/);
+  assert.match(run, /test "\$BUILD_RESULT" = success/);
+  return run;
+}
+
+function runAggregator(run, testResult, buildResult) {
+  execFileSync("bash", ["-euo", "pipefail", "-c", run], {
+    env: { PATH: process.env.PATH, TEST_RESULT: testResult, BUILD_RESULT: buildResult },
+    stdio: "pipe",
+  });
+}
+
+for (const [jobId, needs] of [
+  ["check-macos", ["test-macos", "build-macos"]],
+  ["check-windows", ["test-windows", "build-windows"]],
+]) {
+  test(`${jobId} fails closed for every non-success lane result`, () => {
+    const [testLane, buildLane] = needs;
+    const run = aggregator(jobId, needs, testLane, buildLane);
+    assert.doesNotThrow(() => runAggregator(run, "success", "success"));
+    for (const status of ["failure", "cancelled", "skipped"]) {
+      assert.throws(
+        () => runAggregator(run, status, "success"),
+        `${jobId} must reject ${status} test lane result`,
+      );
+      assert.throws(
+        () => runAggregator(run, "success", status),
+        `${jobId} must reject ${status} build lane result`,
+      );
+    }
+  });
+}

--- a/scripts/test-ci-parallel-gates.mjs
+++ b/scripts/test-ci-parallel-gates.mjs
@@ -107,7 +107,9 @@ for (const [platform, jobIds] of Object.entries({
 })) {
   for (const lane of ["test", "build"]) {
     test(`${platform} ${lane} lane retains every baseline gate`, () => {
-      const commands = parseSteps(jobBlock(jobIds[lane]));
+      const block = jobBlock(jobIds[lane]);
+      assert.doesNotMatch(block, /^    needs:/m, "validation and native builds must run independently");
+      const commands = parseSteps(block);
       for (const [name, expected] of BASELINE_GATES[platform][lane]) {
         assert.equal(
           commands.get(name),
@@ -118,6 +120,18 @@ for (const [platform, jobIds] of Object.entries({
     });
   }
 }
+
+test("parallel lanes preserve blocking checks and existing Windows smoke exceptions", () => {
+  for (const jobId of ["test-macos", "test-windows", "build-macos"]) {
+    assert.doesNotMatch(jobBlock(jobId), /continue-on-error:/);
+  }
+  const windows = jobBlock("build-windows");
+  assert.equal((windows.match(/continue-on-error: true/g) ?? []).length, 2);
+  for (const name of ["Smoke test — download model and transcribe", "Smoke test — transcribe with JSON output"]) {
+    const step = windows.slice(windows.indexOf(`      - name: ${name}`)).split(/\n      - name:/)[0];
+    assert.match(step, /continue-on-error: true/);
+  }
+});
 
 test("model caches are isolated to native lanes", () => {
   assert.doesNotMatch(jobBlock("test-macos"), /name: Cache downloaded models/);
@@ -159,16 +173,15 @@ for (const [jobId, needs] of [
   test(`${jobId} fails closed for every non-success lane result`, () => {
     const [testLane, buildLane] = needs;
     const run = aggregator(jobId, needs, testLane, buildLane);
-    assert.doesNotThrow(() => runAggregator(run, "success", "success"));
-    for (const status of ["failure", "cancelled", "skipped"]) {
-      assert.throws(
-        () => runAggregator(run, status, "success"),
-        `${jobId} must reject ${status} test lane result`,
-      );
-      assert.throws(
-        () => runAggregator(run, "success", status),
-        `${jobId} must reject ${status} build lane result`,
-      );
+    for (const testResult of ["success", "failure", "cancelled", "skipped"]) {
+      for (const buildResult of ["success", "failure", "cancelled", "skipped"]) {
+        const invoke = () => runAggregator(run, testResult, buildResult);
+        if (testResult === "success" && buildResult === "success") {
+          assert.doesNotThrow(invoke);
+        } else {
+          assert.throws(invoke, `${jobId} must reject ${testResult}/${buildResult}`);
+        }
+      }
     }
   });
 }

--- a/scripts/test-frontend-reuse.mjs
+++ b/scripts/test-frontend-reuse.mjs
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { hashFrontendTree, validateFrontend } from "./build-frontend.mjs";
 
-async function fixture() {
+async function fixture(t) {
   const root = await mkdtemp(join(tmpdir(), "sagascript-frontend-reuse-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
   const distPath = join(root, "dist");
   const metadataPath = join(root, "build-meta.env");
   const indexPath = join(distPath, "index.html");
@@ -17,16 +18,19 @@ async function fixture() {
   return { distPath, metadataPath, hash };
 }
 
-test("verified frontend output is reusable without rewriting metadata", async () => {
-  const { distPath, metadataPath, hash } = await fixture();
+test("verified frontend output is reusable without rewriting metadata", async (t) => {
+  const { distPath, metadataPath, hash } = await fixture(t);
+  await utimes(metadataPath, 1000, 1000);
   const before = await readFile(metadataPath, "utf8");
+  const beforeMtime = (await stat(metadataPath)).mtimeMs;
 
   assert.equal(validateFrontend({ distPath, metadataPath }), hash);
   assert.equal(await readFile(metadataPath, "utf8"), before);
+  assert.equal((await stat(metadataPath)).mtimeMs, beforeMtime);
 });
 
-test("changed frontend output is rejected", async () => {
-  const { distPath, metadataPath } = await fixture();
+test("changed frontend output is rejected", async (t) => {
+  const { distPath, metadataPath } = await fixture(t);
   await writeFile(join(distPath, "app.js"), "changed");
 
   assert.throws(
@@ -35,8 +39,8 @@ test("changed frontend output is rejected", async () => {
   );
 });
 
-test("missing frontend output is rejected", async () => {
-  const { distPath, metadataPath } = await fixture();
+test("missing frontend output is rejected", async (t) => {
+  const { distPath, metadataPath } = await fixture(t);
   await rm(distPath, { recursive: true });
 
   assert.throws(
@@ -45,12 +49,12 @@ test("missing frontend output is rejected", async () => {
   );
 });
 
-test("missing frontend metadata is rejected", async () => {
-  const { distPath, metadataPath } = await fixture();
-  await writeFile(metadataPath, "");
+test("missing frontend metadata is rejected", async (t) => {
+  const { distPath, metadataPath } = await fixture(t);
+  await rm(metadataPath);
 
   assert.throws(
     () => validateFrontend({ distPath, metadataPath }),
-    /invalid SAGASCRIPT_FRONTEND_HASH/,
+    /Frontend metadata is missing/,
   );
 });

--- a/scripts/test-frontend-reuse.mjs
+++ b/scripts/test-frontend-reuse.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { hashFrontendTree, validateFrontend } from "./build-frontend.mjs";
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "sagascript-frontend-reuse-"));
+  const distPath = join(root, "dist");
+  const metadataPath = join(root, "build-meta.env");
+  const indexPath = join(distPath, "index.html");
+  await mkdir(distPath);
+  await writeFile(indexPath, "<title>Sagascript Settings</title>\n");
+  const hash = hashFrontendTree(distPath);
+  await writeFile(metadataPath, `SAGASCRIPT_FRONTEND_HASH=${hash}\n`);
+  return { distPath, metadataPath, hash };
+}
+
+test("verified frontend output is reusable without rewriting metadata", async () => {
+  const { distPath, metadataPath, hash } = await fixture();
+  const before = await readFile(metadataPath, "utf8");
+
+  assert.equal(validateFrontend({ distPath, metadataPath }), hash);
+  assert.equal(await readFile(metadataPath, "utf8"), before);
+});
+
+test("changed frontend output is rejected", async () => {
+  const { distPath, metadataPath } = await fixture();
+  await writeFile(join(distPath, "app.js"), "changed");
+
+  assert.throws(
+    () => validateFrontend({ distPath, metadataPath }),
+    /does not match build metadata/,
+  );
+});
+
+test("missing frontend output is rejected", async () => {
+  const { distPath, metadataPath } = await fixture();
+  await rm(distPath, { recursive: true });
+
+  assert.throws(
+    () => validateFrontend({ distPath, metadataPath }),
+    /missing dist\/index\.html/,
+  );
+});
+
+test("missing frontend metadata is rejected", async () => {
+  const { distPath, metadataPath } = await fixture();
+  await writeFile(metadataPath, "");
+
+  assert.throws(
+    () => validateFrontend({ distPath, metadataPath }),
+    /invalid SAGASCRIPT_FRONTEND_HASH/,
+  );
+});

--- a/scripts/test-pipeline-cache.mjs
+++ b/scripts/test-pipeline-cache.mjs
@@ -69,3 +69,39 @@ test("Windows native cache is isolated by runner image and toolchain namespace",
     "installer cleanup must remain after the native build gates",
   );
 });
+
+test("Windows candidates cache only verified models with a candidate primary key", () => {
+  const modelCacheStart = windowsWorkflow.indexOf("name: Cache downloaded models");
+  const identityStart = windowsWorkflow.indexOf("name: Pin validated Windows build identity");
+  const rustCacheStart = windowsWorkflow.indexOf("name: Cache Rust dependencies");
+  assert.ok(modelCacheStart > rustCacheStart && identityStart > modelCacheStart);
+
+  const cache = section(windowsWorkflow, "name: Cache downloaded models", "name: Pin validated Windows build identity");
+  assert.match(cache, /uses: actions\/cache@v5/);
+  assert.match(cache, /path: ~\\AppData\\Roaming\\Sagascript\\Models/);
+  assert.equal((cache.match(/^\s*path:/gm) ?? []).length, 1, "cache must contain one exact model path");
+  assert.equal(
+    cache.match(/^\s*path:\s*(.+)$/m)?.[1],
+    "~\\AppData\\Roaming\\Sagascript\\Models",
+    "cache must exclude settings and logs from the model path",
+  );
+  assert.match(
+    cache,
+    /key: windows-models-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ hashFiles\('src-tauri\/crates\/sagascript-core\/src\/settings\/manager\.rs', 'src-tauri\/crates\/sagascript-core\/src\/transcription\/model\.rs', 'src-tauri\/crates\/sagascript-core\/src\/diarization\/model\.rs'\) \}\}/,
+  );
+  assert.match(
+    cache,
+    /restore-keys:[\s\S]*windows-models-package-\$\{\{ matrix\.architecture \}\}-[\s\S]*windows-models-/,
+  );
+  const nativeGate = windowsWorkflow.indexOf("name: Gate real Windows transcription");
+  const englishGate = windowsWorkflow.indexOf("name: Gate repeated English dictation");
+  assert.ok(nativeGate > modelCacheStart && englishGate > nativeGate);
+  assert.ok(
+    windowsWorkflow.indexOf("& $binary download-model nb-whisper-tiny", nativeGate) > modelCacheStart,
+    "native smoke must verify restored models after cache restore",
+  );
+  assert.ok(
+    windowsWorkflow.indexOf("& $binary download-model base.en", englishGate) > modelCacheStart,
+    "English benchmark must verify restored base.en after cache restore",
+  );
+});

--- a/scripts/test-pipeline-cache.mjs
+++ b/scripts/test-pipeline-cache.mjs
@@ -65,7 +65,7 @@ test("Windows native cache is isolated by runner image and toolchain namespace",
   assert.match(cache, /workspaces:\s+src-tauri/);
   assert.match(
     cache,
-    /shared-key:\s+windows-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ steps\.windows-image\.outputs\.image_os \}\}-\$\{\{ steps\.windows-image\.outputs\.image_version \}\}-\$\{\{ hashFiles\('\.github\/workflows\/windows-package\.yml', 'scripts\/cmake\/windows-x64-portable\.cmake', 'scripts\/verify-windows-x64-cpu-policy\.ps1'\) \}\}/,
+    /shared-key:\s+windows-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ steps\.windows-image\.outputs\.image_os \}\}-\$\{\{ steps\.windows-image\.outputs\.image_version \}\}-\$\{\{ hashFiles\('\.github\/workflows\/windows-package\.yml', 'scripts\/cmake\/windows-x64-portable\.cmake', 'scripts\/cmake\/windows-arm64-native\.cmake', 'scripts\/verify-windows-x64-cpu-policy\.ps1'\) \}\}/,
   );
   assert.ok(
     windowsWorkflow.indexOf("name: Remove cached installer bundles") > cacheStart,

--- a/scripts/test-pipeline-cache.mjs
+++ b/scripts/test-pipeline-cache.mjs
@@ -20,8 +20,11 @@ function section(content, startMarker, endMarker) {
 
 test("CI rust caches use the reviewed immutable action revision", () => {
   const refs = ciWorkflow.match(/uses: Swatinem\/rust-cache@[^\s]+/g) ?? [];
-  assert.equal(refs.length, 3);
-  assert.deepEqual(refs, [`uses: ${rustCacheRef}`, `uses: ${rustCacheRef}`, `uses: ${rustCacheRef}`]);
+  assert.equal(refs.length, 5);
+  assert.deepEqual(
+    refs,
+    Array.from({ length: 5 }, () => `uses: ${rustCacheRef}`),
+  );
 });
 
 test("signed test builds use the shared dependency cache without raw target dumps", () => {

--- a/scripts/test-report-windows-arm64-native.mjs
+++ b/scripts/test-report-windows-arm64-native.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "report-windows-arm64-native.mjs",
+);
+const profiles = [
+  ["debug"],
+  ["release"],
+  ["aarch64-pc-windows-msvc", "debug"],
+  ["aarch64-pc-windows-msvc", "release"],
+];
+
+async function writeBuild(targetRoot, profile, suffix, flags, project = "whisper.cpp") {
+  const buildRoot = join(
+    targetRoot,
+    ...profile,
+    "build",
+    `whisper-rs-sys-${suffix}`,
+    "out",
+    "build",
+  );
+  await mkdir(buildRoot, { recursive: true });
+  await writeFile(
+    join(buildRoot, "CMakeCache.txt"),
+    `CMAKE_PROJECT_NAME:STATIC=${project}\nCMAKE_GENERATOR:INTERNAL=Ninja\n`,
+  );
+  await writeFile(
+    join(buildRoot, "build.ninja"),
+    `rule CXX_COMPILER\n  command = clang++ $FLAGS\nbuild object.o: CXX_COMPILER source.cc\n  FLAGS = ${flags}\n`,
+  );
+}
+
+async function runReporter(setup) {
+  const directory = await mkdtemp(join(tmpdir(), "sagascript-arm64-evidence-"));
+  const targetRoot = join(directory, "target");
+  await mkdir(targetRoot);
+  await setup(targetRoot);
+  try {
+    const result = spawnSync(process.execPath, [scriptPath, targetRoot], {
+      cwd: directory,
+      encoding: "utf8",
+      shell: false,
+    });
+    return {
+      ...result,
+      output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("reports unique ARM64 compiler evidence from the four allowed profiles", async () => {
+  const result = await runReporter(async (targetRoot) => {
+    for (const [index, profile] of profiles.entries()) {
+      await writeBuild(
+        targetRoot,
+        profile,
+        `fixture-${index}`,
+        "-mcpu=native+dotprod+i8mm+nosve+nosme",
+      );
+    }
+    await writeBuild(targetRoot, ["debug"], "foreign", "-mcpu=host+dotprod+nosve+nosme", "other-project");
+  });
+  assert.equal(result.status, 0, result.output);
+  assert.equal((result.stdout.match(/Evidence pass:/g) ?? []).length, 4);
+  assert.match(result.stdout, /Unique -mcpu= flags: -mcpu=native\+dotprod\+i8mm\+nosve\+nosme\n/);
+  assert.equal((result.stdout.match(/-mcpu=native/g) ?? []).length, 1);
+});
+
+test("rejects positive SVE and SME flags, including versioned forms", async () => {
+  for (const positive of [
+    "-mcpu=native+dotprod+i8mm+sve+nosme",
+    "-mcpu=native+dotprod+i8mm+sve2+nosme",
+    "-mcpu=native+dotprod+i8mm+nosve+sme",
+    "-mcpu=native+dotprod+i8mm+nosve+sme2",
+  ]) {
+    const result = await runReporter((targetRoot) =>
+      writeBuild(targetRoot, ["debug"], "positive", positive),
+    );
+    assert.notEqual(result.status, 0, result.output);
+    assert.match(result.output, /positive (?:sve|sme)/i);
+  }
+});
+
+test("rejects evidence missing native or explicit no-SVE/no-SME flags", async () => {
+  for (const flags of [
+    "-mcpu=generic+dotprod+i8mm+nosve+nosme",
+    "-mcpu=native+dotprod+i8mm+nosme",
+    "-mcpu=native+dotprod+i8mm+nosve",
+    "-mcpu=native+dotprod+i8mm+nosve -mcpu=native+dotprod+i8mm+nosme",
+  ]) {
+    const result = await runReporter((targetRoot) =>
+      writeBuild(targetRoot, ["release"], "missing", flags),
+    );
+    assert.notEqual(result.status, 0, result.output);
+    assert.match(result.output, /(?:no actual -mcpu|required \+(?:native|nosve|nosme))/i);
+  }
+});
+
+test("fails when no allowed Rust target profile contains whisper.cpp evidence", async () => {
+  const result = await runReporter((targetRoot) =>
+    writeBuild(targetRoot, ["other-target", "debug"], "out-of-scope", "-mcpu=native+dotprod+i8mm+nosve+nosme"),
+  );
+  assert.notEqual(result.status, 0, result.output);
+  assert.match(result.output, /no whisper\.cpp CMake caches/i);
+});
+
+test("fails when a matching cache has no sibling build.ninja", async () => {
+  const result = await runReporter(async (targetRoot) => {
+    const buildRoot = join(targetRoot, "debug", "build", "whisper-rs-sys-missing", "out", "build");
+    await mkdir(buildRoot, { recursive: true });
+    await writeFile(join(buildRoot, "CMakeCache.txt"), "CMAKE_PROJECT_NAME:STATIC=whisper.cpp\n");
+  });
+  assert.notEqual(result.status, 0, result.output);
+  assert.match(result.output, /no sibling build\.ninja/i);
+});

--- a/scripts/test-windows-arm64-native.mjs
+++ b/scripts/test-windows-arm64-native.mjs
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const hookPath = resolve(scriptDir, "cmake/windows-arm64-native.cmake");
+
+const machineSupportFlags = [
+  "GGML_MACHINE_SUPPORTS_sve",
+  "GGML_MACHINE_SUPPORTS_sme",
+  "GGML_NATIVE",
+  "GGML_MACHINE_SUPPORTS_dotprod",
+  "GGML_MACHINE_SUPPORTS_i8mm",
+  "GGML_MACHINE_SUPPORTS_nosve",
+  "GGML_MACHINE_SUPPORTS_nosme",
+];
+
+function cmakeBracketArgument(value) {
+  const content = String(value).replaceAll("\\", "/");
+  let equals = "";
+  while (content.includes(`]${equals}]`)) {
+    equals += "=";
+  }
+  return `[${equals}[${content}]${equals}]`;
+}
+
+function parseFixtureOutput(output) {
+  return Object.fromEntries(
+    output.trim().split(/\r?\n/).map((line) => line.split("=")),
+  );
+}
+
+async function runScriptFixture({
+  projectName = "whisper.cpp",
+  systemName = "Windows",
+  processor = "aarch64",
+  pointerSize = 8,
+  preseed = {},
+}) {
+  const directory = await mkdtemp(join(tmpdir(), "sagascript-cmake-arm64-"));
+  const fixturePath = join(directory, "fixture.cmake");
+  const outputPath = join(directory, "result.txt");
+  const assignments = [
+    `set(PROJECT_NAME ${cmakeBracketArgument(projectName)})`,
+    `set(CMAKE_SYSTEM_NAME ${cmakeBracketArgument(systemName)})`,
+    `set(CMAKE_SYSTEM_PROCESSOR ${cmakeBracketArgument(processor)})`,
+  ];
+  if (pointerSize !== undefined && pointerSize !== null) {
+    assignments.push(`set(CMAKE_SIZEOF_VOID_P ${pointerSize})`);
+  }
+  for (const [name, value] of Object.entries(preseed)) {
+    assignments.push(`set(${name} ${value} CACHE BOOL "fixture preseed" FORCE)`);
+  }
+  const outputLines = machineSupportFlags
+    .map((name) => `  "${name}=\${${name}}\\n"`)
+    .join("\n");
+  const script = [
+    ...assignments,
+    `include(${cmakeBracketArgument(hookPath)})`,
+    `file(WRITE ${cmakeBracketArgument(outputPath)}\n${outputLines}\n)`,
+  ].join("\n");
+  await writeFile(fixturePath, `${script}\n`, "utf8");
+
+  try {
+    const result = spawnSync("cmake", ["-P", fixturePath], {
+      encoding: "utf8",
+      shell: false,
+    });
+    let values = null;
+    try {
+      values = parseFixtureOutput(await readFile(outputPath, "utf8"));
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    return {
+      ...result,
+      combinedOutput: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+      values,
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function runConfigureFixture() {
+  const directory = await mkdtemp(join(tmpdir(), "sagascript-cmake-arm64-configure-"));
+  const sourceDirectory = join(directory, "source");
+  const buildDirectory = join(directory, "build");
+  const outputPath = join(directory, "result.txt");
+  await mkdir(sourceDirectory);
+
+  const cmakeLists = [
+    "cmake_minimum_required(VERSION 3.16)",
+    // Keeping CXX disabled proves the cached result prevents CheckCXXSourceRuns
+    // from reaching its language/compiler checks or trying to compile the probe.
+    "project(whisper.cpp LANGUAGES NONE)",
+    "include(CheckCXXSourceRuns)",
+    "set(CMAKE_SYSTEM_NAME Windows)",
+    "set(CMAKE_SYSTEM_PROCESSOR aarch64)",
+    "set(CMAKE_SIZEOF_VOID_P 8)",
+    "set(GGML_MACHINE_SUPPORTS_sve ON CACHE BOOL \"fixture preseed\" FORCE)",
+    "set(GGML_MACHINE_SUPPORTS_sme ON CACHE BOOL \"fixture preseed\" FORCE)",
+    "set(GGML_NATIVE ON CACHE BOOL \"fixture preseed\" FORCE)",
+    "set(GGML_MACHINE_SUPPORTS_dotprod ON CACHE BOOL \"fixture preseed\" FORCE)",
+    "set(GGML_MACHINE_SUPPORTS_i8mm ON CACHE BOOL \"fixture preseed\" FORCE)",
+    "set(GGML_MACHINE_SUPPORTS_nosve ON CACHE BOOL \"fixture preseed\" FORCE)",
+    "set(GGML_MACHINE_SUPPORTS_nosme ON CACHE BOOL \"fixture preseed\" FORCE)",
+    `include(${cmakeBracketArgument(hookPath)})`,
+    "check_cxx_source_runs([=[",
+    "#error This source must not be compiled when the hook pre-seeds SVE OFF",
+    "int main() { return 0; }",
+    "]=] GGML_MACHINE_SUPPORTS_sve)",
+    "check_cxx_source_runs([=[#error SME probe must also be skipped]=] GGML_MACHINE_SUPPORTS_sme)",
+    "if(GGML_MACHINE_SUPPORTS_sve OR GGML_MACHINE_SUPPORTS_sme)",
+    "  message(FATAL_ERROR \"pre-seeded SVE probe unexpectedly ran\")",
+    "endif()",
+    `file(WRITE ${cmakeBracketArgument(outputPath)}\n${machineSupportFlags.map((name) => `  "${name}=\${${name}}\\n"`).join("\n")}\n)`,
+  ].join("\n");
+  await writeFile(join(sourceDirectory, "CMakeLists.txt"), `${cmakeLists}\n`, "utf8");
+
+  try {
+    const result = spawnSync("cmake", ["-S", sourceDirectory, "-B", buildDirectory], {
+      encoding: "utf8",
+      shell: false,
+    });
+    let values = null;
+    try {
+      values = parseFixtureOutput(await readFile(outputPath, "utf8"));
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    return {
+      ...result,
+      combinedOutput: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+      values,
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("ARM64 hook accepts Windows and processor case variants", async () => {
+  for (const [systemName, processor] of [
+    ["Windows", "aarch64"],
+    ["wInDoWs", "AARCH64"],
+    ["WINDOWS", "arm64"],
+    ["windows", "ARM64"],
+  ]) {
+    const result = await runScriptFixture({ systemName, processor });
+    assert.equal(result.status, 0, result.combinedOutput);
+    assert.deepEqual(result.values, {
+      GGML_MACHINE_SUPPORTS_sve: "OFF",
+      GGML_MACHINE_SUPPORTS_sme: "OFF",
+      GGML_NATIVE: "",
+      GGML_MACHINE_SUPPORTS_dotprod: "",
+      GGML_MACHINE_SUPPORTS_i8mm: "",
+      GGML_MACHINE_SUPPORTS_nosve: "",
+      GGML_MACHINE_SUPPORTS_nosme: "",
+    });
+  }
+});
+
+test("ARM64 hook forces only SVE and SME off from an old positive cache", async () => {
+  const preseed = Object.fromEntries(machineSupportFlags.map((name) => [name, "ON"]));
+  const result = await runScriptFixture({ preseed });
+  assert.equal(result.status, 0, result.combinedOutput);
+  assert.deepEqual(result.values, {
+    GGML_MACHINE_SUPPORTS_sve: "OFF",
+    GGML_MACHINE_SUPPORTS_sme: "OFF",
+    GGML_NATIVE: "ON",
+    GGML_MACHINE_SUPPORTS_dotprod: "ON",
+    GGML_MACHINE_SUPPORTS_i8mm: "ON",
+    GGML_MACHINE_SUPPORTS_nosve: "ON",
+    GGML_MACHINE_SUPPORTS_nosme: "ON",
+  });
+});
+
+test("ARM64 hook is a no-op for unrelated projects", async () => {
+  const preseed = Object.fromEntries(machineSupportFlags.map((name) => [name, "ON"]));
+  const result = await runScriptFixture({
+    projectName: "unrelated-project",
+    systemName: "Linux",
+    processor: "x86_64",
+    pointerSize: 4,
+    preseed,
+  });
+  assert.equal(result.status, 0, result.combinedOutput);
+  assert.deepEqual(result.values, preseed);
+});
+
+test("ARM64 hook rejects wrong platform, processor, and pointer size", async () => {
+  for (const options of [
+    { systemName: "Linux", processor: "arm64", pointerSize: 8, diagnostic: /CMAKE_SYSTEM_NAME must be Windows/ },
+    { systemName: "Windows", processor: "x86_64", pointerSize: 8, diagnostic: /ARM64 or aarch64 target/ },
+    { systemName: "Windows", processor: "arm64", pointerSize: 4, diagnostic: /8-byte pointers/ },
+  ]) {
+    const result = await runScriptFixture(options);
+    assert.notEqual(result.status, 0, result.combinedOutput);
+    assert.match(result.combinedOutput, options.diagnostic);
+    assert.equal(result.values, null);
+  }
+});
+
+test("actual CheckCXXSourceRuns skips an invalid SVE probe pre-seeded OFF", async () => {
+  const result = await runConfigureFixture();
+  assert.equal(result.status, 0, result.combinedOutput);
+  assert.deepEqual(result.values, {
+    GGML_MACHINE_SUPPORTS_sve: "OFF",
+    GGML_MACHINE_SUPPORTS_sme: "OFF",
+    GGML_NATIVE: "ON",
+    GGML_MACHINE_SUPPORTS_dotprod: "ON",
+    GGML_MACHINE_SUPPORTS_i8mm: "ON",
+    GGML_MACHINE_SUPPORTS_nosve: "ON",
+    GGML_MACHINE_SUPPORTS_nosme: "ON",
+  });
+});

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -236,3 +236,16 @@ test("third-party notice comparison accepts Windows checkout line endings", () =
   );
   assert.match(output, /newline normalization passed/);
 });
+
+test("ARM64 candidate records generated debug and release CPU flags", () => {
+  for (const [name, after, before] of [
+    ["Verify debug ARM64 native CPU flags", "name: Test and lint Rust workspace", "name: Gate real Windows transcription"],
+    ["Verify packaged ARM64 native CPU flags", "name: Build unsigned internal installers", "name: Prepare and verify candidate artifacts"],
+  ]) {
+    const start = workflow.indexOf(`name: ${name}`);
+    assert.ok(start > workflow.indexOf(after) && start < workflow.indexOf(before));
+    const step = workflow.slice(start, workflow.indexOf("\n      - name:", start));
+    assert.match(step, /if: matrix\.architecture == 'arm64'/);
+    assert.match(step, /node scripts\/report-windows-arm64-native\.mjs src-tauri\/target/);
+  }
+});

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -96,7 +96,7 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(rustCache, /workspaces:\s+src-tauri/);
   assert.match(
     rustCache,
-    /shared-key:\s+windows-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ steps\.windows-image\.outputs\.image_os \}\}-\$\{\{ steps\.windows-image\.outputs\.image_version \}\}-\$\{\{ hashFiles\('\.github\/workflows\/windows-package\.yml', 'scripts\/cmake\/windows-x64-portable\.cmake', 'scripts\/verify-windows-x64-cpu-policy\.ps1'\) \}\}/,
+    /shared-key:\s+windows-package-\$\{\{ matrix\.architecture \}\}-\$\{\{ steps\.windows-image\.outputs\.image_os \}\}-\$\{\{ steps\.windows-image\.outputs\.image_version \}\}-\$\{\{ hashFiles\('\.github\/workflows\/windows-package\.yml', 'scripts\/cmake\/windows-x64-portable\.cmake', 'scripts\/cmake\/windows-arm64-native\.cmake', 'scripts\/verify-windows-x64-cpu-policy\.ps1'\) \}\}/,
   );
   assert.doesNotMatch(
     rustCache,
@@ -120,6 +120,17 @@ test("Windows candidate workflow stays non-publishing and explicitly unsigned", 
   assert.match(workflow, /\$msi\[0\]\.Name -notmatch \[regex\]::Escape\(\$version\)/);
   assert.doesNotMatch(workflow, /\$version:/);
   assert.doesNotMatch(workflow, /action-gh-release|gh release|contents: write/);
+});
+
+test("Windows ARM64 disables unsupported scalable vectors before restoring native cache", () => {
+  const start = workflow.indexOf("name: Configure native ARM64 C and C++ toolchain");
+  const end = workflow.indexOf("name: Configure portable x64 inference baseline", start);
+  assert.ok(start >= 0 && end > start);
+  const arm = workflow.slice(start, end);
+  assert.match(arm, /if: matrix\.architecture == 'arm64'/);
+  assert.match(arm, /scripts\/cmake\/windows-arm64-native\.cmake/);
+  assert.match(arm, /CMAKE_PROJECT_INCLUDE=\$policy/);
+  assert.ok(end < workflow.indexOf("name: Cache Rust dependencies"));
 });
 
 test("Windows x64 caches and artifacts use an explicit verified CPU baseline", () => {

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -5,8 +5,12 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 test("Windows PR CI runs build identity regression tests before compilation", async () => {
-  const ci = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
-  const windows = ci.slice(ci.indexOf("  check-windows:"));
+  const ci = (await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"))
+    .replace(/\r\n?/g, "\n");
+  const testWindowsStart = ci.indexOf("  test-windows:");
+  const buildWindowsStart = ci.indexOf("  build-windows:", testWindowsStart);
+  assert.ok(testWindowsStart >= 0 && buildWindowsStart > testWindowsStart);
+  const windows = ci.slice(testWindowsStart, buildWindowsStart);
   const command = "node --test scripts/test-ci-build-identity.mjs scripts/test-windows-release-identity.mjs scripts/test-windows-package-workflow.mjs";
   const checks = windows.indexOf(command);
   assert.ok(checks > windows.indexOf("name: Install Node.js"));


### PR DESCRIPTION
CI previously ran validation and native compilation sequentially on macOS and Windows. This change runs them concurrently and retains the existing required status names as fail-closed aggregators. In the measured cached repeat, CI wall time fell from **10m58s to 8m01s: 2m57s / 26.9% less waiting**. Total runner time increased **23.7%**, from 18m55s to 23m24s.

Changes:
- Split validation/native jobs and Rust caches; both lanes must pass.
- Reduce development/test debug artifact size while retaining line-number backtraces and debug assertions. Release optimization remains unchanged.
- Reuse each job's freshly built frontend only after validating its content hash and title against build metadata.
- Cache Windows model files while retaining integrity/inference gates; remove redundant macOS CLI diarization commands already covered by default features.
- Add archived baseline/cohort reporting and Cargo fingerprint diagnostics.

## Measured results

| Metric | Main control | Cached PR repeat | Change |
|---|---:|---:|---:|
| Complete CI execution wall time | 10m58s | 8m01s | **26.9% shorter** |
| Summed CI runner time | 18m55s | 23m24s | **23.7% higher** |
| macOS native build step | 2m15s | 3m12s | 42.2% longer |
| Windows native build step | 5m08s | 5m39s | 10.1% longer |

Control: [34216174578, attempt 1](https://github.com/Magnus-Gille/sagascript/actions/runs/34216174578/attempts/1), main `b661415f6db99e64bad95cfdd766e7c359733b1a`. After: [34224809046, attempt 2](https://github.com/Magnus-Gille/sagascript/actions/runs/34224809046/attempts/2), PR head `fcd1599f840f4005c97416c076538d8ad71eaaf5`. All seven after jobs passed. Wall time is first job start to last job end; the original run creation time is unsuitable for timing a rerun. Summed runner seconds are not billed cost.

This is one observed cached comparison, not proof of a stable percentile. Application Rust source is unchanged; main-push versus PR-rerun triggers and execution conditions differ. Parallel scheduling and smaller native-cache transfers improve waiting, but **native compilation itself did not get faster**. The corrected first attempt passed in 15m31s with cold validation caches; earlier cold and failed experiments remain excluded from cached speed claims.

## Windows packaging limitation

The [unsigned candidate repeat](https://github.com/Magnus-Gille/sagascript/actions/runs/34224809050) passed x64 in **18m51s**, versus 16m48s in an older cached reference at a different application revision. This does not demonstrate a packaging speedup. The prior cold candidate [34221630681](https://github.com/Magnus-Gille/sagascript/actions/runs/34221630681) passed both architectures.

The runner update to `20260906.161.1` exposed an ARM64 compatibility failure: Clang's native probe enabled SVE and pinned Whisper included Linux-only `sys/prctl.h`. This PR now disables SVE/SME for that Windows ARM64 native build while retaining native tuning and host-supported dotprod/i8mm. Actual generated Ninja compiler flags are checked in both debug and packaged builds. The corrected ARM64 candidate passed on [the preceding revision](https://github.com/Magnus-Gille/sagascript/actions/runs/34230248679); the x64 job was cancelled by the final push, so that run is not a completed performance sample.

Final revision: `5a9fbdabe8c94b7f3d5816a03a4aa38ed029c8c0`. Final [CI](https://github.com/Magnus-Gille/sagascript/actions/runs/34232978856) and [Windows candidates](https://github.com/Magnus-Gille/sagascript/actions/runs/34232978858) both passed. All seven CI jobs and both native Windows candidate jobs succeeded. The generated debug and packaged ARM64 flags were `-mcpu=native+dotprod+i8mm+nosve+nosme`. Final CI execution took 6m00s with 23m00s summed runner time; this additional observation does not replace the earlier cached comparison.

Final candidate job durations were ARM64 23m52s and x64 35m13s. The final ARM64 runner used image `20260830.155.1` and Clang 20.1.6; its successful generated-flags checks do not establish a new successful run on image `20260906.161.1` / Clang 22. No packaging speedup is claimed.

## Verification

All seven CI jobs passed on the corrected first attempt and cached repeat. Local checks passed: 197 frontend/tooling tests (one skipped), 127 Python evaluator tests, 32 aggregate-result cases, frontend build/Svelte/release/license checks, actionlint, and diff checks. Independent Claude Sonnet 5 reviews found no confirmed blockers. Native Luna high/xhigh agents supported implementation, regression correction, compiler experiments, and metric audits; the conductor integrated and checked the results.

Initial LF/CRLF and Python workflow-fixture failures were corrected and regression-tested; failed attempts are retained in the experiment record. A local release-codegen experiment improved app compilation but regressed CLI compilation and increased binary size, so release settings were retained.

No signed macOS or production release workflow was dispatched. Part of #178; the 50% latency target, faster compilation, runner-time reduction, and larger matched cohorts remain open. See `docs/ci-performance/optimization-2026-09-08.md` for method and experiment history. Rollback is to revert this PR's workflow/tooling changes; no application/runtime changes are included. Merging activates the CI configuration on main; no application release is required.

Merged as `c161b61d0a148059522afc3acf5dd7665f7dcd5a`. [Main CI34236871457](https://github.com/Magnus-Gille/sagascript/actions/runs/34236871457) passed all seven jobs in **14m52s wall / 50m46s summed runner time**; all five Rust cache restores explicitly reported no cache found. This first main run is a cold-cache observation, not a warm speed comparison. SBOM34236871536 also passed. The CI configuration is active on main; no app release was performed. Approved task worktree/branch cleanup completed with a verified recovery bundle preserved.
