### PR TITLE
fix(ui): clarify recording shortcut behavior

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -68,6 +68,57 @@ jobs:
             throw "Expected native ${{ matrix.architecture }} runner, got $runnerArchitecture"
           }
 
+      - name: Install pinned LLVM for ARM64 bindgen
+        if: matrix.architecture == 'arm64'
+        shell: pwsh
+        run: |
+          # Upstream rust-bindgen#3264: LLVM 22 is incompatible with bindgen 0.71.
+          $llvmUrl = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/LLVM-20.1.8-woa64.exe'
+          $expectedHash = '7c4ac97eb2ae6b960ca5f9caf3ff6124c8d2a18cc07a7840a4d2ea15537bad8e'
+          $installerPath = Join-Path $env:RUNNER_TEMP 'LLVM-20.1.8-woa64.exe'
+          $installRoot = Join-Path $env:RUNNER_TEMP ('sagascript-llvm-20.1.8-' + [guid]::NewGuid().ToString('N'))
+          $llvmBin = Join-Path $installRoot 'bin'
+
+          Invoke-WebRequest -Uri $llvmUrl -OutFile $installerPath
+          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "LLVM installer SHA256 mismatch: expected $expectedHash, got $actualHash"
+          }
+
+          New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+          # NSIS requires /D to be the final, unquoted argument.
+          $process = Start-Process -FilePath $installerPath -ArgumentList @('/S', "/D=$installRoot") -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "LLVM installer failed with exit code $($process.ExitCode)"
+          }
+
+          $clangPath = Join-Path $llvmBin 'clang-cl.exe'
+          $libclangPath = Join-Path $llvmBin 'libclang.dll'
+          if (-not (Test-Path -LiteralPath $clangPath -PathType Leaf)) {
+            throw "Pinned LLVM clang-cl.exe is missing: $clangPath"
+          }
+          if (-not (Test-Path -LiteralPath $libclangPath -PathType Leaf)) {
+            throw "Pinned LLVM libclang.dll is missing: $libclangPath"
+          }
+
+          $clangVersionOutput = & $clangPath --version 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pinned clang-cl --version failed with exit code $LASTEXITCODE"
+          }
+          $clangVersion = ($clangVersionOutput -join "`n").Trim()
+          Write-Output $clangVersion
+          if ($clangVersion -notmatch '(?m)^clang version 20\.1\.8(?:\s|$)') {
+            throw "Expected clang version 20.1.8, got: $clangVersion"
+          }
+
+          $targetMatch = [regex]::Match($clangVersion, '(?m)^Target:\s*(?<target>\S+)\s*$')
+          if (-not $targetMatch.Success -or $targetMatch.Groups['target'].Value -ne 'aarch64-pc-windows-msvc') {
+            throw "Expected native clang target aarch64-pc-windows-msvc in clang version output"
+          }
+
+          $llvmBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "LIBCLANG_PATH=$llvmBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Configure native ARM64 C and C++ toolchain
         if: matrix.architecture == 'arm64'
         shell: pwsh

--- a/scripts/test-settings-layout.mjs
+++ b/scripts/test-settings-layout.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const content = readFileSync(new URL("../src/lib/Settings.svelte", import.meta.url), "utf8");
+const onboardingContent = readFileSync(new URL("../src/lib/Onboarding.svelte", import.meta.url), "utf8");
 
 test("Settings presents build identity above the ordered navigation tabs", () => {
   const settingsWindow = '<div class="settings-window">';
@@ -27,4 +28,24 @@ test("Settings presents build identity above the ordered navigation tabs", () =>
   const indices = ["Dictate", "Transcribe", "Settings"].map((label) => tabsContent.indexOf(label));
   assert(indices.every((index) => index >= 0), "All tab labels remain");
   assert(indices[0] < indices[1] && indices[1] < indices[2], "Tab order remains unchanged");
+});
+
+test("recording shortcuts use clear mode names and independent helpers", () => {
+  assert.match(content, /label: "Hold to record"/);
+  assert.match(content, /label: "Press to start\/stop"/);
+  assert.match(content, /Hold the shortcut while speaking\. Release to stop\./);
+  assert.match(content, /Press the shortcut to start recording\. Press it again to stop\./);
+  assert.match(content, /shortcutControls[\s\S]*shortcutControl\.helper/);
+  assert.match(content, /Each shortcut above is independent and either or both may be configured\./);
+  assert.doesNotMatch(content, />Push to talk</);
+  assert.doesNotMatch(content, />Toggle</);
+});
+
+test("onboarding explains both recording modes", () => {
+  assert.match(onboardingContent, /Configure separate shortcuts for these recording modes in Dictate\./);
+  assert.match(onboardingContent, /Hold to record/);
+  assert.match(onboardingContent, /Press to start\/stop/);
+  assert.match(onboardingContent, /Hold the shortcut while speaking\. Release to stop\./);
+  assert.match(onboardingContent, /Press the shortcut to start recording\. Press it again to stop\./);
+  assert.doesNotMatch(onboardingContent, /Hold to record, release to transcribe/);
 });

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -133,6 +133,47 @@ test("Windows ARM64 disables unsupported scalable vectors before restoring nativ
   assert.ok(end < workflow.indexOf("name: Cache Rust dependencies"));
 });
 
+test("Windows ARM64 pins and validates the LLVM toolchain before native configuration", () => {
+  const pinStart = workflow.indexOf("name: Install pinned LLVM for ARM64 bindgen");
+  const nativeStart = workflow.indexOf("name: Configure native ARM64 C and C++ toolchain");
+  const cacheStart = workflow.indexOf("name: Cache Rust dependencies");
+  assert.ok(pinStart >= 0 && nativeStart > pinStart && cacheStart > nativeStart);
+
+  const pin = workflow.slice(pinStart, nativeStart);
+  assert.match(pin, /if: matrix\.architecture == 'arm64'/);
+  assert.match(
+    pin,
+    /https:\/\/github\.com\/llvm\/llvm-project\/releases\/download\/llvmorg-20\.1\.8\/LLVM-20\.1\.8-woa64\.exe/,
+  );
+  assert.match(pin, /7c4ac97eb2ae6b960ca5f9caf3ff6124c8d2a18cc07a7840a4d2ea15537bad8e/);
+
+  const download = pin.indexOf("Invoke-WebRequest");
+  const verifyHash = pin.indexOf("Get-FileHash");
+  const execute = pin.indexOf("Start-Process");
+  assert.ok(download >= 0 && verifyHash > download && execute > verifyHash);
+  assert.match(pin, /-Algorithm SHA256/);
+  assert.match(pin, /if \(\$actualHash -ne \$expectedHash\)/);
+  assert.match(pin, /-ArgumentList @\('\/S', "\/D=\$installRoot"\)/);
+  assert.match(pin, /if \(\$process\.ExitCode -ne 0\)/);
+  assert.match(pin, /\[guid\]::NewGuid\(\)/);
+
+  assert.match(pin, /clang-cl\.exe/);
+  assert.match(pin, /libclang\.dll/);
+  assert.match(pin, /Test-Path -LiteralPath \$clangPath -PathType Leaf/);
+  assert.match(pin, /Test-Path -LiteralPath \$libclangPath -PathType Leaf/);
+  assert.match(pin, /clang version 20\\\.1\\\.8/);
+  assert.match(pin, /Write-Output \$clangVersion/);
+  assert.match(pin, /\[regex\]::Match\(\$clangVersion/);
+  assert.match(pin, /Target:\\s\*\(\?<target>\\S\+\)/);
+  assert.match(pin, /aarch64-pc-windows-msvc/);
+  assert.match(pin, /\$targetMatch\.Groups\['target'\]\.Value -ne 'aarch64-pc-windows-msvc'/);
+  assert.doesNotMatch(pin, /-dumpmachine/);
+  assert.match(pin, /\$llvmBin \| Out-File -FilePath \$env:GITHUB_PATH/);
+  assert.match(pin, /LIBCLANG_PATH=\$llvmBin/);
+  assert.match(pin, /rust-bindgen#3264/);
+  assert.doesNotMatch(pin, /WHISPER_DONT_GENERATE_BINDINGS|disable ABI asserts/);
+});
+
 test("Windows x64 caches and artifacts use an explicit verified CPU baseline", () => {
   const policyStart = workflow.indexOf("name: Configure portable x64 inference baseline");
   const cacheStart = workflow.indexOf("name: Cache Rust dependencies");

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -735,7 +735,13 @@
                 <kbd>{part}</kbd>
               {/each}
             </div>
-            <p class="hotkey-hint">Hold to record, release to transcribe</p>
+            <p class="hotkey-hint hotkey-mode-intro">Configure separate shortcuts for these recording modes in Dictate.</p>
+            <div class="hotkey-mode-copy">
+              <p class="hotkey-mode-label">Hold to record</p>
+              <p class="hotkey-hint">Hold the shortcut while speaking. Release to stop.</p>
+              <p class="hotkey-mode-label">Press to start/stop</p>
+              <p class="hotkey-hint">Press the shortcut to start recording. Press it again to stop.</p>
+            </div>
           </div>
         {:else}
           <p class="description">
@@ -1038,6 +1044,19 @@
     font-size: 12px;
     color: var(--text-muted);
     margin: 0;
+  }
+
+  .hotkey-mode-copy {
+    display: grid;
+    gap: 2px;
+    text-align: left;
+  }
+
+  .hotkey-mode-label {
+    font-size: 12px;
+    color: var(--text);
+    font-weight: 600;
+    margin: 4px 0 0;
   }
 
   strong {

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -115,9 +115,17 @@
   // Hotkey recorder state
   let recordingProfileId: string | null = $state(null);
   type ExplicitShortcutSlot = "push_to_talk_shortcut" | "toggle_shortcut";
-  const shortcutControls: { slot: ExplicitShortcutSlot; label: string }[] = [
-    { slot: "push_to_talk_shortcut", label: "Push to talk" },
-    { slot: "toggle_shortcut", label: "Toggle" },
+  const shortcutControls: { slot: ExplicitShortcutSlot; label: string; helper: string }[] = [
+    {
+      slot: "push_to_talk_shortcut",
+      label: "Hold to record",
+      helper: "Hold the shortcut while speaking. Release to stop.",
+    },
+    {
+      slot: "toggle_shortcut",
+      label: "Press to start/stop",
+      helper: "Press the shortcut to start recording. Press it again to stop.",
+    },
   ];
   let recordingShortcutSlot: ExplicitShortcutSlot | null = $state(null);
   let hotkeyCaptureGeneration = 0;
@@ -1664,6 +1672,7 @@
                         onclick={() => beginHotkeyCapture(profile.id, shortcutControl.slot)}
                       >{formatHotkeyDisplay(displayProfileShortcut(profile, shortcutControl.slot, settings.hotkey_mode) || "Not set")}</button>
                     {/if}
+                    <div class="shortcut-helper">{shortcutControl.helper}</div>
                     {#if profile.push_to_talk_shortcut && profile.toggle_shortcut}
                       <button
                         type="button"
@@ -1711,7 +1720,7 @@
             </div>
           {/if}
           <div class="hotkey-hint">
-            Push to talk starts while held; Toggle starts and stops with each press. They are independent and either or both may be configured. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission: macOS sends keyboard events to Sagascript, which immediately ignores everything except bare F13–F24 and never stores or sends them.{/if}
+            Each shortcut above is independent and either or both may be configured. Use a modifier ({modifierNames().meta}, {modifierNames().ctrl}, {modifierNames().alt}, Shift) + key{#if supportedBareFunctionKeyRange(platform)}, or {supportedBareFunctionKeyRange(platform)} by itself{/if}.{#if platform === "macos"}{" "}Bare F13–F24 requires Accessibility permission: macOS sends keyboard events to Sagascript, which immediately ignores everything except bare F13–F24 and never stores or sends them.{/if}
           </div>
         </div>
 
@@ -2362,6 +2371,12 @@
     color: var(--text-muted);
     font-size: 11px;
     font-weight: 600;
+  }
+
+  .shortcut-helper {
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.35;
   }
 
   .shortcut-clear {


### PR DESCRIPTION
## Summary
- Use Hold to record and Press to start/stop with visible explanations in Dictate.
- Explain both independent modes during onboarding.
- Preserve runtime behavior, defaults, saved values and CLI identifiers.

Implements #231. Keep the issue open until the separate testing session records native manual acceptance.

## Verification
- Red/green copy regression tests; focused tests 3/3 passed.
- Full frontend suite: 210 passed, 1 expected Windows-only skip.
- Svelte check: 0 errors, 0 warnings; production frontend build passed.
- Isolated Chromium visual QA at 800px and 430px: text fits, keyboard focus works, no overflow or browser errors.
- Native shortcut manual acceptance remains with the separate testing session; installed app was not touched.

## Review
Independent read-only Claude Sonnet 5 review: ready to merge, no blocking findings. Root adjudication and optional suggestions recorded in PR comment.

No release/version bump or installed-app changes.