### PR TITLE
CI: pin compatible LLVM for Windows ARM64 bindings

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -68,6 +68,57 @@ jobs:
             throw "Expected native ${{ matrix.architecture }} runner, got $runnerArchitecture"
           }
 
+      - name: Install pinned LLVM for ARM64 bindgen
+        if: matrix.architecture == 'arm64'
+        shell: pwsh
+        run: |
+          # Upstream rust-bindgen#3264: LLVM 22 is incompatible with bindgen 0.71.
+          $llvmUrl = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/LLVM-20.1.8-woa64.exe'
+          $expectedHash = '7c4ac97eb2ae6b960ca5f9caf3ff6124c8d2a18cc07a7840a4d2ea15537bad8e'
+          $installerPath = Join-Path $env:RUNNER_TEMP 'LLVM-20.1.8-woa64.exe'
+          $installRoot = Join-Path $env:RUNNER_TEMP ('sagascript-llvm-20.1.8-' + [guid]::NewGuid().ToString('N'))
+          $llvmBin = Join-Path $installRoot 'bin'
+
+          Invoke-WebRequest -Uri $llvmUrl -OutFile $installerPath
+          $actualHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "LLVM installer SHA256 mismatch: expected $expectedHash, got $actualHash"
+          }
+
+          New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+          # NSIS requires /D to be the final, unquoted argument.
+          $process = Start-Process -FilePath $installerPath -ArgumentList @('/S', "/D=$installRoot") -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "LLVM installer failed with exit code $($process.ExitCode)"
+          }
+
+          $clangPath = Join-Path $llvmBin 'clang-cl.exe'
+          $libclangPath = Join-Path $llvmBin 'libclang.dll'
+          if (-not (Test-Path -LiteralPath $clangPath -PathType Leaf)) {
+            throw "Pinned LLVM clang-cl.exe is missing: $clangPath"
+          }
+          if (-not (Test-Path -LiteralPath $libclangPath -PathType Leaf)) {
+            throw "Pinned LLVM libclang.dll is missing: $libclangPath"
+          }
+
+          $clangVersionOutput = & $clangPath --version 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pinned clang-cl --version failed with exit code $LASTEXITCODE"
+          }
+          $clangVersion = ($clangVersionOutput -join "`n").Trim()
+          Write-Output $clangVersion
+          if ($clangVersion -notmatch '(?m)^clang version 20\.1\.8(?:\s|$)') {
+            throw "Expected clang version 20.1.8, got: $clangVersion"
+          }
+
+          $targetMatch = [regex]::Match($clangVersion, '(?m)^Target:\s*(?<target>\S+)\s*$')
+          if (-not $targetMatch.Success -or $targetMatch.Groups['target'].Value -ne 'aarch64-pc-windows-msvc') {
+            throw "Expected native clang target aarch64-pc-windows-msvc in clang version output"
+          }
+
+          $llvmBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "LIBCLANG_PATH=$llvmBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Configure native ARM64 C and C++ toolchain
         if: matrix.architecture == 'arm64'
         shell: pwsh

--- a/scripts/test-windows-package-workflow.mjs
+++ b/scripts/test-windows-package-workflow.mjs
@@ -133,6 +133,47 @@ test("Windows ARM64 disables unsupported scalable vectors before restoring nativ
   assert.ok(end < workflow.indexOf("name: Cache Rust dependencies"));
 });
 
+test("Windows ARM64 pins and validates the LLVM toolchain before native configuration", () => {
+  const pinStart = workflow.indexOf("name: Install pinned LLVM for ARM64 bindgen");
+  const nativeStart = workflow.indexOf("name: Configure native ARM64 C and C++ toolchain");
+  const cacheStart = workflow.indexOf("name: Cache Rust dependencies");
+  assert.ok(pinStart >= 0 && nativeStart > pinStart && cacheStart > nativeStart);
+
+  const pin = workflow.slice(pinStart, nativeStart);
+  assert.match(pin, /if: matrix\.architecture == 'arm64'/);
+  assert.match(
+    pin,
+    /https:\/\/github\.com\/llvm\/llvm-project\/releases\/download\/llvmorg-20\.1\.8\/LLVM-20\.1\.8-woa64\.exe/,
+  );
+  assert.match(pin, /7c4ac97eb2ae6b960ca5f9caf3ff6124c8d2a18cc07a7840a4d2ea15537bad8e/);
+
+  const download = pin.indexOf("Invoke-WebRequest");
+  const verifyHash = pin.indexOf("Get-FileHash");
+  const execute = pin.indexOf("Start-Process");
+  assert.ok(download >= 0 && verifyHash > download && execute > verifyHash);
+  assert.match(pin, /-Algorithm SHA256/);
+  assert.match(pin, /if \(\$actualHash -ne \$expectedHash\)/);
+  assert.match(pin, /-ArgumentList @\('\/S', "\/D=\$installRoot"\)/);
+  assert.match(pin, /if \(\$process\.ExitCode -ne 0\)/);
+  assert.match(pin, /\[guid\]::NewGuid\(\)/);
+
+  assert.match(pin, /clang-cl\.exe/);
+  assert.match(pin, /libclang\.dll/);
+  assert.match(pin, /Test-Path -LiteralPath \$clangPath -PathType Leaf/);
+  assert.match(pin, /Test-Path -LiteralPath \$libclangPath -PathType Leaf/);
+  assert.match(pin, /clang version 20\\\.1\\\.8/);
+  assert.match(pin, /Write-Output \$clangVersion/);
+  assert.match(pin, /\[regex\]::Match\(\$clangVersion/);
+  assert.match(pin, /Target:\\s\*\(\?<target>\\S\+\)/);
+  assert.match(pin, /aarch64-pc-windows-msvc/);
+  assert.match(pin, /\$targetMatch\.Groups\['target'\]\.Value -ne 'aarch64-pc-windows-msvc'/);
+  assert.doesNotMatch(pin, /-dumpmachine/);
+  assert.match(pin, /\$llvmBin \| Out-File -FilePath \$env:GITHUB_PATH/);
+  assert.match(pin, /LIBCLANG_PATH=\$llvmBin/);
+  assert.match(pin, /rust-bindgen#3264/);
+  assert.doesNotMatch(pin, /WHISPER_DONT_GENERATE_BINDINGS|disable ABI asserts/);
+});
+
 test("Windows x64 caches and artifacts use an explicit verified CPU baseline", () => {
   const policyStart = workflow.indexOf("name: Configure portable x64 inference baseline");
   const cacheStart = workflow.indexOf("name: Cache Rust dependencies");


### PR DESCRIPTION
## Summary

- Pin the Windows ARM64 compiler and bindgen libclang to official LLVM 20.1.8, with SHA256 verification before installation.
- Verify compiler version, native target and required binaries before exposing PATH/LIBCLANG_PATH.
- Preserve x64 behavior, native tuning, ABI layout tests and existing CI gates.

Unblocks #232. The updated Windows ARM64 runner ships Clang 22.1.8; whisper-rs-sys uses bindgen 0.71.1, matching the upstream LLVM 22 type-completeness incompatibility: https://github.com/rust-lang/rust-bindgen/issues/3264 and https://github.com/rust-lang/rust-bindgen/pull/3278.

## Verification

- 25 focused workflow/cache/ARM64 regression tests pass (red/green coverage added).
- Full frontend suite: 209 passed, 1 expected Windows-only skip, 0 failures.
- actionlint and git diff --check pass; PowerShell syntax parse passed during implementation.
- Hosted ARM64 and x64 package builds must pass before merge.
- Independent read-only Claude Sonnet 5 review completed: no blocking code defects; approval conditional on all exact-head ARM64/x64 package and ordinary CI checks passing. Full workflow review confirmed compiler wiring and workflow-hashed cache invalidation. Hosted LLVM installation and toolchain configuration already passed; compilation/runtime/package gates remain pending.

No runtime dependency changes, app installation, stable release or deployment.
